### PR TITLE
[FP8 tests] Enable several fp8 tests

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -169,6 +169,8 @@ def check_type_supported(dtype, device):
     if is_interpreter():
         if dtype in [tl.bfloat16, "bfloat16", torch.bfloat16]:
             pytest.skip("bfloat16 is not supported in the interpreter")
+    if dtype == 'float8e4b15' and is_cpu():
+        pytest.skip("float8e4b15 not supported on CPU")
 
 
 class MfmaLayout:
@@ -1089,6 +1091,7 @@ def test_abs(dtype_x, device):
     _test_unary(dtype_x, 'tl.abs(x)', 'np.abs(x) ', device=device)
 
 
+@pytest.mark.cpu
 @pytest.mark.interpreter
 @pytest.mark.parametrize("in_dtype", [tl.float8e4b15, tl.float8e4nv, tl.float8e5])
 def test_abs_fp8(in_dtype, device):
@@ -3490,6 +3493,7 @@ def test_dot3d(B, num_warps, M, N, K, in_dtype_str, out_dtype_str, device):
     np.testing.assert_allclose(out_ref, to_numpy(out_tri), rtol=0.01, atol=1e-2)
 
 
+@pytest.mark.cpu
 @pytest.mark.interpreter
 def test_max_num_imprecise_acc(device):
 
@@ -4917,6 +4921,7 @@ def test_nested_while(device):
 # -----------------------
 
 
+@pytest.mark.cpu
 def test_num_threads(device):
     if is_hip():
         pytest.skip("test_num_threads is not supported in HIP")
@@ -5252,6 +5257,9 @@ def test_ptx_cast(dtype_str, device):
 
 def f8_to_f16(x, dtype):
 
+    if is_cpu():
+        assert (False and "Works as expected only for GPU")
+
     @triton.jit
     def kernel(Y, X, N, BLOCK_SIZE: tl.constexpr):
         pid = tl.program_id(0)
@@ -5278,10 +5286,9 @@ def matmul_kernel(  #
         low_precision_acc: tl.constexpr,  #
         num_pipeline_stages: tl.constexpr = 3  #
 ):
-    pid = tl.program_id(axis=0)
-    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
-    pid_m = pid % num_pid_m
-    pid_n = pid // num_pid_m
+    pid_m = tl.program_id(axis=0)
+    pid_n = tl.program_id(axis=1)
+
     offs_am = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
     offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
     offs_k = tl.arange(0, BLOCK_SIZE_K)
@@ -5300,6 +5307,7 @@ def matmul_kernel(  #
     tl.store(c_ptrs, accumulator)
 
 
+@pytest.mark.cpu
 @pytest.mark.interpreter
 @pytest.mark.parametrize("in_type_str", ['float8e5', 'float8e4nv', 'float8e4b15'])
 @pytest.mark.parametrize("low_precision_acc", [0, 32, 64, 128])
@@ -5310,23 +5318,36 @@ def test_fp8_dot_acc(in_type_str, low_precision_acc, device):
         cc = torch.cuda.get_device_capability()
         if cc[0] >= 9 and in_type_str == "float8e4b15":
             pytest.skip("Dot op does not support fp8e4b15 on CUDA arch >= 90")
+    # WARN "low_precision_acc is used only with float8e4b15, and currently ignored on CPU"
+
     check_type_supported(in_type_str, device)
     M, N, K = 128, 256, 256
-    BLOCK_M, BLOCK_N, BLOCK_K = 128, 256, 128
+    if is_cpu():
+        block_m, block_n, block_k = 32, 32, 128
+    else:
+        block_m, block_n, block_k = M, N, K
+    BLOCK_M, BLOCK_N, BLOCK_K = block_m, block_n, block_k
     A = numpy_random((M, K), dtype_str=in_type_str)
     B = numpy_random((K, N), dtype_str=in_type_str)
     C = torch.empty((M, N), dtype=torch.float32, device=device)
     num_warps = 8
     a = to_triton(A, device=device, dst_type=in_type_str)
     b = to_triton(B, device=device, dst_type=in_type_str)
-    grid = (triton.cdiv(M, BLOCK_M), 1)
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
     matmul_kernel[grid](a, b, C, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), C.stride(0), C.stride(1),
                         BLOCK_M, BLOCK_N, BLOCK_K, low_precision_acc, num_warps=num_warps)
     torch_a = torch.from_numpy(A).to(device=device)
-    th_a = f8_to_f16(torch_a, in_type_str)
     torch_b = torch.from_numpy(B).to(device=device)
-    th_b = f8_to_f16(torch_b, in_type_str)
-    ref_out = torch.matmul(th_a, th_b).to(torch.float32)
+    if is_cpu() and 'float8' in in_type_str:
+        in_dtype = getattr(tl, in_type_str)
+        th_a = convert_float_to_float32(torch_a, in_dtype)
+        th_b = convert_float_to_float32(torch_b, in_dtype)
+        ref_out = torch.matmul(th_a, th_b).to(torch.float32)
+    else:
+        th_a = f8_to_f16(torch_a, in_type_str)
+        th_b = f8_to_f16(torch_b, in_type_str)
+        ref_out = torch.matmul(th_a, th_b).to(torch.float32)
+
     if in_type_str == 'float8e4nv':
         torch.testing.assert_close(ref_out, C, rtol=0.01, atol=0.01)
     elif low_precision_acc > 32:
@@ -5511,17 +5532,20 @@ def test_tl_range(device):
     if is_hip():
         pytest.skip("test_tl_range is not supported in HIP")
     M, N, K = 64, 64, 512
-    BLOCK_M, BLOCK_N, BLOCK_K = M, N, 64
+    if is_cpu():
+        block_m, block_n, block_k = 32, 32, 64
+    else:
+        block_m, block_n, block_k = M, N, 64
+    BLOCK_M, BLOCK_N, BLOCK_K = block_m, block_n, block_k
     a = torch.randn((M, K), device=device, dtype=torch.float16)
     b = torch.randn((K, N), device=device, dtype=torch.float16)
     c = torch.empty((M, N), dtype=torch.float32, device=device)
-    pgm = matmul_kernel[
-        1,
-    ](a, b, c, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), c.stride(0), c.stride(1), BLOCK_M, BLOCK_N,
-      BLOCK_K, 0, num_pipeline_stages=5)
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+    pgm = matmul_kernel[grid](a, b, c, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), c.stride(0),
+                              c.stride(1), BLOCK_M, BLOCK_N, BLOCK_K, 0, num_pipeline_stages=5)
     if is_cpu():
         # torch.matmul not implemented for Half float (float16) cpu
-        ref_out = torch.tensor(np.matmul(to_numpy(a), to_numpy(b))).to(torch.float32)
+        ref_out = torch.tensor(np.matmul(to_numpy(a), to_numpy(b)), dtype=torch.float32, device=device)
     else:
         ref_out = torch.matmul(a, b).to(torch.float32)
     if is_interpreter():


### PR DESCRIPTION
This commit enables several fp8 tests, that uses `tl.range`. Requires PR #40. 

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- [x] This PR does not need a test because `FILL THIS IN`.
- [x] I have not added any `lit` tests.


