### PR TITLE
Add support for simple reductions.

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2121,6 +2121,7 @@ keep_dims_3d_configs = [(op, 'float32', (32, 2, 16), axis, True)
                                                   for op in ['min', 'max', 'sum']]
 
 
+@pytest.mark.cpu
 @pytest.mark.interpreter
 @pytest.mark.parametrize(
     "op, dtype_str, shape, axis, keep_dims", reduce_configs1 + reduce_configs2 + reduce_configs3 + invalid_config +
@@ -2128,6 +2129,9 @@ keep_dims_3d_configs = [(op, 'float32', (32, 2, 16), axis, True)
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_reduce(op, dtype_str, shape, axis, keep_dims, num_ctas, device):
     check_type_supported(dtype_str, device)  # bfloat16 on cc < 80 will not be tested
+
+    if is_cpu() and op in ('argmin', 'argmax'):
+        pytest.skip(f"Not yet implemented on CPU: {op}")
 
     @triton.jit
     def kernel(X, Z, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr, IS_3D: tl.constexpr,

--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -98,6 +98,7 @@ class CPUBackend(BaseBackend):
         # TritonCPU -> LLVM-IR (MLIR)
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
+        cpu.passes.ttcpuir.add_lower_vector_multi_dim(pm)
         cpu.passes.ttcpuir.add_vector_to_scf(pm, True, 1, False)
         cpu.passes.ttcpuir.add_lower_affine(pm)
         passes.convert.add_scf_to_cf(pm)

--- a/third_party/cpu/include/TritonCPUToLLVM/Passes.h
+++ b/third_party/cpu/include/TritonCPUToLLVM/Passes.h
@@ -5,6 +5,8 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
 #include <memory>
 
 namespace mlir {
@@ -21,6 +23,7 @@ namespace cpu {
 std::unique_ptr<OperationPass<ModuleOp>> createFuncOpToLLVMPass();
 std::unique_ptr<OperationPass<ModuleOp>> createMemoryOpToLLVMPass();
 std::unique_ptr<OperationPass<ModuleOp>> createGetProgramIdOpToLLVMPass();
+std::unique_ptr<OperationPass<triton::FuncOp>> createLowerMultiReductionPass();
 
 void tritonCPUToLLVMPipelineBuilder(OpPassManager &pm);
 void registerTritonCPUToLLVMPipeline();

--- a/third_party/cpu/include/TritonCPUToLLVM/Passes.td
+++ b/third_party/cpu/include/TritonCPUToLLVM/Passes.td
@@ -43,4 +43,15 @@ def GetProgramIdOpToLLVM : Pass<"triton-cpu-get-program-id-op-to-llvm", "mlir::M
                              "mlir::triton::TritonDialect"];
 }
 
+def LowerMultiReduction : Pass<"triton-cpu-lower-multi-reduction", "mlir::triton::FuncOp"> {
+    let summary = "Convert multi-dimensional reductions.";
+    let description = [{
+    }];
+    let constructor = "mlir::triton::cpu::createLowerMultiReductionPass()";
+
+    let dependentDialects = ["mlir::vector::VectorDialect",
+                             "mlir::triton::cpu::TritonCPUDialect",
+                             "mlir::triton::TritonDialect"];
+}
+
 #endif

--- a/third_party/cpu/include/TritonToTritonCPU/Passes.h
+++ b/third_party/cpu/include/TritonToTritonCPU/Passes.h
@@ -23,6 +23,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createConvertMemoryOps();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertPtrOps();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertDotOp();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertControlFlowOps();
+std::unique_ptr<OperationPass<ModuleOp>> createConvertReductionOp();
 
 void tritonToTritonCPUPipelineBuilder(OpPassManager &pm);
 void registerTritonToTritonCPUPipeline();

--- a/third_party/cpu/include/TritonToTritonCPU/Passes.td
+++ b/third_party/cpu/include/TritonToTritonCPU/Passes.td
@@ -74,4 +74,18 @@ def ConvertControlFlowOps : Pass<"triton-cpu-convert-control-flow-op", "mlir::Mo
                              "mlir::triton::cpu::TritonCPUDialect"];
 }
 
+def ConvertReductionOp : Pass<"triton-cpu-convert-reduction", "mlir::ModuleOp"> {
+    let summary = "Convert Triton ReduceOp.";
+    let description = [{
+
+    }];
+    let constructor = "mlir::triton::cpu::createConvertReductionOp()";
+
+    let dependentDialects = ["mlir::arith::ArithDialect",
+                             "mlir::vector::VectorDialect",
+                             "mlir::scf::SCFDialect",
+                             "mlir::triton::TritonDialect",
+                             "mlir::triton::cpu::TritonCPUDialect"];
+}
+
 #endif

--- a/third_party/cpu/lib/TritonCPUToLLVM/CMakeLists.txt
+++ b/third_party/cpu/lib/TritonCPUToLLVM/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_triton_library(TritonCPUToLLVM
     FuncOpToLLVM.cpp
     GetProgramIdOpToLLVM.cpp
+    LowerMultiReduction.cpp
     MemoryOpToLLVM.cpp
     Pipeline.cpp
     TypeConverter.cpp

--- a/third_party/cpu/lib/TritonCPUToLLVM/LowerMultiReduction.cpp
+++ b/third_party/cpu/lib/TritonCPUToLLVM/LowerMultiReduction.cpp
@@ -1,0 +1,59 @@
+#include "TypeConverter.h"
+
+#include "cpu/include/TritonCPUToLLVM/Passes.h"
+
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonCPU/IR/Dialect.h"
+
+namespace mlir {
+namespace triton {
+#define GEN_PASS_DEF_LOWERMULTIREDUCTION
+#include "cpu/include/TritonCPUToLLVM/Passes.h.inc"
+} // namespace triton
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::triton;
+using namespace mlir::triton::cpu;
+
+namespace {
+
+// This pass exists because LowerVectorMultiReductionPass can be run on
+// func::FuncOp only and we translate triton::FuncOp directly into llvm::FuncOp.
+// So we run the same set of patterns on triton::FuncOp.
+struct LowerMultiReduction
+    : public mlir::triton::impl::LowerMultiReductionBase<LowerMultiReduction> {
+  using LowerMultiReductionBase::LowerMultiReductionBase;
+
+  void runOnOperation() override {
+    Operation *op = getOperation();
+    MLIRContext *context = op->getContext();
+
+    RewritePatternSet loweringPatterns(context);
+    vector::VectorMultiReductionLowering options;
+    vector::populateVectorMultiReductionLoweringPatterns(loweringPatterns,
+                                                         options);
+
+    if (failed(applyPatternsAndFoldGreedily(op, std::move(loweringPatterns))))
+      signalPassFailure();
+  }
+};
+
+} // anonymous namespace
+
+namespace mlir {
+namespace triton {
+namespace cpu {
+
+std::unique_ptr<OperationPass<triton::FuncOp>> createLowerMultiReductionPass() {
+  return std::make_unique<LowerMultiReduction>();
+}
+
+} // namespace cpu
+} // namespace triton
+} // namespace mlir

--- a/third_party/cpu/lib/TritonToTritonCPU/CMakeLists.txt
+++ b/third_party/cpu/lib/TritonToTritonCPU/CMakeLists.txt
@@ -3,6 +3,7 @@ add_triton_library(TritonToTritonCPU
     ConvertDotOp.cpp
     ConvertElementwiseOps.cpp
     ConvertMemoryOps.cpp
+    ConvertReductionOp.cpp
     ConvertPtrOps.cpp
     Pipeline.cpp
     TypeConverter.cpp

--- a/third_party/cpu/lib/TritonToTritonCPU/ConvertReductionOp.cpp
+++ b/third_party/cpu/lib/TritonToTritonCPU/ConvertReductionOp.cpp
@@ -1,0 +1,218 @@
+#include "TypeConverter.h"
+
+#include "cpu/include/TritonToTritonCPU/Passes.h"
+
+#include "mlir/Analysis/DataFlowFramework.h"
+#include "mlir/Dialect/Index/IR/IndexDialect.h"
+#include "mlir/Dialect/Index/IR/IndexOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "triton/Analysis/Allocation.h"
+#include "triton/Analysis/AxisInfo.h"
+#include "triton/Analysis/Membar.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonCPU/IR/Dialect.h"
+
+namespace mlir {
+namespace triton {
+#define GEN_PASS_DEF_CONVERTREDUCTIONOP
+#include "cpu/include/TritonToTritonCPU/Passes.h.inc"
+} // namespace triton
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::triton;
+using namespace mlir::triton::cpu;
+
+namespace {
+
+class ReductionConversionTarget : public ConversionTarget {
+public:
+  explicit ReductionConversionTarget(MLIRContext &ctx, TypeConverter &converter)
+      : ConversionTarget(ctx) {
+    addLegalDialect<vector::VectorDialect>();
+    addLegalDialect<arith::ArithDialect>();
+    addLegalDialect<TritonDialect>();
+    addLegalDialect<TritonCPUDialect>();
+    addLegalOp<mlir::UnrealizedConversionCastOp>();
+
+    addIllegalOp<triton::ReduceOp>();
+  }
+};
+
+struct ReduceOpConversion : public OpConversionPattern<triton::ReduceOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::ReduceOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    MLIRContext *ctx = op.getContext();
+    // Currently, only simple reductions with a single input argumet are
+    // supported.
+    // TODO: support generic case.
+    if (op.getNumOperands() != 1 || op.getNumResults() != 1)
+      return failure();
+
+    Value src = rewriter.getRemappedValue(op.getOperand(0));
+    VectorType srcTy = dyn_cast<VectorType>(src.getType());
+    assert(srcTy);
+
+    Block *block = op.getBody();
+    if (block->getNumArguments() != 2)
+      return failure();
+    Value itArg = block->getArgument(0);
+    Value accArg = block->getArgument(1);
+
+    auto &blockOps = block->getOperations();
+    if (blockOps.size() != 2)
+      return failure();
+
+    Operation &retOp = blockOps.back();
+    if (!isa<ReduceReturnOp>(retOp) || retOp.getNumOperands() != 1)
+      return failure();
+
+    Value retVal = retOp.getOperand(0);
+    Operation *defOp = retVal.getDefiningOp();
+    if (!defOp || defOp->getNumOperands() != 2)
+      return failure();
+
+    Value lhs = defOp->getOperand(0);
+    Value rhs = defOp->getOperand(1);
+    if ((lhs != itArg || rhs != accArg) && (lhs != accArg || rhs != itArg))
+      return failure();
+
+    vector::CombiningKind reductionKind;
+    if (failed(detectReductionKind(defOp, reductionKind)))
+      return failure();
+
+    Type resTy = getTypeConverter()->convertType(op.getType(0));
+    Value acc = buildInitValue(op.getLoc(), resTy, reductionKind, rewriter);
+    int64_t axis = op.getAxis();
+    rewriter.replaceOpWithNewOp<vector::MultiDimReductionOp>(
+        op, resTy, reductionKind, src, acc, rewriter.getI64ArrayAttr(axis));
+    return success();
+  }
+
+  LogicalResult detectReductionKind(Operation *op,
+                                    vector::CombiningKind &out) const {
+    if (isa<arith::AddFOp, arith::AddIOp>(op))
+      out = vector::CombiningKind::ADD;
+    else if (isa<arith::MulFOp, arith::MulIOp>(op))
+      out = vector::CombiningKind::MUL;
+    else if (isa<arith::MinSIOp>(op))
+      out = vector::CombiningKind::MINSI;
+    else if (isa<arith::MinUIOp>(op))
+      out = vector::CombiningKind::MINUI;
+    else if (isa<arith::MinimumFOp>(op))
+      out = vector::CombiningKind::MINIMUMF;
+    else if (isa<arith::MinNumFOp>(op))
+      out = vector::CombiningKind::MINNUMF;
+    else if (isa<arith::MaxSIOp>(op))
+      out = vector::CombiningKind::MAXSI;
+    else if (isa<arith::MaxUIOp>(op))
+      out = vector::CombiningKind::MAXUI;
+    else if (isa<arith::MaximumFOp>(op))
+      out = vector::CombiningKind::MAXIMUMF;
+    else if (isa<arith::MaxNumFOp>(op))
+      out = vector::CombiningKind::MAXNUMF;
+    else if (isa<arith::AndIOp>(op))
+      out = vector::CombiningKind::AND;
+    else if (isa<arith::OrIOp>(op))
+      out = vector::CombiningKind::OR;
+    else if (isa<arith::XOrIOp>(op))
+      out = vector::CombiningKind::XOR;
+    else
+      return failure();
+    return success();
+  }
+
+  Value buildInitValue(Location loc, Type resTy, vector::CombiningKind kind,
+                       ConversionPatternRewriter &rewriter) const {
+    VectorType vecTy = dyn_cast<VectorType>(resTy);
+    Type elemTy = vecTy ? vecTy.getElementType() : resTy;
+
+    TypedAttr initVal;
+    if (kind == vector::CombiningKind::ADD ||
+        kind == vector::CombiningKind::OR ||
+        kind == vector::CombiningKind::XOR ||
+        kind == vector::CombiningKind::MAXUI)
+      initVal = rewriter.getZeroAttr(elemTy);
+    else if (kind == vector::CombiningKind::MUL)
+      initVal = rewriter.getOneAttr(elemTy);
+    else if (kind == vector::CombiningKind::AND ||
+             kind == vector::CombiningKind::MINUI)
+      initVal = rewriter.getIntegerAttr(elemTy, -1);
+    else if (kind == vector::CombiningKind::MAXSI)
+      initVal = rewriter.getIntegerAttr(
+          elemTy,
+          static_cast<int64_t>(1UL << (elemTy.getIntOrFloatBitWidth() - 1)));
+    else if (kind == vector::CombiningKind::MINSI)
+      initVal = rewriter.getIntegerAttr(
+          elemTy, static_cast<int64_t>(
+                      1UL << (elemTy.getIntOrFloatBitWidth() - 1) - 1));
+    else if (kind == vector::CombiningKind::MINIMUMF ||
+             kind == vector::CombiningKind::MINNUMF) {
+      if (elemTy.isF32())
+        initVal =
+            rewriter.getF32FloatAttr(std::numeric_limits<float>::infinity());
+      else if (elemTy.isF64())
+        initVal =
+            rewriter.getF64FloatAttr(std::numeric_limits<double>::infinity());
+      else
+        llvm_unreachable("Unsupported type for acc init value.");
+    } else if (kind == vector::CombiningKind::MAXIMUMF ||
+               kind == vector::CombiningKind::MAXNUMF) {
+      if (elemTy.isF32())
+        initVal =
+            rewriter.getF32FloatAttr(-std::numeric_limits<float>::infinity());
+      else if (elemTy.isF64())
+        initVal =
+            rewriter.getF64FloatAttr(-std::numeric_limits<double>::infinity());
+      else
+        llvm_unreachable("Unsupported type for acc init value.");
+    }
+
+    if (vecTy)
+      initVal = SplatElementsAttr::get(vecTy, initVal);
+
+    return rewriter.create<arith::ConstantOp>(loc, resTy, initVal);
+  }
+};
+
+struct ConvertReductionOp
+    : public triton::impl::ConvertReductionOpBase<ConvertReductionOp> {
+  using ConvertReductionOpBase::ConvertReductionOpBase;
+
+  ConvertReductionOp() : ConvertReductionOpBase() {}
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ModuleOp mod = getOperation();
+
+    TritonToTritonCPUTypeConverter typeConverter;
+    ReductionConversionTarget convTarget(*context, typeConverter);
+    RewritePatternSet patterns(context);
+    patterns.add<ReduceOpConversion>(typeConverter, context);
+
+    if (failed(applyPartialConversion(mod, convTarget, std::move(patterns))))
+      return signalPassFailure();
+  }
+};
+
+} // namespace
+
+namespace mlir {
+namespace triton {
+namespace cpu {
+
+std::unique_ptr<OperationPass<ModuleOp>> createConvertReductionOp() {
+  return std::make_unique<ConvertReductionOp>();
+}
+
+} // namespace cpu
+} // namespace triton
+} // namespace mlir

--- a/third_party/cpu/lib/TritonToTritonCPU/Pipeline.cpp
+++ b/third_party/cpu/lib/TritonToTritonCPU/Pipeline.cpp
@@ -12,6 +12,7 @@ void tritonToTritonCPUPipelineBuilder(OpPassManager &pm) {
   pm.addPass(mlir::triton::cpu::createConvertPtrOps());
   pm.addPass(mlir::triton::cpu::createConvertElementwiseOps());
   pm.addPass(mlir::triton::cpu::createConvertDotOp());
+  pm.addPass(mlir::triton::cpu::createConvertReductionOp());
   pm.addPass(mlir::triton::cpu::createConvertControlFlowOps());
   // pm.addPass(mlir::createReconcileUnrealizedCastsPass());
 }

--- a/third_party/cpu/triton_cpu.cc
+++ b/third_party/cpu/triton_cpu.cc
@@ -42,6 +42,10 @@ void init_triton_cpu_passes_ttcpuir(py::module &&m) {
     opts.enableLowerTensors(lower_tensors);
     pm.addPass(mlir::createConvertVectorToSCFPass(opts));
   });
+  m.def("add_lower_vector_multi_dim", [](mlir::PassManager &pm) {
+    pm.addNestedPass<mlir::triton::FuncOp>(
+        mlir::triton::cpu::createLowerMultiReductionPass());
+  });
   m.def("add_vector_to_llvmir", [](mlir::PassManager &pm) {
     pm.addPass(mlir::createConvertVectorToLLVMPass());
   });


### PR DESCRIPTION
This covers only those cases that are covered by `vector::MultiDimReductionOp`. Generic case support will have to be added later.