### PR TITLE
Support FP8 conversions for CPU.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -79,3 +79,4 @@ jobs:
       - name: Run python unit tests
         run: |
           python -m pytest -s -n 32 --device cpu python/test/unit/language/test_core.py -m cpu
+          python -m pytest -s -n 32 --device cpu python/test/unit/language/test_conversions.py

--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -20,6 +20,9 @@ def is_hip():
 def is_on_mi300():
     return is_hip() and triton.runtime.driver.active.get_current_target().arch in ('gfx940', 'gfx941', 'gfx942')
 
+def is_cpu():
+    return not is_interpreter() and triton.runtime.driver.active.get_current_target().backend == "cpu"
+
 def matching_int(dtype):
     if dtype.primitive_bitwidth == 8:
         return torch.int8
@@ -281,6 +284,8 @@ def upcast_test(src_dtype, dst_dtype, exponent_bits, mantissa_bits, exponent_bia
     ('float8e5b16', 'float16'),
 ])
 def test_typeconvert_upcast(src_dtype, dst_dtype, device):
+    if src_dtype in ('float8e4b8', 'float8e4b15') and is_cpu():
+        pytest.skip(f"Conversion from {src_dtype} to {dst_dtype} is not supported on CPU")
 
     if src_dtype == 'float8e4nv' and is_cuda() and torch.cuda.get_device_capability(0) < (9, 0):
         pytest.skip("float8e4nv upcast tests only supported on NVGPU with compute capability 9.0+")
@@ -288,7 +293,7 @@ def test_typeconvert_upcast(src_dtype, dst_dtype, device):
     if src_dtype in ('float8e4nv', 'float8e4b15') and is_hip():
         pytest.skip(f"{src_dtype} upcast tests not supported on ROCm")
 
-    if src_dtype in ('float8e4b8', 'float8e5b16') and (is_cuda() or not is_on_mi300()):
+    if src_dtype in ('float8e4b8', 'float8e5b16') and (is_cuda() or (is_hip() and not is_on_mi300())):
         pytest.skip("{src_dtype} upcast tests only supported on AMDGPU MI300")
 
     # dtype : (exponent_bits, mantissa_bits, exponent_bias, max_repr)
@@ -329,14 +334,16 @@ def test_typeconvert_upcast(src_dtype, dst_dtype, device):
     ('float16', 'float8e4b8', 'rtne', 0x5b80),
 ])
 def test_typeconvert_downcast(src_dtype, dst_dtype, rounding, max_repr, device):
+    if is_cpu() and dst_dtype not in ['float8e5', 'float8e4nv', 'float8e5b16']:
+        pytest.skip(f"Conversion from {src_dtype} to {dst_dtype} is not supported on CPU")
 
     if src_dtype != 'float32' and is_cuda() and torch.cuda.get_device_capability(0) < (9, 0):
         pytest.skip("non-float32 downcast tests only supported on NVGPU with compute capability 9.0+")
 
-    if dst_dtype in ('float8e5', 'float8e4nv') and rounding == 'rtne' and (is_hip() or torch.cuda.get_device_capability(0) < (9, 0)):
+    if dst_dtype in ('float8e5', 'float8e4nv') and rounding == 'rtne' and (is_hip() or (is_cuda() and torch.cuda.get_device_capability(0) < (9, 0))):
         pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on NVGPU with compute capability 9.0+")
 
-    if dst_dtype in ('float8e5b16', 'float8e4b8') and rounding == 'rtne' and (is_cuda() or not is_on_mi300()):
+    if dst_dtype in ('float8e5b16', 'float8e4b8') and rounding == 'rtne' and (is_cuda() or (is_hip() and not is_on_mi300())):
         pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on AMDGPU MI300")
 
     # dtype : (exponent_bits, mantissa_bits, exponent_bias)

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3136,8 +3136,6 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
         if in_dtype == 'bfloat16':
             pytest.skip("bfloat16 is not supported in the interpreter")
     elif is_cpu():
-        if input_precision != "ieee":
-            pytest.skip(f"{input_precision} not supported on CPU")
         if in_dtype == 'float8e4nv' or in_dtype == 'float8e5':
             pytest.skip("float8e4nv and float8e5 not supported on CPU")
         # This test kernel runs in a single thread and can take a long time

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -425,6 +425,7 @@ def _mod_operation_ill_conditioned(dtype_x, dtype_y) -> bool:
     ]
 
 
+@pytest.mark.cpu
 def test_dtype_codegen():
     for dtype in dtypes_with_bfloat16:
         full_name = f"triton.language.{dtype}"
@@ -3850,6 +3851,7 @@ def test_masked_load_shared_memory(dtype, device):
     torch.testing.assert_close(out, reference_out, atol=1e-2, rtol=0)
 
 
+@pytest.mark.cpu
 @pytest.mark.interpreter
 @pytest.mark.parametrize("cache", ["", ".ca", ".cg"])
 def test_load_cache_modifier(cache, device):
@@ -3878,6 +3880,7 @@ def test_load_cache_modifier(cache, device):
         assert 'ld.global.cg' not in ptx
 
 
+@pytest.mark.cpu
 @pytest.mark.interpreter
 @pytest.mark.parametrize("N", [16, 10, 11, 1024])
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
@@ -3905,6 +3908,7 @@ def test_vectorization(N, num_ctas, device):
     torch.testing.assert_close(dst[:N], src[:N], atol=1e-6, rtol=0)
 
 
+@pytest.mark.cpu
 @pytest.mark.interpreter
 @pytest.mark.parametrize("has_hints", [False, True])
 def test_vectorization_hints(has_hints, device):
@@ -3937,6 +3941,7 @@ def test_vectorization_hints(has_hints, device):
 # ---------------
 
 
+@pytest.mark.cpu
 @pytest.mark.interpreter
 @pytest.mark.parametrize("cache", ["", ".wb", ".cg", ".cs", ".wt"])
 def test_store_cache_modifier(cache, device):
@@ -3980,6 +3985,7 @@ def test_store_cache_modifier(cache, device):
         assert 'st.global.wt' in ptx
 
 
+@pytest.mark.cpu
 @pytest.mark.interpreter
 @pytest.mark.parametrize("eviction_policy", ["", "evict_last", "evict_first"])
 def test_store_eviction_policy(eviction_policy, device):

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3136,8 +3136,6 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
         if in_dtype == 'bfloat16':
             pytest.skip("bfloat16 is not supported in the interpreter")
     elif is_cpu():
