### PR TITLE
[CPU] Add an OpenMP-based CPU launcher

### DIFF
--- a/include/triton/Tools/Sys/GetEnv.hpp
+++ b/include/triton/Tools/Sys/GetEnv.hpp
@@ -4,7 +4,6 @@
 #include <algorithm>
 #include <assert.h>
 #include <cstdlib>
-#include <optional>
 #include <set>
 #include <sstream>
 #include <string>
@@ -30,9 +29,6 @@ inline const std::set<std::string> CACHE_INVALIDATING_ENV_VARS = {
 
 inline const std::set<std::string> CACHE_NEUTRAL_ENV_VARS = {
     "TRITON_REPRODUCER_PATH",
-    "TRITON_CPU_SINGLE_CORE",
-    "TRITON_CPU_MAX_THREADS",
-    "TRITON_CPU_OMP_DEBUG",
 };
 
 namespace tools {
@@ -53,21 +49,6 @@ inline std::string getStrEnv(const std::string &env) {
   if (!cstr)
     return "";
   std::string result(cstr);
-  return result;
-}
-
-inline std::optional<int64_t> getIntEnv(const std::string &env) {
-  assertIsRecognized(env);
-  const char *cstr = std::getenv(env.c_str());
-  if (!cstr) {
-    return std::nullopt;
-  }
-
-  char *endptr;
-  long int result = std::strtol(cstr, &endptr, 10);
-  if (endptr == cstr) {
-    assert(false && "invalid integer");
-  }
   return result;
 }
 

--- a/include/triton/Tools/Sys/GetEnv.hpp
+++ b/include/triton/Tools/Sys/GetEnv.hpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <assert.h>
 #include <cstdlib>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <string>
@@ -29,6 +30,9 @@ inline const std::set<std::string> CACHE_INVALIDATING_ENV_VARS = {
 
 inline const std::set<std::string> CACHE_NEUTRAL_ENV_VARS = {
     "TRITON_REPRODUCER_PATH",
+    "TRITON_CPU_SINGLE_CORE",
+    "TRITON_CPU_MAX_THREADS",
+    "TRITON_CPU_OMP_DEBUG",
 };
 
 namespace tools {
@@ -49,6 +53,21 @@ inline std::string getStrEnv(const std::string &env) {
   if (!cstr)
     return "";
   std::string result(cstr);
+  return result;
+}
+
+inline std::optional<int64_t> getIntEnv(const std::string &env) {
+  assertIsRecognized(env);
+  const char *cstr = std::getenv(env.c_str());
+  if (!cstr) {
+    return std::nullopt;
+  }
+
+  char *endptr;
+  long int result = std::strtol(cstr, &endptr, 10);
+  if (endptr == cstr) {
+    assert(false && "invalid integer");
+  }
   return result;
 }
 

--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -47,7 +47,7 @@ def _build(name, src, srcdir, library_dirs, include_dirs, libraries):
     cc_cmd += [f"-I{dir}" for dir in include_dirs]
     # CPU backend uses C++ (driver.cpp). Some old version compilers need a specific C++17 flag.
     if src.endswith(".cpp") or src.endswith(".cc"):
-        cc_cmd += ["-std=c++17"]
+        cc_cmd += ["-std=c++17", "-fopenmp"]
     ret = subprocess.check_call(cc_cmd)
     if ret == 0:
         return so

--- a/third_party/cpu/backend/driver.py
+++ b/third_party/cpu/backend/driver.py
@@ -281,7 +281,7 @@ static void run_omp_kernels(uint32_t gridX, uint32_t gridY, uint32_t gridZ, kern
     if (getBoolEnv("TRITON_CPU_OMP_DEBUG"))
       printf("Single core launcher\\n");
 
-    for (uint32_t i = 0; i < N; ++i) {{
+    for (size_t i = 0; i < N; ++i) {{
       const auto [x, y, z] = all_grids[i];
       (*kernel_ptr)({kernel_fn_args_list + ', ' if len(kernel_fn_args) > 0 else ''} x, y, z);
     }}
@@ -299,7 +299,7 @@ static void run_omp_kernels(uint32_t gridX, uint32_t gridY, uint32_t gridZ, kern
 
   // For now, use the default chunk size, total iterations / max_threads.
 #pragma omp parallel for schedule(static) num_threads(max_threads.value())
-  for (uint32_t i = 0; i < N; ++i) {{
+  for (size_t i = 0; i < N; ++i) {{
     const auto [x, y, z] = all_grids[i];
     (*kernel_ptr)({kernel_fn_args_list + ', ' if len(kernel_fn_args) > 0 else ''} x, y, z);
   }}


### PR DESCRIPTION
This PR implements a simple OpenMP-based CPU launcher with some debugging and tunable environment variables. 

**Details:**
- By default, it uses the entire threads on a machine. So there might be a chance of contention between logical threads on the same physical core. Need a fine tuning.
- It uses static scheduling. No reason to use dynamic scheduling for now (overhead is high). I used the default chunk size: total iterations / # of threads, where the minimum chunk size is 10.

**Initial performance:**

Environment: I only tested on an AMD EPYC Zen4 96-core machine with Centos 9, as a development server in Meta. My test wasn't on a physical machine; it is a VM.

I only tested the vector addition example. I added `TritonCPU 1-core` as well as `TorchCPU` as the references. I disabled the turbo boost-like feature during this test. I used a smaller `BLOCK_SIZE` of 128 for CPU. Some observations so far:
- For large vector sizes >= 2^24, the GB/s seems to be stable.
  - The performance of `TritonCPU` with maximum threads is similar to that of `TorchCPU`.
- A large variance is observed in the sizes of 2^18 to 2^22, for both `TritonCPU` and `TorchCPU`
- The OpenMP's speedups for larger sizes are not impressive: ~6x.

```
> % python3 python/tutorials/01-vector-add.py
tensor([0.5151, 1.6826, 0.9153,  ..., 0.9852, 1.2714, 1.8192])
tensor([0.5151, 1.6826, 0.9153,  ..., 0.9852, 1.2714, 1.8192])
The maximum difference between torch-cpu and triton-cpu is 0.0
tensor([0.5151, 1.6826, 0.9153,  ..., 0.9852, 1.2714, 1.8192], device='cuda:0')
tensor([0.5151, 1.6826, 0.9153,  ..., 0.9852, 1.2714, 1.8192], device='cuda:0')
The maximum difference between torch-gpu and triton-gpu is 0.0
vector-add-performance (CPU_BLOCK_SIZE=128, GPU_BLOCK_SIZE=1024):
           size  TritonCPU 1-core  TritonCPU    TorchCPU    TritonGPU     TorchGPU
0        4096.0          0.403202   0.062194    4.472021    10.816901    10.666666
1        8192.0          3.120957   1.619745    7.883864    21.186207    21.041095
2       16384.0          3.280629   0.958061    3.545745    41.234899    40.959998
3       32768.0          3.188169   2.692145    6.301640    81.919996    80.313725
4       65536.0          3.969092   0.291063    7.116936   158.554837   156.535030
5      131072.0          5.689773   5.975995    9.832181   284.115618   282.482757
6      262144.0          5.911389  12.657541    4.723294   484.256150   489.074621
7      524288.0          6.442556  15.187768    5.880182   783.298835   771.011790
8     1048576.0          6.401166  55.634510    1.416960  1153.126078  1149.754339
9     2097152.0         10.465727  32.779651   98.862590  1521.145131  1481.039473
10    4194304.0          9.414268  34.194252  195.153484  1767.262872  1745.687030
11    8388608.0          3.347814   4.684119    5.160477  1972.861670  1957.515852
12   16777216.0          3.677767   7.394172    7.372241  2109.103660  2077.759573
13   33554432.0          3.057506  12.829415   10.310923  2168.532851  2172.839199
14   67108864.0          3.555315  17.150573   15.640461  2226.669987  2237.160951
15  134217728.0          3.711412  16.852324   18.304376  2246.948652  2260.369439
```

**TODO:**
- More experimentation with the fused softmax case.
- More rigorous performance testing on a stable environment.

**Debugging and control features**

`TRITON_CPU_MAX_THREADS` and `TRITON_CPU_OMP_DEBUG` are supported.

```
TRITON_CPU_MAX_THREADS=40 TRITON_CPU_OMP_DEBUG=1 python3 python/tutorials/01-vector-add.py
```