### PR TITLE
[Scf If types] Support conversion of types for scf::if

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5554,6 +5554,7 @@ def test_maxnreg(device):
         raise
 
 
+@pytest.mark.cpu
 @pytest.mark.interpreter
 def test_temp_var_in_loop(device):
 


### PR DESCRIPTION
This commit copies same approach as it were for `scf::for`. It's aimed to convert types like: `tensor<32xi32>` to `vector<32xi32>`.

Maybe there should be some utility that will be used in all such ConversionPasses to avoid code-duplication.

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

 - [x] This PR does not need a test because `it enables`: `test_temp_var_in_loop` from `test_core` pytest suit.

 - [x] I have not added any `lit` tests.