-        if in_dtype == 'float8e4nv' or in_dtype == 'float8e5':
-            pytest.skip("float8e4nv and float8e5 not supported on CPU")
         # This test kernel runs in a single thread and can take a long time
         # for bigger sizes with the current codegen on CPU. Limit input sizes
         # by default to get more reasonable tests execution time.

--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -19,7 +19,7 @@ class CPUOptions:
     cluster_dims: tuple = (1, 1, 1)
     extern_libs: dict = None
     debug: bool = False
-    allowed_dot_input_precisions: Tuple[str] = ("ieee", )
+    allowed_dot_input_precisions: Tuple[str] = ("ieee", "tf32", "tf32x3")
     allow_fp8e4nv: bool = False
     enable_fp_fusion: bool = True
 

--- a/third_party/cpu/include/TritonCPUTransforms/Passes.h
+++ b/third_party/cpu/include/TritonCPUTransforms/Passes.h
@@ -23,6 +23,9 @@ std::unique_ptr<OperationPass<ModuleOp>>
 createConvertUnsupportedOps(bool promoteBf16ToFp32,
                             bool convertMixedPrecisionMatmul);
 std::unique_ptr<OperationPass<ModuleOp>> createDecomposeFpConversions();
+std::unique_ptr<OperationPass<ModuleOp>>
+createDecomposeFpConversions(bool decomposeBf16Conversions,
+                             bool decomposeFp8Conversions);
 
 #define GEN_PASS_REGISTRATION
 #include "cpu/include/TritonCPUTransforms/Passes.h.inc"

--- a/third_party/cpu/include/TritonCPUTransforms/Passes.td
+++ b/third_party/cpu/include/TritonCPUTransforms/Passes.td
@@ -36,7 +36,16 @@ def DecomposeFpConversions : Pass<"triton-cpu-decompose-fp-conversions", "mlir::
         intrinsics. This pass transforms such conversions into vector code
         instead.
     }];
