### PR TITLE
[TUTORIAL] Add the non-persistent softmax and make it for CPU

### DIFF
--- a/python/tutorials/01-vector-add.py
+++ b/python/tutorials/01-vector-add.py
@@ -25,7 +25,7 @@ import triton.language as tl
 
 GPU_BLOCK_SIZE = 1024
 CPU_BLOCK_SIZE = 4096
-USE_GPU = True
+USE_GPU = False
 
 
 @triton.jit
@@ -89,7 +89,7 @@ size = 98432
 triton.runtime.driver.set_active_to_cpu()
 x = torch.rand(size, device='cpu')
 y = torch.rand(size, device='cpu')
-output_torch_cpu = x + y
+output_torch_cpu = torch.add(x, y)
 output_triton_cpu = add(x, y, None, is_cpu=True)
 print(output_torch_cpu)
 print(output_triton_cpu)
@@ -98,7 +98,7 @@ print(f'The maximum difference between torch-cpu and triton-cpu is '
 
 LINE_VALS = ['triton-cpu-single', 'triton-cpu', 'torch-cpu']
 LINE_NAMES = ['TritonCPU 1', 'TritonCPU', 'TorchCPU']
-LINE_STYLES = [('blue', '-'), ('green', '-'), ('cyan', '-')]
+LINE_STYLES = [('blue', '--'), ('blue', '-'), ('green', '-')]
 
 if USE_GPU and triton.runtime.driver.get_active_gpus():
     triton.runtime.driver.set_active_to_gpu()
@@ -150,31 +150,35 @@ def benchmark(size, provider):
     y = torch.rand(size, device=device, dtype=torch.float32)
 
     if device == 'cpu':
+        is_cpu = True
         triton.runtime.driver.set_active_to_cpu()
         if 'single' in provider:
             os.environ['TRITON_CPU_SINGLE_CORE'] = '1'
         else:
             os.unsetenv('TRITON_CPU_SINGLE_CORE')
     else:
+        is_cpu = False
         triton.runtime.driver.set_active_to_gpu()
 
     quantiles = [0.5, 0.2, 0.8]
     if provider == 'torch-gpu':
-        ms, min_ms, max_ms = triton.testing.do_bench(lambda: x + y, quantiles=quantiles)
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: x + y, quantiles=quantiles, is_cpu=is_cpu)
     elif provider == 'triton-gpu':
-        ms, min_ms, max_ms = triton.testing.do_bench(lambda: add(x, y, None, False), quantiles=quantiles)
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: add(x, y, None, False), quantiles=quantiles, is_cpu=is_cpu)
     elif provider == 'torch-cpu':
         # Note that we preallocate the output buffer here to only measure the kernel performance
         # without a large chunk of memory allocation.
         output = torch.empty_like(x)
         ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.add(x, y, out=output), quantiles=quantiles,
-                                                     is_cpu=True)
+                                                     is_cpu=is_cpu)
     elif provider == 'triton-cpu-single':
         output = torch.empty_like(x)
-        ms, min_ms, max_ms = triton.testing.do_bench(lambda: add(x, y, output, True), quantiles=quantiles, is_cpu=True)
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: add(x, y, output, True), quantiles=quantiles,
+                                                     is_cpu=is_cpu)
     elif provider == 'triton-cpu':
         output = torch.empty_like(x)
-        ms, min_ms, max_ms = triton.testing.do_bench(lambda: add(x, y, output, True), quantiles=quantiles, is_cpu=True)
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: add(x, y, output, True), quantiles=quantiles,
+                                                     is_cpu=is_cpu)
     gbps = lambda ms: 12 * size / ms * 1e-6
     return gbps(ms), gbps(max_ms), gbps(min_ms)
 

