### PR TITLE
Add fast-math support

### DIFF
--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -42,12 +42,10 @@ struct BreakStructPhiNodesPass : PassInfoMixin<BreakStructPhiNodesPass> {
 
 using namespace llvm;
 
-std::string translateLLVMIRToASM(llvm::Module &module,
-                                 const std::string &triple,
-                                 const std::string &proc,
-                                 const std::string &features,
-                                 const std::vector<std::string> &flags,
-                                 bool enable_fp_fusion, bool isObject) {
+std::string translateLLVMIRToASM(
+    llvm::Module &module, const std::string &triple, const std::string &proc,
+    const std::string &features, const std::vector<std::string> &flags,
+    bool enable_fp_fusion, bool isObject, bool enable_fast_math = false) {
   using namespace mlir;
   // options
   auto options = llvm::cl::getRegisteredOptions();
@@ -115,10 +113,20 @@ std::string translateLLVMIRToASM(llvm::Module &module,
   llvm::TargetOptions opt;
   if (enable_fp_fusion)
     opt.AllowFPOpFusion = llvm::FPOpFusion::Fast;
-  opt.UnsafeFPMath = false;
-  opt.NoInfsFPMath = false;
-  opt.NoNaNsFPMath = true;
-  opt.TrapUnreachable = true;
+
+  if (enable_fast_math) {
+    opt.UnsafeFPMath = true;
+    opt.NoInfsFPMath = true;
+    opt.NoNaNsFPMath = true;
+    opt.NoTrappingFPMath = true;
+    opt.NoSignedZerosFPMath = true;
+    opt.ApproxFuncFPMath = true;
+  } else {
+    opt.UnsafeFPMath = false;
+    opt.NoInfsFPMath = false;
+    opt.NoNaNsFPMath = true;
+    opt.TrapUnreachable = true;
+  }
   std::unique_ptr<llvm::TargetMachine> machine{target->createTargetMachine(
       module.getTargetTriple(), proc, features, opt, llvm::Reloc::PIC_,
       std::nullopt,
@@ -360,7 +368,8 @@ void init_triton_llvm(py::module &&m) {
 
   m.def(
       "translate_to_host_asm",
-      [](std::string llvmIR, bool enable_fp_fusion) -> py::object {
+      [](std::string llvmIR, bool enable_fp_fusion,
+         bool enable_fast_math) -> py::object {
         std::string res;
         {
           // when allow_threads goes out of scope, gil will be released
@@ -380,7 +389,7 @@ void init_triton_llvm(py::module &&m) {
           res =
               translateLLVMIRToASM(*module, llvm::sys::getDefaultTargetTriple(),
                                    llvm::sys::getHostCPUName().str(), "", {},
-                                   enable_fp_fusion, false);
+                                   enable_fp_fusion, false, enable_fast_math);
         }
         return py::str(res);
       },

--- a/third_party/cpu/triton_cpu.cc
+++ b/third_party/cpu/triton_cpu.cc
@@ -56,9 +56,17 @@ void init_triton_cpu_passes_ttcpuir(py::module &&m) {
     pm.addNestedPass<mlir::triton::FuncOp>(
         mlir::triton::cpu::createLowerMultiReductionPass());
   });
-  m.def("add_vector_to_llvmir", [](mlir::PassManager &pm) {
-    pm.addPass(mlir::createConvertVectorToLLVMPass());
-  });
+  m.def("add_vector_to_llvmir",
+        [](mlir::PassManager &pm, bool reassoc_fp_reduction) {
+          mlir::ConvertVectorToLLVMPassOptions opts;
+          opts.reassociateFPReductions = reassoc_fp_reduction;
+          // opts.force32BitVectorIndices = true;
+          // opts.amx = false;
+          // opts.armNeon = false;
+          // opts.armSVE = false;
+          // opts.x86Vector = false;
+          pm.addPass(mlir::createConvertVectorToLLVMPass(opts));
+        });
   m.def("add_lower_affine", [](mlir::PassManager &pm) {
     pm.addPass(mlir::createLowerAffinePass());
   });


### PR DESCRIPTION
Add fast-math option: allow unsafe fp math optimizations and reassociation.