-    // TODO: add options to specify which FP conversions to decompose.
+
+    let options = [
+        Option<"decomposeBf16Conversions", "decompose-bf16-conversions",
+               "bool", /*default*/"false",
+               "Lower BF16 conversions to arith operations.">,
+        Option<"decomposeFp8Conversions", "decompose-fp8-conversions",
+               "bool", /*default*/"false",
+               "Lower FP8 conversions to arith operations.">,
+    ];
+
     let constructor = "mlir::triton::cpu::createDecomposeFpConversions()";
 
     let dependentDialects = ["mlir::arith::ArithDialect",

--- a/third_party/cpu/lib/TritonCPUTransforms/DecomposeFpConversions.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/DecomposeFpConversions.cpp
@@ -12,8 +12,10 @@
 
 namespace mlir {
 namespace triton {
+namespace cpu {
 #define GEN_PASS_DEF_DECOMPOSEFPCONVERSIONS
 #include "cpu/include/TritonCPUTransforms/Passes.h.inc"
+} // namespace cpu
 } // namespace triton
 } // namespace mlir
 
@@ -33,33 +35,479 @@ struct Fp32ToBf16Conversion : public OpRewritePattern<arith::TruncFOp> {
       return failure();
 
     Location loc = op.getLoc();
-    Value i32Src =
-        rewriter.create<arith::BitcastOp>(loc, toInt32(src.getType()), src);
-    TypedAttr shiftValAttr = rewriter.getI32IntegerAttr(16);
-    if (auto vecTy = dyn_cast<VectorType>(i32Src.getType()))
-      shiftValAttr = SplatElementsAttr::get(vecTy, shiftValAttr);
-    Value shiftedSrc = rewriter.create<arith::ShRUIOp>(
-        loc, i32Src, rewriter.create<arith::ConstantOp>(loc, shiftValAttr));
-    Value i16Res = rewriter.create<arith::TruncIOp>(loc, toInt16(src.getType()),
-                                                    shiftedSrc);
-    Value res = rewriter.create<arith::BitcastOp>(loc, op.getType(), i16Res);
+    Value i32Src = op_bitcast(toInt32(src.getType()), src);
+    Value shiftedSrc = op_lshr(i32Src, cst_like(i32Src, 16));
+    Value i16Res = op_trunci(toInt16(src.getType()), shiftedSrc);
+    Value res = op_bitcast(op.getType(), i16Res);
+    rewriter.replaceOp(op, res);
+    return success();
+  }
+};
+
+typedef std::function<Value(Location, Value, PatternRewriter &)> FpToFpConvFn;
+
+// Convert FP8 to FP16/FP32.
+Value convertFp8(Location loc, Value src, int srcExpBits, int srcExpBias,
+                 Type dstFpTy, PatternRewriter &rewriter) {
+  assert(srcExpBits >= 4 && srcExpBits <= 5 && "Unexpect FP8 type conversion");
+  assert(srcExpBias >= 0 && srcExpBias <= 16 && "Unexpect FP8 type conversion");
+  assert((dstFpTy.isF16() || dstFpTy.isF32()) &&
+         "Unsupported FP8 type conversion");
+  Type srcTy = src.getType();
+  Type dstTy = toTyOrVectorOf(srcTy, dstFpTy);
+  int dstExpBits = dstFpTy.isF16() ? 5 : 8;
+  int dstMantBits = dstFpTy.isF16() ? 10 : 23;
+  int dstExpBias = dstFpTy.isF16() ? 15 : 127;
+  int srcMantBits = 7 - srcExpBits;
+  assert(dstExpBias >= srcExpBias && "Unsupported FP8 type conversion");
+  Type dstIntTy =
+      dstFpTy.isF16() ? rewriter.getI16Type() : rewriter.getI32Type();
+  Value i8Src = op_bitcast(toInt8(srcTy), src);
+  Value intSrc = op_zext(toTyOrVectorOf(srcTy, dstIntTy), i8Src);
+  Value shiftedVal;
+  if (srcExpBits != dstExpBits) {
+    Value sign = op_and(intSrc, cst_like(intSrc, 0x80));
+    Value nosign = op_and(intSrc, cst_like(intSrc, 0x7f));
+    shiftedVal = op_addi(
+        op_shl(sign, cst_like(sign, dstFpTy.getIntOrFloatBitWidth() - 8)),
+        op_shl(nosign, cst_like(nosign, dstMantBits - srcMantBits)));
+  } else {
+    shiftedVal =
+        op_shl(intSrc, cst_like(intSrc, dstFpTy.getIntOrFloatBitWidth() - 8));
+  }
+  Value res = op_bitcast(dstTy, shiftedVal);
+  if (srcExpBias != dstExpBias) {
+    double scale = pow(2, dstExpBias - srcExpBias);
+    res = op_mulf(res, cst_like(res, scale));
+  }
+  return res;
+}
+
+Value convertFp8E4M3ToFp16(Location loc, Value src, PatternRewriter &rewriter) {
+  return convertFp8(loc, src, 4, 7, rewriter.getF16Type(), rewriter);
+}
+
+Value convertFp8E5M2ToFp16(Location loc, Value src, PatternRewriter &rewriter) {
+  return convertFp8(loc, src, 5, 15, rewriter.getF16Type(), rewriter);
+}
+
+Value convertFp8E5M2B16ToFp16(Location loc, Value src,
+                              PatternRewriter &rewriter) {
+  Value f32Res = convertFp8(loc, src, 5, 16, rewriter.getF32Type(), rewriter);
+  return rewriter.create<arith::TruncFOp>(loc, toFp16(src.getType()), f32Res);
+}
+
+Value convertFp8E4M3ToBf16(Location loc, Value src, PatternRewriter &rewriter) {
+  Value f32Res = convertFp8(loc, src, 4, 7, rewriter.getF32Type(), rewriter);
+  return rewriter.create<arith::TruncFOp>(loc, toBf16(src.getType()), f32Res);
+}
+
+Value convertFp8E5M2ToBf16(Location loc, Value src, PatternRewriter &rewriter) {
+  Value f32Res = convertFp8(loc, src, 5, 15, rewriter.getF32Type(), rewriter);
+  return rewriter.create<arith::TruncFOp>(loc, toBf16(src.getType()), f32Res);
+}
+
+Value convertFp8E5M2B16ToBf16(Location loc, Value src,
+                              PatternRewriter &rewriter) {
+  Value f32Res = convertFp8(loc, src, 5, 16, rewriter.getF32Type(), rewriter);
+  return rewriter.create<arith::TruncFOp>(loc, toBf16(src.getType()), f32Res);
+}
+
+Value convertFp8E4M3ToFp32(Location loc, Value src, PatternRewriter &rewriter) {
+  return convertFp8(loc, src, 4, 7, rewriter.getF32Type(), rewriter);
+}
+
+Value convertFp8E5M2ToFp32(Location loc, Value src, PatternRewriter &rewriter) {
+  return convertFp8(loc, src, 5, 15, rewriter.getF32Type(), rewriter);
+}
+
+Value convertFp8E5M2B16ToFp32(Location loc, Value src,
+                              PatternRewriter &rewriter) {
+  return convertFp8(loc, src, 5, 16, rewriter.getF32Type(), rewriter);
+}
+
+// Convert F16/FP32 to FP8.
+Value convertToFp8(Location loc, Value src, Type dstFpTy, int dstExpBits,
+                   int dstExpBias, bool rtneRounding, bool unsignedZero,
+                   PatternRewriter &rewriter) {
+  assert(dstExpBits >= 4 && dstExpBits <= 5 && "Unexpect FP8 type conversion");
+  assert(dstExpBias >= 0 && dstExpBias <= 16 && "Unexpect FP8 type conversion");
+  Type srcTy = src.getType();
+  Type srcFpTy = getElemTyOrTy(srcTy);
+  assert((srcFpTy.isF16() || srcFpTy.isF32()) &&
+         "Unsupported FP8 type conversion");
+  int dstMantBits = 7 - dstExpBits;
+  int srcExpBits = srcFpTy.isF16() ? 5 : 8;
+  int srcMantBits = srcFpTy.isF16() ? 10 : 23;
+  int srcExpBias = srcFpTy.isF16() ? 15 : 127;
+  assert(dstExpBias <= srcExpBias && "Unsupported FP8 type conversion");
+  Type srcIntTy =
+      srcFpTy.isF16() ? rewriter.getI16Type() : rewriter.getI32Type();
+  Value intSrc = op_bitcast(toTyOrVectorOf(srcTy, srcIntTy), src);
+  // Extract sign and put it to the proper place for FP8.
+  Value sign =
+      op_lshr(op_and(intSrc, cst_like(intSrc, 1 << (srcExpBits + srcMantBits))),
+              cst_like(intSrc, srcFpTy.getIntOrFloatBitWidth() - 8));
+  // Extract mantissa and exponent.
+  Value mant = op_and(intSrc, cst_like(intSrc, (1 << srcMantBits) - 1));
+  Value exp = op_and(op_lshr(intSrc, cst_like(intSrc, srcMantBits)),
+                     cst_like(intSrc, (1 << srcExpBits) - 1));
+  Value isZeroExp = op_icmp_eq(exp, cst_like(exp, 0));
+  mant = op_select(isZeroExp, mant,
+                   op_addi(mant, cst_like(mant, 1 << srcMantBits)));
+  exp = op_select(isZeroExp, exp, op_subi(exp, cst_like(exp, 1)));
+  double adjustment = pow(0.5, srcMantBits - dstMantBits);
+  exp = op_subi(exp, cst_like(exp, srcExpBias - dstExpBias));
+  mant = op_mulf(op_sitofp(srcTy, mant), cst_like(src, adjustment));
+  // Make exponent non-negative.
+  if (dstExpBias - srcExpBias <= -8) {
+    // In this case we don't have enough mantissa bits, so can round to 0.
+    Value mask = op_icmp_sgt(exp, cst_like(exp, -8));
+    exp = op_select(mask, exp, cst_like(exp, 0));
+    mant = op_select(mask, mant, cst_like(mant, 0.0));
+  }
+  if (dstExpBias - srcExpBias <= -4) {
+    Value mask = op_icmp_sgt(exp, cst_like(exp, -4));
+    exp = op_select(mask, exp, op_addi(exp, cst_like(exp, 4)));
+    mant = op_select(mask, mant, op_mulf(mant, cst_like(mant, 0.0625)));
+  }
+  if (dstExpBias - srcExpBias <= -2) {
+    Value mask = op_icmp_sgt(exp, cst_like(exp, -2));
+    exp = op_select(mask, exp, op_addi(exp, cst_like(exp, 2)));
+    mant = op_select(mask, mant, op_mulf(mant, cst_like(mant, 0.25)));
+  }
+  if (dstExpBias - srcExpBias <= -1) {
+    Value mask = op_icmp_sgt(exp, cst_like(exp, -1));
+    exp = op_select(mask, exp, op_addi(exp, cst_like(exp, 1)));
+    mant = op_select(mask, mant, op_mulf(mant, cst_like(mant, 0.5)));
+  }
+  if (rtneRounding) {
+    // Bring the value to the range [2 ** 10/23, 2 ** 11/24]
+    // where the representable fp16/fp32 map exactly to integers.
+    // Addition has RTNE semantics.
+    Value offs = cst_like(mant, static_cast<double>(1 << srcMantBits));
+    mant = op_addf(mant, offs);
+    mant = op_subf(mant, offs);
+  }
+  mant = op_fptosi(toTyOrVectorOf(srcTy, srcIntTy), mant);
+
+  Value res =
+      op_addi(sign, op_addi(op_shl(exp, cst_like(exp, 7 - dstExpBits)), mant));
+  res = op_trunci(toInt8(srcTy), res);
+  if (unsignedZero) {
+    Value isNegativeZero = op_icmp_eq(res, cst_like(res, 0x80));
+    res = op_select(isNegativeZero, cst_like(res, 0), res);
+  }
+  res = op_bitcast(toTyOrVectorOf(srcTy, dstFpTy), res);
+  return res;
+}
+
+Value convertFp16ToFp8E4M3Rtz(Location loc, Value src,
+                              PatternRewriter &rewriter) {
+  // TODO: Fix type to Float8E4M3FN.
+  return convertToFp8(loc, src, rewriter.getFloat8E4M3FNUZType(), 4, 7, false,
+                      false, rewriter);
+}
+
+Value convertFp16ToFp8E4M3Rtne(Location loc, Value src,
+                               PatternRewriter &rewriter) {
+  // TODO: Fix type to Float8E4M3FN.
+  return convertToFp8(loc, src, rewriter.getFloat8E4M3FNUZType(), 4, 7, true,
+                      false, rewriter);
+}
+
+Value convertFp16ToFp8E5M2Rtz(Location loc, Value src,
+                              PatternRewriter &rewriter) {
+  Type srcTy = src.getType();
+  Type dstTy = toFp8E5M2(srcTy);
+  Value i16Src = op_bitcast(toInt16(srcTy), src);
+  Value shiftedSrc = op_lshr(i16Src, cst_like(i16Src, 8));
+  Value i8Res = op_trunci(toInt8(srcTy), shiftedSrc);
+  Value res = op_bitcast(dstTy, i8Res);
+  return res;
+}
+
+Value convertFp16ToFp8E5M2Rtne(Location loc, Value src,
+                               PatternRewriter &rewriter) {
+  Type srcTy = src.getType();
+  Type dstTy = toFp8E5M2(srcTy);
+  Value i16Src = op_bitcast(toInt16(srcTy), src);
+  Value sign = op_and(i16Src, cst_like(i16Src, 0x8000));
+  Value truncated = op_and(i16Src, cst_like(i16Src, 0x7f00));
+  Value tail = op_and(i16Src, cst_like(i16Src, 0xff));
+  Value odd_trunc = op_icmp_ne(op_and(truncated, cst_like(truncated, 0x100)),
+                               cst_like(truncated, 0));
+  Value round_up =
+      op_or(op_icmp_ugt(tail, cst_like(tail, 0x80)),
+            op_and(op_icmp_eq(tail, cst_like(tail, 0x80)), odd_trunc));
+  // Skip round-up if it leads to inf/nan.
+  round_up =
+      op_and(round_up, op_icmp_ult(truncated, cst_like(truncated, 0x7b00)));
+  truncated = op_select(
+      round_up, op_addi(truncated, cst_like(truncated, 0x100)), truncated);
+
+  Value res = op_lshr(op_or(truncated, sign), cst_like(truncated, 8));
+  res = op_bitcast(dstTy, op_trunci(toInt8(srcTy), res));
+  return res;
+}
+
+Value convertFp16ToFp8E5M2B16Rtz(Location loc, Value src,
+                                 PatternRewriter &rewriter) {
+  Value f32Src =
+      rewriter.create<arith::ExtFOp>(loc, toFp32(src.getType()), src);
+  return convertToFp8(loc, f32Src, rewriter.getFloat8E5M2FNUZType(), 5, 16,
+                      false, true, rewriter);
+}
+
+Value convertFp16ToFp8E5M2B16Rtne(Location loc, Value src,
+                                  PatternRewriter &rewriter) {
+  Value f32Src =
+      rewriter.create<arith::ExtFOp>(loc, toFp32(src.getType()), src);
+  return convertToFp8(loc, f32Src, rewriter.getFloat8E5M2FNUZType(), 5, 16, true,
+                      true, rewriter);
+}
+
+Value convertBf16ToFp8E4M3Rtz(Location loc, Value src,
+                              PatternRewriter &rewriter) {
+  // TODO: Fix type to Float8E4M3FN.
+  Value f32Src =
+      rewriter.create<arith::ExtFOp>(loc, toFp32(src.getType()), src);
+  return convertToFp8(loc, f32Src, rewriter.getFloat8E4M3FNUZType(), 4, 7,
+                      false, false, rewriter);
+}
+
+Value convertBf16ToFp8E4M3Rtne(Location loc, Value src,
+                               PatternRewriter &rewriter) {
+  // TODO: Fix type to Float8E4M3FN.
+  Value f32Src =
+      rewriter.create<arith::ExtFOp>(loc, toFp32(src.getType()), src);
+  return convertToFp8(loc, f32Src, rewriter.getFloat8E4M3FNUZType(), 4, 7, true,
+                      false, rewriter);
+}
+
+Value convertBf16ToFp8E5M2Rtz(Location loc, Value src,
+                              PatternRewriter &rewriter) {
+  Value f32Src =
+      rewriter.create<arith::ExtFOp>(loc, toFp32(src.getType()), src);
+  return convertToFp8(loc, f32Src, rewriter.getFloat8E5M2Type(), 5, 15, false,
+                      false, rewriter);
+}
+
+Value convertBf16ToFp8E5M2Rtne(Location loc, Value src,
+                               PatternRewriter &rewriter) {
+  Value f32Src =
+      rewriter.create<arith::ExtFOp>(loc, toFp32(src.getType()), src);
+  return convertToFp8(loc, f32Src, rewriter.getFloat8E5M2Type(), 5, 15, true,
+                      false, rewriter);
+}
+
+Value convertBf16ToFp8E5M2B16Rtz(Location loc, Value src,
+                                 PatternRewriter &rewriter) {
+  Value f32Src =
+      rewriter.create<arith::ExtFOp>(loc, toFp32(src.getType()), src);
+  return convertToFp8(loc, f32Src, rewriter.getFloat8E5M2FNUZType(), 5, 16,
+                      false, true, rewriter);
+}
+
+Value convertBf16ToFp8E5M2B16Rtne(Location loc, Value src,
+                                  PatternRewriter &rewriter) {
+  Value f32Src =
+      rewriter.create<arith::ExtFOp>(loc, toFp32(src.getType()), src);
+  return convertToFp8(loc, f32Src, rewriter.getFloat8E5M2FNUZType(), 5, 16,
+                      true, true, rewriter);
+}
+
+Value convertFp32ToFp8E4M3Rtz(Location loc, Value src,
+                              PatternRewriter &rewriter) {
+  // TODO: Fix type to Float8E4M3FN.
+  return convertToFp8(loc, src, rewriter.getFloat8E4M3FNUZType(), 4, 7, false,
+                      false, rewriter);
+}
+
+Value convertFp32ToFp8E4M3Rtne(Location loc, Value src,
+                               PatternRewriter &rewriter) {
+  // TODO: Fix type to Float8E4M3FN.
+  return convertToFp8(loc, src, rewriter.getFloat8E4M3FNUZType(), 4, 7, true,
+                      false, rewriter);
+}
+
+Value convertFp32ToFp8E5M2Rtz(Location loc, Value src,
+                              PatternRewriter &rewriter) {
+  return convertToFp8(loc, src, rewriter.getFloat8E5M2Type(), 5, 15, false,
+                      false, rewriter);
+}
+
+Value convertFp32ToFp8E5M2Rtne(Location loc, Value src,
+                               PatternRewriter &rewriter) {
+  return convertToFp8(loc, src, rewriter.getFloat8E5M2Type(), 5, 15, true,
+                      false, rewriter);
+}
+
+Value convertFp32ToFp8E5M2B16Rtz(Location loc, Value src,
+                                 PatternRewriter &rewriter) {
+  return convertToFp8(loc, src, rewriter.getFloat8E5M2FNUZType(), 5, 16, false,
+                      true, rewriter);
+}
+
+Value convertFp32ToFp8E5M2B16Rtne(Location loc, Value src,
+                                  PatternRewriter &rewriter) {
+  return convertToFp8(loc, src, rewriter.getFloat8E5M2FNUZType(), 5, 16, true,
+                      true, rewriter);
+}
+
+FpToFpConvFn
+getFpToFpConversionFn(Type srcTy, Type dstTy,
+                      std::optional<arith::RoundingMode> roundMode) {
+  // TODO: Float8E4M3FNUZType is used for both float8e4nv and float8e4b8 by
+  // frontend. float8e4b8 tests are skipped for CPU so we interpret this type as
+  // float8e4nv. Needs to be fixed. See get_fp8e4nv_ty at ir.cc.
+  auto F8E4M3TyID = TypeID::get<Float8E4M3FNUZType>();
+  auto F8E5M2TyID = TypeID::get<Float8E5M2Type>();
+  auto F8E5M2B16TyID = TypeID::get<Float8E5M2FNUZType>();
+  auto F16TyID = TypeID::get<Float16Type>();
+  auto BF16TyID = TypeID::get<BFloat16Type>();
+  auto F32TyID = TypeID::get<Float32Type>();
+
+  static DenseMap<std::tuple<TypeID, TypeID>, FpToFpConvFn> fpExtFnMap = {
+      {{F8E4M3TyID, F16TyID}, convertFp8E4M3ToFp16},
+      {{F8E5M2TyID, F16TyID}, convertFp8E5M2ToFp16},
+      {{F8E5M2B16TyID, F16TyID}, convertFp8E5M2B16ToFp16},
+      {{F8E4M3TyID, BF16TyID}, convertFp8E4M3ToBf16},
+      {{F8E5M2TyID, BF16TyID}, convertFp8E5M2ToBf16},
+      {{F8E5M2B16TyID, BF16TyID}, convertFp8E5M2B16ToBf16},
+      {{F8E4M3TyID, F32TyID}, convertFp8E4M3ToFp32},
+      {{F8E5M2TyID, F32TyID}, convertFp8E5M2ToFp32},
+      {{F8E5M2B16TyID, F32TyID}, convertFp8E5M2B16ToFp32},
+  };
+  static DenseMap<std::tuple<TypeID, TypeID, arith::RoundingMode>, FpToFpConvFn>
+      fpTruncFnMap = {
+          {{F16TyID, F8E4M3TyID, arith::RoundingMode::toward_zero},
+           convertFp16ToFp8E4M3Rtz},
+          {{F16TyID, F8E4M3TyID, arith::RoundingMode::to_nearest_even},
+           convertFp16ToFp8E4M3Rtne},
+          {{F16TyID, F8E5M2TyID, arith::RoundingMode::toward_zero},
+           convertFp16ToFp8E5M2Rtz},
+          {{F16TyID, F8E5M2TyID, arith::RoundingMode::to_nearest_even},
+           convertFp16ToFp8E5M2Rtne},
+          {{F16TyID, F8E5M2B16TyID, arith::RoundingMode::toward_zero},
+           convertFp16ToFp8E5M2B16Rtz},
+          {{F16TyID, F8E5M2B16TyID, arith::RoundingMode::to_nearest_even},
+           convertFp16ToFp8E5M2B16Rtne},
+          {{BF16TyID, F8E4M3TyID, arith::RoundingMode::toward_zero},
+           convertBf16ToFp8E4M3Rtz},
+          {{BF16TyID, F8E4M3TyID, arith::RoundingMode::to_nearest_even},
+           convertBf16ToFp8E4M3Rtne},
+          {{BF16TyID, F8E5M2TyID, arith::RoundingMode::toward_zero},
+           convertBf16ToFp8E5M2Rtz},
+          {{BF16TyID, F8E5M2TyID, arith::RoundingMode::to_nearest_even},
+           convertBf16ToFp8E5M2Rtne},
+          {{BF16TyID, F8E5M2B16TyID, arith::RoundingMode::toward_zero},
+           convertBf16ToFp8E5M2B16Rtz},
+          {{BF16TyID, F8E5M2B16TyID, arith::RoundingMode::to_nearest_even},
+           convertBf16ToFp8E5M2B16Rtne},
+          {{F32TyID, F8E4M3TyID, arith::RoundingMode::toward_zero},
+           convertFp32ToFp8E4M3Rtz},
+          {{F32TyID, F8E4M3TyID, arith::RoundingMode::to_nearest_even},
+           convertFp32ToFp8E4M3Rtne},
+          {{F32TyID, F8E5M2TyID, arith::RoundingMode::toward_zero},
+           convertFp32ToFp8E5M2Rtz},
+          {{F32TyID, F8E5M2TyID, arith::RoundingMode::to_nearest_even},
+           convertFp32ToFp8E5M2Rtne},
+          {{F32TyID, F8E5M2B16TyID, arith::RoundingMode::toward_zero},
+           convertFp32ToFp8E5M2B16Rtz},
+          {{F32TyID, F8E5M2B16TyID, arith::RoundingMode::to_nearest_even},
+           convertFp32ToFp8E5M2B16Rtne},
+      };
+
+  if (roundMode) {
+    auto key =
+        std::make_tuple(srcTy.getTypeID(), dstTy.getTypeID(), *roundMode);
+    if (fpTruncFnMap.count(key))
+      return fpTruncFnMap.at(key);
+  } else {
+    auto key = std::make_tuple(srcTy.getTypeID(), dstTy.getTypeID());
+    if (fpExtFnMap.count(key))
+      return fpExtFnMap.at(key);
+  }
+
+  return FpToFpConvFn();
+}
+
+Value convertFpToFp(Location loc, Value src, Type dstTy,
+                    std::optional<arith::RoundingMode> roundMode,
+                    PatternRewriter &rewriter) {
+  Type srcTy = src.getType();
+  Type srcElemTy = getElemTyOrTy(srcTy);
+  Type dstElemTy = getElemTyOrTy(dstTy);
+  auto fn = getFpToFpConversionFn(srcElemTy, dstElemTy, roundMode);
+  if (!fn) {
+    llvm::errs() << "Unsupported conversion from " << srcElemTy << " to "
+                 << dstElemTy;
+    if (roundMode)
+      llvm::errs() << " with rounding mode "
+                   << arith::stringifyRoundingMode(*roundMode);
+    llvm::errs() << "\n";
+    llvm_unreachable("");
+  }
+  return fn(loc, src, rewriter);
+}
+
+struct RewriteTruncFp8 : public OpRewritePattern<arith::TruncFOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(arith::TruncFOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    Value src = op.getIn();
+    Type srcTy = src.getType();
+    Type dstTy = op.getType();
+    if (!isFp8(dstTy))
+      return failure();
+    Value res = convertFpToFp(loc, src, dstTy, op.getRoundingmode(), rewriter);
+    rewriter.replaceOp(op, res);
+    return success();
+  }
+};
+
+struct RewriteExtFp8 : public OpRewritePattern<arith::ExtFOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(arith::ExtFOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    Value src = op.getIn();
+    Type srcTy = src.getType();
+    if (!isFp8(srcTy))
+      return failure();
+    Type dstTy = op.getType();
+    Value res = convertFpToFp(loc, src, dstTy, std::nullopt, rewriter);
     rewriter.replaceOp(op, res);
     return success();
   }
 };
 
 struct DecomposeFpConversions