--- a/python/tutorials/02-fused-softmax-cpu.py
+++ b/python/tutorials/02-fused-softmax-cpu.py
@@ -1,0 +1,225 @@
+"""
+Fused Softmax
+=============
+
+In this tutorial, you will write a fused softmax operation that is significantly faster
+than PyTorch's native op for a particular class of matrices: those whose rows can fit in
+the GPU's SRAM.
+
+In doing so, you will learn about:
+
+* The benefits of kernel fusion for bandwidth-bound operations.
+
+* Reduction operators in Triton.
+
+"""
+
+# %%
+# Motivations
+# -----------
+#
+# Custom GPU kernels for elementwise additions are educationally valuable but won't get you very far in practice.
+# Let us consider instead the case of a simple (numerically stabilized) softmax operation:
+
+import torch
+
+import triton
+import triton.language as tl
+
+USE_GPU = True
+
+
+@torch.jit.script
+def naive_softmax(x):
+    """Compute row-wise softmax of X using native pytorch
+
+    We subtract the maximum element in order to avoid overflows. Softmax is invariant to
+    this shift.
+    """
+    # read  MN elements ; write M  elements
+    x_max = x.max(dim=1)[0]
+    # read MN + M elements ; write MN elements
+    z = x - x_max[:, None]
+    # read  MN elements ; write MN elements
+    numerator = torch.exp(z)
+    # read  MN elements ; write M  elements
+    denominator = numerator.sum(dim=1)
+    # read MN + M elements ; write MN elements
+    ret = numerator / denominator[:, None]
+    # in total: read 5MN + 2M elements ; wrote 3MN + 2M elements
+    return ret
+
+
+# %%
+# When implemented naively in PyTorch, computing :code:`y = naive_softmax(x)` for :math:`x \in R^{M \times N}`
+# requires reading :math:`5MN + 2M` elements from DRAM and writing back :math:`3MN + 2M` elements.
+# This is obviously wasteful; we'd prefer to have a custom "fused" kernel that only reads
+# X once and does all the necessary computations on-chip.
+# Doing so would require reading and writing back only :math:`MN` bytes, so we could
+# expect a theoretical speed-up of ~4x (i.e., :math:`(8MN + 4M) / 2MN`).
+# The `torch.jit.script` flags aims to perform this kind of "kernel fusion" automatically
+# but, as we will see later, it is still far from ideal.
+
+# %%
+# Compute Kernel
+# --------------
+#
+# Our softmax kernel works as follows: each program loads a row of the input matrix X,
+# normalizes it and writes back the result to the output Y.
+#
+# Note that one important limitation of Triton is that each block must have a
+# power-of-two number of elements, so we need to internally "pad" each row and guard the
+# memory operations properly if we want to handle any possible input shapes:
+
+
+@triton.jit
+def softmax_kernel(output_ptr, input_ptr, input_row_stride, output_row_stride, n_cols, BLOCK_SIZE: tl.constexpr):
+    # The rows of the softmax are independent, so we parallelize across those
+    row_idx = tl.program_id(0)
+    # The stride represents how much we need to increase the pointer to advance 1 row
+    row_start_ptr = input_ptr + row_idx * input_row_stride
+    # The block size is the next power of two greater than n_cols, so we can fit each
+    # row in a single block
+    col_offsets = tl.arange(0, BLOCK_SIZE)
+    input_ptrs = row_start_ptr + col_offsets
+    # Load the row into SRAM, using a mask since BLOCK_SIZE may be > than n_cols
+    row = tl.load(input_ptrs, mask=col_offsets < n_cols, other=-float('inf'))
+    # Subtract maximum for numerical stability
+    row_minus_max = row - tl.max(row, axis=0)
+    # Note that exponentiation in Triton is fast but approximate (i.e., think __expf in CUDA)
+    numerator = tl.exp(row_minus_max)
+    denominator = tl.sum(numerator, axis=0)
+    softmax_output = numerator / denominator
+    # Write back output to DRAM
+    output_row_start_ptr = output_ptr + row_idx * output_row_stride
+    output_ptrs = output_row_start_ptr + col_offsets
+    tl.store(output_ptrs, softmax_output, mask=col_offsets < n_cols)
+
+
+# %%
+# We can create a helper function that enqueues the kernel and its (meta-)arguments for any given input tensor.
+
+
+def softmax(x):
+    n_rows, n_cols = x.shape
+    # The block size is the smallest power of two greater than the number of columns in `x`
+    BLOCK_SIZE = triton.next_power_of_2(n_cols)
+    # Another trick we can use is to ask the compiler to use more threads per row by
+    # increasing the number of warps (`num_warps`) over which each row is distributed.
+    # You will see in the next tutorial how to auto-tune this value in a more natural
+    # way so you don't have to come up with manual heuristics yourself.
+    num_warps = 4
+    if BLOCK_SIZE >= 2048:
+        num_warps = 8
+    if BLOCK_SIZE >= 4096:
+        num_warps = 16
+    # Allocate output
+    y = torch.empty_like(x)
+    # Enqueue kernel. The 1D launch grid is simple: we have one kernel instance per row of
+    # the input matrix
+    softmax_kernel[(n_rows, )](
+        y,
+        x,
+        x.stride(0),
+        y.stride(0),
+        n_cols,
+        num_warps=num_warps,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+    return y
+
+
+# %%
+# Unit Test
+# ---------
+
+# %%
+# We make sure that we test our kernel on a matrix with an irregular number of rows and columns.
+# This will allow us to verify that our padding mechanism works.
+
+triton.runtime.driver.set_active_to_cpu()
+
+torch.manual_seed(0)
+x = torch.randn(1823, 781, device='cpu')
+y_triton_cpu = softmax(x)
+y_torch_cpu = torch.softmax(x, axis=1)
+assert torch.allclose(y_triton_cpu, y_torch_cpu), (y_triton_cpu, y_torch_cpu)
+
+LINE_VALS = ['triton-cpu-single', 'triton-cpu', 'torch-cpu-native', 'torch-cpu-jit']
+LINE_NAMES = ['TritonCPU 1', 'TritonCPU', 'TorchCPU (native)', 'TorchCPU (jit)']
+LINE_STYLES = [('blue', '-'), ('blue', '--'), ('green', '-'), ('green', '--')]
+
+if USE_GPU and triton.runtime.driver.get_active_gpus():
+    triton.runtime.driver.set_active_to_gpu()
+    x = x.to('cuda')
+    y_triton_gpu = softmax(x)
+    y_torch_gpu = torch.softmax(x, axis=1)
+    assert torch.allclose(y_triton_gpu, y_torch_gpu), (y_triton_gpu, y_torch_gpu)
+    LINE_VALS += ['triton-gpu', 'torch-gpu-native', 'torch-gpu-jit']
+    LINE_NAMES += ['TritonGPU', 'TorchGPU (native)', 'TorchGPU (jit)']
+    LINE_STYLES += [('yellow', '-'), ('red', '-'), ('red', '--')]
+
+# %%
+# As expected, the results are identical.
+
+# %%
+# Benchmark
+# ---------
+#
+# Here we will benchmark our operation as a function of the number of columns in the input matrix -- assuming 4096 rows.
+# We will then compare its performance against (1) :code:`torch.softmax` and (2) the :code:`naive_softmax` defined above.
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=['N'],  # argument names to use as an x-axis for the plot
+        x_vals=[128 * i for i in range(2, 52)],  # different possible values for `x_name`
+        line_arg='provider',  # argument name whose value corresponds to a different line in the plot
+        line_vals=LINE_VALS,  # Possible values for `line_arg`.
+        line_names=LINE_NAMES,  # Label name for the lines.
+        styles=LINE_STYLES,  # Line styles.
+        ylabel="GB/s",  # label name for the y-axis
+        plot_name="softmax-performance",  # name for the plot. Used also as a file name for saving the plot.
+        args={'M': 4096},  # values for function arguments not in `x_names` and `y_name`
+    ))
+def benchmark(M, N, provider):
+    import os
+
+    device = 'cpu' if 'cpu' in provider else 'cuda'
+    x = torch.randn(M, N, device=device, dtype=torch.float32)
+
+    if device == 'cpu':
+        triton.runtime.driver.set_active_to_cpu()
+        if 'single' in provider:
+            os.environ['TRITON_CPU_SINGLE_CORE'] = '1'
+        else:
+            os.unsetenv('TRITON_CPU_SINGLE_CORE')
+    else:
+        triton.runtime.driver.set_active_to_gpu()
+
+    quantiles = [0.5, 0.2, 0.8]
+    if provider == 'torch-cpu-native':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.softmax(x, axis=-1), quantiles=quantiles)
+    if provider == 'torch-cpu-jit':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: naive_softmax(x), quantiles=quantiles)
+    if provider == 'torch-gpu-native':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.softmax(x, axis=-1), quantiles=quantiles)
+    if provider == 'torch-gpu-jit':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: naive_softmax(x), quantiles=quantiles)
+    if provider == 'triton-cpu-single':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: softmax(x), quantiles=quantiles)
+    if provider == 'triton-cpu':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: softmax(x), quantiles=quantiles)
+    if provider == 'triton-gpu':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: softmax(x), quantiles=quantiles)
+    gbps = lambda ms: 2 * x.nelement() * x.element_size() * 1e-9 / (ms * 1e-3)
+    return gbps(ms), gbps(max_ms), gbps(min_ms)
+
+
+benchmark.run(show_plots=True, print_data=True)
+
+# %%
+# In the above plot, we can see that:
+#  - Triton is 4x faster than the Torch JIT. This confirms our suspicions that the Torch JIT does not do any fusion here.
+#  - Triton is noticeably faster than :code:`torch.softmax` -- in addition to being **easier to read, understand and maintain**.
+#    Note however that the PyTorch `softmax` operation is more general and will work on tensors of any shape.


