### PR TITLE
[so] Compile asm to .so as part of staged lowering

### DIFF
--- a/third_party/cpu/backend/driver.py
+++ b/third_party/cpu/backend/driver.py
@@ -47,24 +47,15 @@ class CPUUtils(object):
     def __init__(self):
         pass
 
-    def load_binary(self, name, src, shared_mem, device):
-        # src actually holds asm text, compile to a shared library.
-        key = hashlib.md5(src).hexdigest()
-        cache = get_cache_manager(key)
-        cache_path = cache.get_file(f"{name}.so")
-        if cache_path is None:
-            with tempfile.TemporaryDirectory() as tmpdir:
-                asm_path = os.path.join(tmpdir, "kernel.s")
-                Path(asm_path).write_bytes(src)
-                Path("kernel.s").write_bytes(src)
-                so = _build(name, asm_path, tmpdir, library_dir, include_dir, ["gcc", "m"])
-                with open(so, "rb") as f:
-                    cache_path = cache.put(f.read(), f"{name}.so", binary=True)
-        import ctypes
-        lib = ctypes.cdll.LoadLibrary(cache_path)
-        fn_ptr = getattr(lib, name)
-        fn_ptr_as_void_p = ctypes.cast(fn_ptr, ctypes.c_void_p).value
-        return (fn_ptr, fn_ptr_as_void_p, 0, 0)
+    def load_binary(self, name, kernel, shared_mem, device):
+        with tempfile.NamedTemporaryFile(mode="wb", suffix=".so") as f:
+            f.write(kernel)
+            f.flush()
+            import ctypes
+            lib = ctypes.cdll.LoadLibrary(f.name)
+            fn_ptr = getattr(lib, name)
+            fn_ptr_as_void_p = ctypes.cast(fn_ptr, ctypes.c_void_p).value
+            return (lib, fn_ptr_as_void_p, 0, 0)
 
     def get_device_properties(self, *args):
         return {"max_shared_mem": 0}


### PR DESCRIPTION
... instead of doing it at load time. This more closely mirrors how the other backends work. E.g. for the CUDA backend, we compile ptx -> cubin as part of staged lowering too.