-    : public triton::impl::DecomposeFpConversionsBase<DecomposeFpConversions> {
-  using DecomposeFpConversionsBase::DecomposeFpConversionsBase;
+    : public triton::cpu::impl::DecomposeFpConversionsBase<
+          DecomposeFpConversions> {
+  DecomposeFpConversions() = default;
 
-  DecomposeFpConversions() : DecomposeFpConversionsBase() {}
+  DecomposeFpConversions(bool decomposeBf16Conversions,
+                         bool decomposeFp8Conversions) {
+    this->decomposeBf16Conversions = decomposeBf16Conversions;
+    this->decomposeFp8Conversions = decomposeFp8Conversions;
+  }
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     ModuleOp mod = getOperation();
 
     RewritePatternSet patterns(context);
-    patterns.add<Fp32ToBf16Conversion>(context);
+    if (decomposeBf16Conversions)
+      patterns.add<Fp32ToBf16Conversion>(context);
+    if (decomposeFp8Conversions) {
+      patterns.add<RewriteTruncFp8>(context);
+      patterns.add<RewriteExtFp8>(context);
+    }
 
     if (failed(mlir::applyPatternsAndFoldGreedily(mod, std::move(patterns))))
       return signalPassFailure();
@@ -74,6 +522,13 @@ namespace cpu {
 
 std::unique_ptr<OperationPass<ModuleOp>> createDecomposeFpConversions() {
   return std::make_unique<DecomposeFpConversions>();
+}
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createDecomposeFpConversions(bool decomposeBf16Conversions,
+                             bool decomposeFp8Conversions) {
+  return std::make_unique<DecomposeFpConversions>(decomposeBf16Conversions,
+                                                  decomposeFp8Conversions);
 }
 
 } // namespace cpu

--- a/third_party/cpu/lib/TritonCPUTransforms/DecomposeFpConversions.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/DecomposeFpConversions.cpp
@@ -263,8 +263,8 @@ Value convertFp16ToFp8E5M2B16Rtne(Location loc, Value src,
                                   PatternRewriter &rewriter) {
   Value f32Src =
       rewriter.create<arith::ExtFOp>(loc, toFp32(src.getType()), src);
-  return convertToFp8(loc, f32Src, rewriter.getFloat8E5M2FNUZType(), 5, 16, true,
-                      true, rewriter);
+  return convertToFp8(loc, f32Src, rewriter.getFloat8E5M2FNUZType(), 5, 16,
+                      true, true, rewriter);
 }
 
 Value convertBf16ToFp8E4M3Rtz(Location loc, Value src,

--- a/third_party/cpu/lib/TritonCPUTransforms/OptCommon.h
+++ b/third_party/cpu/lib/TritonCPUTransforms/OptCommon.h
@@ -1,46 +1,150 @@
 #ifndef TRITONCPU_CONVERSION_TRITONCPUOPT_OPTCOMMON_H
 #define TRITONCPU_CONVERSION_TRITONCPUOPT_OPTCOMMON_H
 
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
 
 namespace mlir {
 namespace triton {
 namespace cpu {
 
-inline bool isTyOrVectorOf(mlir::Type ty, mlir::Type elemTy) {
-  if (auto vecTy = dyn_cast<mlir::VectorType>(ty))
-    return vecTy.getElementType() == elemTy;
-  return ty == elemTy;
+inline Type getElemTyOrTy(Type ty) {
+  if (auto vecTy = dyn_cast<VectorType>(ty))
+    return vecTy.getElementType();
+  return ty;
 }
 
-inline bool isBf16(mlir::Type ty) {
-  return isTyOrVectorOf(ty, mlir::BFloat16Type::get(ty.getContext()));
+inline bool isTyOrVectorOf(Type ty, Type elemTy) {
+  return getElemTyOrTy(ty) == elemTy;
 }
 
-inline bool isFp32(mlir::Type ty) {
-  return isTyOrVectorOf(ty, mlir::Float32Type::get(ty.getContext()));
+inline bool isBf16(Type ty) {
+  return isTyOrVectorOf(ty, BFloat16Type::get(ty.getContext()));
 }
 
-inline mlir::Type toTyOrVectorOf(mlir::Type ty, mlir::Type elemTy) {
-  if (auto vecTy = dyn_cast<mlir::VectorType>(ty))
+inline bool isFp16(Type ty) {
+  return isTyOrVectorOf(ty, Float16Type::get(ty.getContext()));
+}
+
+inline bool isFp32(Type ty) {
+  return isTyOrVectorOf(ty, Float32Type::get(ty.getContext()));
+}
+
+inline bool isFp8(Type ty) {
+  Type elemTy = getElemTyOrTy(ty);
+  if (elemTy.isIntOrFloat() && !elemTy.isInteger())
+    return elemTy.getIntOrFloatBitWidth() == 8;
+  return false;
+}
+
+inline Type toTyOrVectorOf(Type ty, Type elemTy) {
+  if (auto vecTy = dyn_cast<VectorType>(ty))
     return vecTy.cloneWith(std::nullopt, elemTy);
   return elemTy;
 }
 
-inline mlir::Type toInt16(mlir::Type ty) {
-  return toTyOrVectorOf(ty, mlir::IntegerType::get(ty.getContext(), 16));
+inline Type toInt8(Type ty) {
+  return toTyOrVectorOf(ty, IntegerType::get(ty.getContext(), 8));
 }
 
-inline mlir::Type toInt32(mlir::Type ty) {
-  return toTyOrVectorOf(ty, mlir::IntegerType::get(ty.getContext(), 32));
+inline Type toInt16(Type ty) {
+  return toTyOrVectorOf(ty, IntegerType::get(ty.getContext(), 16));
 }
 
-inline mlir::Type toFp32(mlir::Type ty) {
-  return toTyOrVectorOf(ty, mlir::Float32Type::get(ty.getContext()));
+inline Type toInt32(Type ty) {
+  return toTyOrVectorOf(ty, IntegerType::get(ty.getContext(), 32));
+}
+
+inline Type toFp8E5M2(Type ty) {
+  return toTyOrVectorOf(ty, Float8E5M2Type::get(ty.getContext()));
+}
+
+inline Type toFp16(Type ty) {
+  return toTyOrVectorOf(ty, Float16Type::get(ty.getContext()));
+}
+
+inline Type toBf16(Type ty) {
+  return toTyOrVectorOf(ty, BFloat16Type::get(ty.getContext()));
+}
+
+inline Type toFp32(Type ty) {
+  return toTyOrVectorOf(ty, Float32Type::get(ty.getContext()));
+}
+
+inline Value intCst(Location loc, Type ty, int64_t val,
+                    PatternRewriter &rewriter) {
+  TypedAttr valAttr = IntegerAttr::get(getElemTyOrTy(ty), val);
+  if (auto vecTy = dyn_cast<VectorType>(ty))
+    valAttr = SplatElementsAttr::get(vecTy, valAttr);
+  return rewriter.create<arith::ConstantOp>(loc, valAttr);
+}
+
+inline Value fpCst(Location loc, Type ty, double val,
+                   PatternRewriter &rewriter) {
+  TypedAttr valAttr = FloatAttr::get(getElemTyOrTy(ty), val);
+  if (auto vecTy = dyn_cast<VectorType>(ty))
+    valAttr = SplatElementsAttr::get(vecTy, valAttr);
+  return rewriter.create<arith::ConstantOp>(loc, valAttr);
+}
+
+template <typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
+Value cstLike(Location loc, Value tySrc, T val, PatternRewriter &rewriter) {
+  return intCst(loc, tySrc.getType(), val, rewriter);
+}
+
+template <typename T,
+          std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
+Value cstLike(Location loc, Value tySrc, T val, PatternRewriter &rewriter) {
+  return fpCst(loc, tySrc.getType(), val, rewriter);
 }
 
 } // namespace cpu
 } // namespace triton
 } // namespace mlir
+
+#define int_cst(ty, val) intCst(loc, ty, val, rewriter)
+#define cst_like(src, val) cstLike(loc, src, val, rewriter)
+
+#define op_addi(lhs, rhs) rewriter.create<arith::AddIOp>(loc, lhs, rhs)
+#define op_addf(lhs, rhs) rewriter.create<arith::AddFOp>(loc, lhs, rhs)
+#define op_subi(lhs, rhs) rewriter.create<arith::SubIOp>(loc, lhs, rhs)
+#define op_subf(lhs, rhs) rewriter.create<arith::SubFOp>(loc, lhs, rhs)
+#define op_mulf(lhs, rhs) rewriter.create<arith::MulFOp>(loc, lhs, rhs)
+#define op_bitcast(ty, val) rewriter.create<arith::BitcastOp>(loc, ty, val)
+#define op_lshr(lhs, rhs) rewriter.create<arith::ShRUIOp>(loc, lhs, rhs)
+#define op_shl(lhs, rhs) rewriter.create<arith::ShLIOp>(loc, lhs, rhs)
+#define op_trunci(ty, val) rewriter.create<arith::TruncIOp>(loc, ty, val)
+#define op_zext(ty, val) rewriter.create<arith::ExtUIOp>(loc, ty, val)
+#define op_sext(ty, val) rewriter.create<arith::ExtSIOp>(loc, ty, val)
+#define op_and(lhs, rhs) rewriter.create<arith::AndIOp>(loc, lhs, rhs)
+#define op_or(lhs, rhs) rewriter.create<arith::OrIOp>(loc, lhs, rhs)
+#define op_minui(lhs, rhs) rewriter.create<arith::MinUIOp>(loc, lhs, rhs)
+#define op_maxui(lhs, rhs) rewriter.create<arith::MaxUIOp>(loc, lhs, rhs)
+#define op_select(cond, val, other)                                            \
+  rewriter.create<arith::SelectOp>(loc, cond, val, other)
+#define op_sitofp(ty, val) rewriter.create<arith::SIToFPOp>(loc, ty, val)
+#define op_fptosi(ty, val) rewriter.create<arith::FPToSIOp>(loc, ty, val)
+
+#define op_icmp_eq(lhs, rhs)                                                   \
+  rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, lhs, rhs)
+#define op_icmp_ne(lhs, rhs)                                                   \
+  rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ne, lhs, rhs)
+#define op_icmp_ugt(lhs, rhs)                                                  \
+  rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ugt, lhs, rhs)
+#define op_icmp_uge(lhs, rhs)                                                  \
+  rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::uge, lhs, rhs)
+#define op_icmp_ult(lhs, rhs)                                                  \
+  rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ult, lhs, rhs)
+#define op_icmp_ule(lhs, rhs)                                                  \
+  rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ule, lhs, rhs)
+#define op_icmp_sgt(lhs, rhs)                                                  \
+  rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sgt, lhs, rhs)
+#define op_icmp_sge(lhs, rhs)                                                  \
+  rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sge, lhs, rhs)
+#define op_icmp_slt(lhs, rhs)                                                  \
+  rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::slt, lhs, rhs)
+#define op_icmp_sle(lhs, rhs)                                                  \
+  rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sle, lhs, rhs)
 
 #endif

