### PR TITLE
[Op support] Support 'get_num_programs'

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5576,6 +5576,7 @@ def test_temp_var_in_loop(device):
     assert (acc == out).all()
 
 
+@pytest.mark.cpu
 @pytest.mark.interpreter
 def test_num_programs(device):
     # Assuming that the kernel is launched with a grid of (11, 21, 31)

--- a/third_party/cpu/backend/driver.py
+++ b/third_party/cpu/backend/driver.py
@@ -128,8 +128,8 @@ def make_launcher(constants, signature, ids):
     arg_ptrs_list = ', '.join(f"&arg{i}" for i, ty in signature.items()) if len(signature) > 0 else ''
     kernel_fn_args = [i for i in signature.keys() if i not in constants]
     kernel_fn_args_list = ', '.join(f"arg{i}" for i in kernel_fn_args) if len(kernel_fn_args) > 0 else ''
-    kernel_fn_arg_types = (', '.join(f"{ty_to_cpp(signature[i])}" for i in kernel_fn_args) +
-                           ", " if len(signature) > 0 else '') + "uint32_t, uint32_t, uint32_t"
+    kernel_fn_arg_types = (', '.join(f"{ty_to_cpp(signature[i])}" for i in kernel_fn_args) + ", "
+                           if len(signature) > 0 else '') + "uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t"
 
     # generate glue code
     src = f"""
@@ -236,7 +236,7 @@ static void run_omp_kernels(uint32_t gridX, uint32_t gridY, uint32_t gridZ, kern
 
     for (size_t i = 0; i < N; ++i) {{
       const auto [x, y, z] = all_grids[i];
-      (*kernel_ptr)({kernel_fn_args_list + ', ' if len(kernel_fn_args) > 0 else ''} x, y, z);
+      (*kernel_ptr)({kernel_fn_args_list + ', ' if len(kernel_fn_args) > 0 else ''} x, y, z, gridX, gridY, gridZ);
     }}
     return;
   }}
@@ -254,7 +254,7 @@ static void run_omp_kernels(uint32_t gridX, uint32_t gridY, uint32_t gridZ, kern
 #pragma omp parallel for schedule(static) num_threads(max_threads.value())
   for (size_t i = 0; i < N; ++i) {{
     const auto [x, y, z] = all_grids[i];
-    (*kernel_ptr)({kernel_fn_args_list + ', ' if len(kernel_fn_args) > 0 else ''} x, y, z);
+    (*kernel_ptr)({kernel_fn_args_list + ', ' if len(kernel_fn_args) > 0 else ''} x, y, z, gridX, gridY, gridZ);
   }}
 }}
 

--- a/third_party/cpu/include/TritonCPUToLLVM/Passes.td
+++ b/third_party/cpu/include/TritonCPUToLLVM/Passes.td
@@ -5,9 +5,7 @@ include "mlir/Pass/PassBase.td"
 
 def FuncOpToLLVM : Pass<"triton-cpu-func-op-to-llvm", "mlir::ModuleOp"> {
     let summary = "Convert FuncOp to LLVM for CPU.";
-    let description = [{
-
-    }];
+    let description = [{}];
     let constructor = "mlir::triton::cpu::createFuncOpToLLVMPass()";
 
     let dependentDialects = ["mlir::arith::ArithDialect",
@@ -19,9 +17,7 @@ def FuncOpToLLVM : Pass<"triton-cpu-func-op-to-llvm", "mlir::ModuleOp"> {
 
 def MemoryOpToLLVM : Pass<"triton-cpu-memory-op-to-llvm", "mlir::ModuleOp"> {
     let summary = "Convert Triton memory operations to LLVM for CPU.";
-    let description = [{
-
-    }];
+    let description = [{}];
     let constructor = "mlir::triton::cpu::createMemoryOpToLLVMPass()";
 
     let dependentDialects = ["mlir::arith::ArithDialect",
@@ -34,9 +30,7 @@ def MemoryOpToLLVM : Pass<"triton-cpu-memory-op-to-llvm", "mlir::ModuleOp"> {
 
 def GetProgramIdOpToLLVM : Pass<"triton-cpu-get-program-id-op-to-llvm", "mlir::ModuleOp"> {
     let summary = "Convert Triton GetProgramId to LLVM for CPU.";
-    let description = [{
-
-    }];
+    let description = [{}];
     let constructor = "mlir::triton::cpu::createGetProgramIdOpToLLVMPass()";
 
     let dependentDialects = ["mlir::LLVM::LLVMDialect",
@@ -45,8 +39,7 @@ def GetProgramIdOpToLLVM : Pass<"triton-cpu-get-program-id-op-to-llvm", "mlir::M
 
 def LowerMultiReduction : Pass<"triton-cpu-lower-multi-reduction", "mlir::triton::FuncOp"> {
     let summary = "Convert multi-dimensional reductions.";
-    let description = [{
-    }];
+    let description = [{}];
     let constructor = "mlir::triton::cpu::createLowerMultiReductionPass()";
 
     let dependentDialects = ["mlir::vector::VectorDialect",
@@ -56,8 +49,7 @@ def LowerMultiReduction : Pass<"triton-cpu-lower-multi-reduction", "mlir::triton
 
 def AtomicOpsToLLVM : Pass<"triton-cpu-atomic-ops-to-llvm", "mlir::ModuleOp"> {
     let summary = "Convert Triton atomic operations to LLVM.";
-    let description = [{
-    }];
+    let description = [{}];
     let constructor = "mlir::triton::cpu::createAtomicOpsToLLVMPass()";
 
     let dependentDialects = ["mlir::vector::VectorDialect",

--- a/third_party/cpu/lib/TritonCPUToLLVM/FuncOpToLLVM.cpp
+++ b/third_party/cpu/lib/TritonCPUToLLVM/FuncOpToLLVM.cpp
@@ -79,6 +79,9 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
     amendedInputTy.push_back(i32_ty);
     amendedInputTy.push_back(i32_ty);
     amendedInputTy.push_back(i32_ty);
+    amendedInputTy.push_back(ui32_ty);
+    amendedInputTy.push_back(ui32_ty);
+    amendedInputTy.push_back(ui32_ty);
     auto amendedFuncTy = FunctionType::get(funcTy.getContext(), amendedInputTy,
                                            funcTy.getResults());
     // 2. Modify the argument attributes to add new arguments.
@@ -87,6 +90,9 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
     SmallVector<Attribute> amendedArgAttrs;
     if (funcOp.getAllArgAttrs())
       amendedArgAttrs = llvm::to_vector<4>(funcOp.getAllArgAttrs());
+    amendedArgAttrs.emplace_back(DictionaryAttr::get(ctx));
+    amendedArgAttrs.emplace_back(DictionaryAttr::get(ctx));
+    amendedArgAttrs.emplace_back(DictionaryAttr::get(ctx));
     amendedArgAttrs.emplace_back(DictionaryAttr::get(ctx));
     amendedArgAttrs.emplace_back(DictionaryAttr::get(ctx));
     amendedArgAttrs.emplace_back(DictionaryAttr::get(ctx));
@@ -99,6 +105,9 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
     region.addArgument(i32_ty, loc);
     region.addArgument(i32_ty, loc);
     region.addArgument(i32_ty, loc);
+    region.addArgument(ui32_ty, loc);
+    region.addArgument(ui32_ty, loc);
+    region.addArgument(ui32_ty, loc);
     rewriter.inlineRegionBefore(region, amendedFuncOp.getBody(),
                                 amendedFuncOp.end());
     return amendedFuncOp;


### PR DESCRIPTION
This commit supports 'get_num_programs' in a same way with 'get_program_id'.
Verified with pytest: "test_core.py::test_num_programs"

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `this PR enables one of pytests`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
