### PR TITLE
[CPU] Dump human-readable asm code in TRITON_CACHE_DIR

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -293,13 +293,6 @@ def compile(src, target=None, options=None):
             ttgir_full_name = fn_cache_manager.get_file(ir_filename)
             next_module = parse(ttgir_full_name, ext, context)
             print(f"re-parse ttgir with {ttgir_full_name}")
-        # It's ugly, but a quick hack to generate human-readable asm.
-        if ext == "bc" and backend.target.backend == "cpu":
-            from triton._C.libtriton import llvm
-
-            asm_filename = f"{src.name}.asm"
-            asm = llvm.translate_to_host_asm(module, options.enable_fp_fusion)
-            metadata_group[asm_filename] = fn_cache_manager.put(asm, asm_filename)
         module = next_module
     # write-back metadata
     metadata_group[metadata_filename] = fn_cache_manager.put(json.dumps(metadata, default=vars), metadata_filename,

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -293,6 +293,13 @@ def compile(src, target=None, options=None):
             ttgir_full_name = fn_cache_manager.get_file(ir_filename)
             next_module = parse(ttgir_full_name, ext, context)
             print(f"re-parse ttgir with {ttgir_full_name}")
+        # It's ugly, but a quick hack to generate human-readable asm.
+        if ext == "bc" and backend.target.backend == "cpu":
+            from triton._C.libtriton import llvm
+
+            asm_filename = f"{src.name}.asm"
+            asm = llvm.translate_to_host_asm(module, options.enable_fp_fusion)
+            metadata_group[asm_filename] = fn_cache_manager.put(asm, asm_filename)
         module = next_module
     # write-back metadata
     metadata_group[metadata_filename] = fn_cache_manager.put(json.dumps(metadata, default=vars), metadata_filename,

--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -1,7 +1,6 @@
 import functools
 import hashlib
 import os
-import re
 
 from dataclasses import dataclass
 from typing import Any, Tuple
@@ -140,6 +139,13 @@ class CPUBackend(BaseBackend):
 
     @staticmethod
     def make_bc(src, metadata, options):
+        if os.environ.get("TRITON_CPU_ASM_DUMP", "0") == "1":
+            from triton.runtime.cache import get_cache_manager
+
+            asm = llvm.translate_to_host_asm(src, options.enable_fp_fusion)
+            fn_cache_manager = get_cache_manager(metadata['hash'])
+            fn_cache_manager.put(asm, f"{metadata['name']}.asm")
+
         ret = llvm.translate_to_bc(src)
         return ret
 

--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -140,9 +140,6 @@ class CPUBackend(BaseBackend):
 
     @staticmethod
     def make_bc(src, metadata, options):
-        if os.environ.get("TRITON_CPU_ASM_DUMP", "0") == "1":
-            print("********** Module ASM **********")
-            print(llvm.translate_to_host_asm(src, options.enable_fp_fusion))
         ret = llvm.translate_to_bc(src)
         return ret
 


### PR DESCRIPTION
I think it'd be much better to dump generated assembly code in the cache directory.

`.asm` file is now dropped at `TRITON_CACHE_DIR`.

```
> % ll /home/minjang/temp/triton-cache/888bdd8e7af20d785cf333479fbae3dd400aca0d11d7ceec5739759a8b2da4b2/
total 276
-rw-r--r-- 1 minjang users 169178 Jun 10 15:27 add_kernel.asm
-rw-r--r-- 1 minjang users  10724 Jun 10 15:27 add_kernel.bc
-rw-r--r-- 1 minjang users    394 Jun 10 15:27 add_kernel.json
-rw-r--r-- 1 minjang users  43591 Jun 10 15:27 add_kernel.llir
-rw-r--r-- 1 minjang users  37239 Jun 10 15:27 add_kernel.ttcir
-rw-r--r-- 1 minjang users   3418 Jun 10 15:27 add_kernel.ttir
-rw-r--r-- 1 minjang users    823 Jun 10 15:27 __grp__add_kernel.json
```