### PR TITLE
Added g++ installation after switching to ubuntu-22.04

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -59,7 +59,7 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install wheel cmake==3.24 ninja pytest-xdist lit
           sudo apt-get update
-          sudo apt-get install -y zlib1g-dev
+          sudo apt-get install -y zlib1g-dev g++
           pip install torch==2.1.2
 
       - name: Install Triton


### PR DESCRIPTION
After switching runner from `summerwind/actions-runner:ubuntu-20.04` to `summerwind/actions-runner:ubuntu-22.04` we need to install g++ in the container because it is no longer present in it.