### PR TITLE
Enabled simple build&test workflow, disabled old Integration Tests workflow because it fails to run

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,6 +3,14 @@ run-name: ${{ inputs.run_name }}
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+      # You can name your branch dev-foo to get CI runs.
+      - 'dev-**'
+  push:
+    branches:
+      - main
 
 jobs:
   pre-commit:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,14 +9,15 @@
 name: Integration Tests
 on:
   workflow_dispatch:
-  pull_request:
-    # You can name your branch dev-foo to get CI runs.
-    branches: [main, 'dev-**']
-  merge_group:
-    branches: [main, 'dev-**']
-    types: [checks_requested]
-  push:
-    branches: [main]
+  # Disabled automatic triggers because tests in this workflow fail to run.
+  # pull_request:
+  #   # You can name your branch dev-foo to get CI runs.
+  #   branches: [main, 'dev-**']
+  # merge_group:
+  #   branches: [main, 'dev-**']
+  #   types: [checks_requested]
+  # push:
+  #   branches: [main]
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,15 +9,15 @@
 name: Integration Tests
 on:
   workflow_dispatch:
-  # Disabled automatic triggers because tests in this workflow fail to run.
-  # pull_request:
-  #   # You can name your branch dev-foo to get CI runs.
-  #   branches: [main, 'dev-**']
-  # merge_group:
-  #   branches: [main, 'dev-**']
-  #   types: [checks_requested]
-  # push:
-  #   branches: [main]
+# Disabled automatic triggers because tests in this workflow fail to run.
+#   pull_request:
+#     # You can name your branch dev-foo to get CI runs.
+#     branches: [main, 'dev-**']
+#   merge_group:
+#     branches: [main, 'dev-**']
+#     types: [checks_requested]
+#   push:
+#     branches: [main]
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -8,14 +8,16 @@ name: Integration Tests
 
 on:
   workflow_dispatch:
-  pull_request:
-    # You can name your branch dev-foo to get CI runs.
-    branches: [main, 'dev-**']
-  merge_group:
-    branches: [main, 'dev-**']
-    types: [checks_requested]
-  push:
-    branches: [main]
+
+# Disabled automatic triggers because tests in this workflow fail to run.
+#   pull_request:
+#     # You can name your branch dev-foo to get CI runs.
+#     branches: [main, 'dev-**']
+#   merge_group:
+#     branches: [main, 'dev-**']
+#     types: [checks_requested]
+#   push:
+#     branches: [main]
 
 concurrency:
   group: ${{ github.ref }}


### PR DESCRIPTION
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it doesn't modify any Triton code`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