--- a/third_party/cpu/lib/TritonToTritonCPU/ConvertElementwiseOps.cpp
+++ b/third_party/cpu/lib/TritonToTritonCPU/ConvertElementwiseOps.cpp
@@ -55,6 +55,7 @@ public:
     addIllegalOp<triton::PreciseSqrtOp>();
     addIllegalOp<triton::MulhiUIOp>();
     addIllegalOp<triton::ClampFOp>();
+    addIllegalOp<triton::FpToFpOp>();
   }
 };
 
@@ -131,6 +132,44 @@ struct ClampFOpConversion : public OpConversionPattern<triton::ClampFOp> {
     }
     rewriter.replaceOp(op, res);
     return success();
+  }
+};
+
+struct FpToFpOpConversion : public OpConversionPattern<triton::FpToFpOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::FpToFpOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto src = rewriter.getRemappedValue(op.getSrc());
+    auto srcTy = src.getType();
+    auto resTy = getTypeConverter()->convertType(op.getType());
+    auto srcElemTy = isa<VectorType>(srcTy)
+                         ? cast<VectorType>(srcTy).getElementType()
+                         : srcTy;
+    auto resElemTy = isa<VectorType>(resTy)
+                         ? cast<VectorType>(resTy).getElementType()
+                         : resTy;
+
+    if (srcElemTy.getIntOrFloatBitWidth() > resElemTy.getIntOrFloatBitWidth()) {
+      std::optional<RoundingMode> rounding = op.getRounding();
+      assert(rounding && "Rounding mode expected for truncate conversions");
+      auto roundingAttr = arith::RoundingModeAttr::get(
+          getContext(), *rounding == RoundingMode::RTZ
+                            ? arith::RoundingMode::toward_zero
+                            : arith::RoundingMode::to_nearest_even);
+      rewriter.replaceOpWithNewOp<arith::TruncFOp>(op, resTy, src, roundingAttr,
+                                                   nullptr);
+      return success();
+    }
+
+    if (srcElemTy.getIntOrFloatBitWidth() < resElemTy.getIntOrFloatBitWidth()) {
+      rewriter.replaceOpWithNewOp<arith::ExtFOp>(op, resTy, src);
+      return success();
+    }
+
+    return failure();
   }
 };
 