### PR DESCRIPTION
The updated fused-softmax has only persistent thread approach, which isn't straightforward for CPU. So, at least for now, bring back the old version and make it for CPU.


```
> % python3 python/tutorials/02-fused-softmax-cpu.py
softmax-performance:
         N  TritonCPU 1  TritonCPU  TorchCPU (native)  TorchCPU (jit)    TritonGPU  TorchGPU (native)  TorchGPU (jit)
0    256.0     2.045810   0.542863           0.550007        0.105642   923.042225         907.072700      289.023160
1    384.0     1.427173   0.807165           0.810944        0.177129  1110.779696        1095.309199      366.122895
2    512.0     1.784980   1.068528           1.088198        0.211705  1297.742602        1263.344616      429.744271
3    640.0     1.041241   1.301883           1.346970        0.262986  1489.454534        1418.528150      488.345762
4    768.0     1.230687   1.609295           1.618619        0.317283  1536.000004        1542.023579      517.389457
5    896.0     1.416729   1.849389           1.897273        0.333948  1632.569476        1644.272402      552.713269
6   1024.0     1.576671   2.081733           2.149679        0.462035  1730.323387        1716.163678      568.333887
7   1152.0     0.907632   2.351888           2.485568        0.472176  1673.259543        1351.257714      578.542444
8   1280.0     0.979819   2.566572           2.737079        0.530910  1724.631523        1471.066260      575.634579
9   1408.0     1.074241   2.874134           2.970841        0.581537  1754.004924        1373.135287      577.409710
10  1536.0     1.234496   3.098663           3.206416        0.632289  1793.459554        1446.976986      564.357367
11  1664.0     1.248459   3.253711           3.514285        0.667555  1836.137885        1380.823376      553.046423
12  1792.0     1.308964   3.570367           3.644222        0.778013  1857.295629        1454.047605      552.546838
13  1920.0     1.397980   3.754436           4.049148        0.858990  1892.281048        1413.429190      537.033607
14  2048.0     1.098481   3.738032           3.799553        0.852281  1917.834370        1800.130436      520.126988
15  2176.0     0.292744   3.409505           4.282864        0.829781  1894.748314        1455.404295      513.297370
16  2304.0     0.299672   3.639198           4.355468        0.811003  1921.250756        1501.779785      506.395380
17  2432.0     0.334191   3.866809           4.669806        0.894382  1933.515485        1510.229245      499.572316
18  2560.0     0.336801   3.938183           4.194150        0.918556  1940.370035        1565.973662      497.049667
19  2688.0     0.402710   4.385851           5.425224        1.087770  1953.521621        1432.853753      494.522457
20  2816.0     0.415767   4.416612           5.027677        1.039629  1971.007567        1478.003110      495.801922
21  2944.0     0.457665   4.677714           5.401216        0.985688  1974.234465        1474.159433      492.510389
22  3072.0     0.413956   5.058929           6.468632        1.114623  1977.201751        1534.501456      492.520434
23  3200.0     0.554844   5.242629           6.017523        1.247334  1983.535101        1442.888555      490.575643
24  3328.0     0.572705   5.504096           6.268642        1.155721  1990.579442        1483.618615      489.918352
25  3456.0     0.641787   5.673712           6.742990        1.198830  2005.067363        1475.174591      488.669415
26  3584.0     0.656487   5.869218           6.482186        1.476252  2022.047420        1519.675365      489.172411
27  3712.0     0.679076   5.982188           6.830568        1.240226  2032.667340        1475.005008      487.194065
28  3840.0     0.786011   6.294764           7.042874        1.376185  2040.560452        1510.046061      488.861834
29  3968.0     0.853159   5.944800           6.563339        1.309741  2045.937575        1506.574686      484.901465
30  4096.0     0.923387   6.258306           6.739743        1.435479  2039.039315        1975.649459      482.103901
31  4224.0     0.406333   4.971108           7.311503        1.452058  2049.941231        1854.792404      482.204690
32  4352.0     0.217094   4.467071           6.976144        1.488152  2055.557217        1873.244256      485.504749
33  4480.0     0.232029   4.908665           7.119896        1.392533  2058.106796        1852.794835      486.326707
34  4608.0     0.227503   5.463585           7.254451        1.494221  2063.223480        1870.972161      485.901754
35  4736.0     0.251055   4.627794           7.686124        1.617630  2068.087057        1798.503138      485.597659
36  4864.0     0.252149   5.424953           7.345514        1.719156  2073.578774        1815.137066      485.120886
37  4992.0     0.275326   4.835612           6.765786        1.642713  2077.126276        1797.400842      486.421917
38  5120.0     0.235966   5.317037           9.137089        1.788218  2082.987623        1822.976348      485.541776
39  5248.0     0.297392   6.633583           9.538905        1.727937  2086.161444        1747.626724      485.627328
40  5376.0     0.299619   7.118532           8.234546        1.659288  2090.780078        1774.097261      486.481461
41  5504.0     0.320007   6.008573           8.128889        1.602451  2092.480490        1759.630378      487.130160
42  5632.0     0.314133   6.351171           8.050021        1.792623  2092.586334        1778.892039      486.106541
43  5760.0     0.337048   5.757307           8.092474        1.688131  2087.133685        1739.893821      487.256497
44  5888.0     0.339773   6.242073           7.904060        1.838005  2086.989189        1761.411634      487.473169
45  6016.0     0.362206   6.302467           9.525986        1.739385  2069.326109        1745.151224      487.410710
46  6144.0     0.327055   6.859109           8.240472        1.959596  2068.537081        2015.846193      485.302067
47  6272.0     0.387260   6.386997           7.970573        1.781531  2065.121588        1976.770663      488.071118
48  6400.0     0.390301   6.781471           8.607681        1.922527  2068.686929        1979.939542      488.928692
49  6528.0     0.419166   7.119655           8.357271        1.831618  2072.124067        1958.017621      489.396867
```