@@ -211,6 +250,7 @@ struct ConvertElementwiseOps
         typeConverter, context);
     patterns.add<MulhiUIOpConversion>(typeConverter, context);
     patterns.add<ClampFOpConversion>(typeConverter, context);
+    patterns.add<FpToFpOpConversion>(typeConverter, context);
 
     if (failed(applyPartialConversion(mod, convTarget, std::move(patterns))))
       return signalPassFailure();

--- a/third_party/cpu/triton_cpu.cc
+++ b/third_party/cpu/triton_cpu.cc
@@ -41,9 +41,12 @@ void init_triton_cpu_passes_ttcpuir(py::module &&m) {
           pm.addPass(mlir::triton::cpu::createConvertUnsupportedOps(
               promote_bf16_to_fp32, convert_mixed_precision_matmul));
         });
-  m.def("add_decompose_fp_conversions", [](mlir::PassManager &pm) {
-    pm.addPass(mlir::triton::cpu::createDecomposeFpConversions());
-  });
+  m.def("add_decompose_fp_conversions",
+        [](mlir::PassManager &pm, bool decomposeBf16Conversions,
+           bool decomposeFp8Conversions) {
+          pm.addPass(mlir::triton::cpu::createDecomposeFpConversions(
+              decomposeBf16Conversions, decomposeFp8Conversions));
+        });
   m.def("add_vector_to_scf", [](mlir::PassManager &pm, bool full_unroll,
                                 unsigned target_rank, bool lower_tensors) {
     mlir::VectorTransferToSCFOptions opts;


### PR DESCRIPTION
This PR adds FP8 conversions so that we can run appropriate tests. Efficient conversions are used only in a couple of cases, others follow a generic emulation similar to the one used in conversion tests.