### PR TITLE
[CPU] Support device_print for scalar types

### DIFF
--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -151,6 +151,8 @@ class CPUBackend(BaseBackend):
         llvm.init_targets()
         context = llvm.context()
         llvm_mod = llvm.to_module(mod, context)
+        if llvm_mod is None:
+            raise RuntimeError("Failed to convert to LLVM IR")
         llvm.set_host_target(llvm_mod)
         #if options.extern_libs:
         #    paths = [path for (name, path) in options.extern_libs]

--- a/third_party/cpu/include/TritonCPUToLLVM/Passes.h
+++ b/third_party/cpu/include/TritonCPUToLLVM/Passes.h
@@ -25,6 +25,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createMemoryOpToLLVMPass();
 std::unique_ptr<OperationPass<ModuleOp>> createGetProgramIdOpToLLVMPass();
 std::unique_ptr<OperationPass<triton::FuncOp>> createLowerMultiReductionPass();
 std::unique_ptr<OperationPass<ModuleOp>> createAtomicOpsToLLVMPass();
+std::unique_ptr<OperationPass<ModuleOp>> createDebugOpsToLLVMPass();
 
 void tritonCPUToLLVMPipelineBuilder(OpPassManager &pm);
 void registerTritonCPUToLLVMPipeline();

--- a/third_party/cpu/include/TritonCPUToLLVM/Passes.td
+++ b/third_party/cpu/include/TritonCPUToLLVM/Passes.td
@@ -57,4 +57,13 @@ def AtomicOpsToLLVM : Pass<"triton-cpu-atomic-ops-to-llvm", "mlir::ModuleOp"> {
                              "mlir::triton::TritonDialect"];
 }
 
+def DebugOpsToLLVM : Pass<"triton-cpu-debug-ops-to-llvm", "mlir::ModuleOp"> {
+    let summary = "Convert Triton debug operations (prints and asserts) to LLVM.";
+    let description = [{}];
+    let constructor = "mlir::triton::cpu::createDebugOpsToLLVMPass()";
+
+    let dependentDialects = ["mlir::triton::cpu::TritonCPUDialect",
+                             "mlir::triton::TritonDialect"];
+}
+
 #endif

--- a/third_party/cpu/lib/TritonCPUToLLVM/CMakeLists.txt
+++ b/third_party/cpu/lib/TritonCPUToLLVM/CMakeLists.txt
@@ -1,11 +1,13 @@
 add_triton_library(TritonCPUToLLVM
     AtomicOpsToLLVM.cpp
+    DebugOpsToLLVM.cpp
     FuncOpToLLVM.cpp
     GetProgramIdOpToLLVM.cpp
     LowerMultiReduction.cpp
     MemoryOpToLLVM.cpp
     Pipeline.cpp
     TypeConverter.cpp
+    Utility.cpp
 
     DEPENDS
     TritonCPUToLLVMConversionPassIncGen

--- a/third_party/cpu/lib/TritonCPUToLLVM/DebugOpsToLLVM.cpp
+++ b/third_party/cpu/lib/TritonCPUToLLVM/DebugOpsToLLVM.cpp
@@ -1,0 +1,199 @@
+#include "TypeConverter.h"
+#include "Utility.h"
+
+#include "cpu/include/TritonCPUToLLVM/Passes.h"
+
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonCPU/IR/Dialect.h"
+
+namespace mlir {
+namespace triton {
+#define GEN_PASS_DEF_DEBUGOPSTOLLVM
+#include "cpu/include/TritonCPUToLLVM/Passes.h.inc"
+} // namespace triton
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::triton;
+using namespace mlir::triton::cpu;
+
+namespace {
+
+class TritonLLVMConversionTarget : public ConversionTarget {
+public:
+  explicit TritonLLVMConversionTarget(MLIRContext &ctx)
+      : ConversionTarget(ctx) {
+    addLegalDialect<LLVM::LLVMDialect>();
+    addLegalOp<mlir::UnrealizedConversionCastOp>();
+  }
+};
+
+// The code for the print is similar to the GPU's TargetInfo.cpp.
+LLVM::LLVMFuncOp getPrintfDeclaration(ConversionPatternRewriter &rewriter) {
+  auto moduleOp = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
+  StringRef funcName("printf");
+  Operation *funcOp = moduleOp.lookupSymbol(funcName);
+  if (funcOp)
+    return cast<LLVM::LLVMFuncOp>(*funcOp);
+
+  auto *context = rewriter.getContext();
+
+  // int printf(char* format, ...)
+  SmallVector<Type> argsType{ptr_ty(context)};
+  auto funcType = LLVM::LLVMFunctionType::get(i32_ty, argsType, true);
+
+  ConversionPatternRewriter::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPointToStart(moduleOp.getBody());
+
+  auto op = rewriter.create<LLVM::LLVMFuncOp>(UnknownLoc::get(context),
+                                              funcName, funcType);
+  return op;
+}
+
+void emitPrintf(ConversionPatternRewriter &rewriter, Value formatStrStart,
+                int /*formatStrByteCount*/, ValueRange args) {
+  auto loc = UnknownLoc::get(rewriter.getContext());
+  SmallVector<Value> formatStrAndArgs{formatStrStart};
+  for (auto arg : args) {
+    formatStrAndArgs.push_back(arg);
+  }
+  call(getPrintfDeclaration(rewriter), formatStrAndArgs);
+}
+
+Value llPrintf(StringRef msg, ValueRange args,
+               ConversionPatternRewriter &rewriter,
+               int *formatStrByteCount = nullptr) {
+  assert(!msg.empty() && "printf with empty string not supported");
+  llvm::SmallString<64> msgNewline(msg);
+  msgNewline.push_back('\n');
+  msgNewline.push_back('\0');
+  Value msgValue =
+      LLVM::addStringToModule(UnknownLoc::get(rewriter.getContext()), rewriter,
+                              "printfFormat_", msgNewline);
+  emitPrintf(rewriter, msgValue, msgNewline.size_in_bytes(), args);
+  if (formatStrByteCount)
+    *formatStrByteCount = msgNewline.size_in_bytes();
+  return msgValue;
+}
+
+// TODO: This code is the same as the GPU-backend code. Consider refactoring.
+std::string getFormatSubstr(Value value, bool hex = false,
+                            std::optional<int> width = std::nullopt) {
+  Type type = value.getType();
+  if (isa<LLVM::LLVMPointerType>(type)) {
+    return "%p";
+  }
+  // Hex is "0x%0nx" or "0x%0nllx", where n is the number of hex digits in the
+  // type (so 4 for fp16, 8 for int32, 16 for int64).
+  if (hex) {
+    // Ignore `width` for `hex` values, pad to typeWidth.
+    std::string ret = "0x%0" + std::to_string(type.getIntOrFloatBitWidth() / 4);
+    if (type.getIntOrFloatBitWidth() > 32) {
+      ret += "ll";
+    }
+    ret += "x";
+    return ret;
+  }
+
+  std::string prefix = "%";
+  if (width.has_value()) {
+    prefix += std::to_string(*width);
+  } else if (hex) {
+    prefix += "0";
+    prefix += std::to_string(value.getType().getIntOrFloatBitWidth() / 4);
+  }
+
+  if (type.isBF16() || type.isF16() || type.isF32() || type.isF64()) {
+    return prefix + "f";
+  } else if (type.isSignedInteger()) {
+    if (type.getIntOrFloatBitWidth() == 64)
+      return prefix + "lli";
+    else
+      return prefix + "i";
+  } else if (type.isUnsignedInteger() || type.isSignlessInteger()) {
+    if (type.getIntOrFloatBitWidth() == 64)
+      return prefix + "llu";
+    else
+      return prefix + "u";
+  }
+  assert(false && "not supported type");
+  return "";
+}
+
+// TritonCPU's device_print prints all values in the same line unlike GPUs
+// and interpreter where each value is printed in a separate line.
+struct PrintOpConversion : public ConvertOpToLLVMPattern<triton::PrintOp> {
+  explicit PrintOpConversion(LLVMTypeConverter &typeConverter)
+      : mlir::ConvertOpToLLVMPattern<triton::PrintOp>(typeConverter) {}
+
+  LogicalResult
+  matchAndRewrite(triton::PrintOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op->getLoc();
+
+    auto getPid = [&](int axis) {
+      return getProgramId(op->getParentOfType<LLVM::LLVMFuncOp>(), axis);
+    };
+    SmallVector<Value> values = {getPid(0), getPid(1), getPid(2)};
+
+    std::string formatStr;
+    llvm::raw_string_ostream os(formatStr);
+    os << "(" << getFormatSubstr(values[0]) << ", "
+       << getFormatSubstr(values[1]) << ", " << getFormatSubstr(values[2])
+       << ")" << op.getPrefix();
+
+    for (size_t i = 0; i < op.getNumOperands(); i++) {
+      auto elems = unpackLLElements(loc, adaptor.getOperands()[i], rewriter);
+      if (dyn_cast<RankedTensorType>(op.getOperand(i).getType())) {
+        llvm_unreachable("Not implemented for tensor types");
+      }
+
+      // Only support scalars for now.
+      assert(elems.size() == 1);
+      if (i != 0) {
+        os << ", ";
+      }
+      os << getFormatSubstr(elems[0], op.getHex());
+      values.push_back(elems[0]);
+    }
+
+    llPrintf(formatStr, values, rewriter);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct DebugOpsToLLVM
+    : public triton::impl::DebugOpsToLLVMBase<DebugOpsToLLVM> {
+  using DebugOpsToLLVMBase::DebugOpsToLLVMBase;
+
+  DebugOpsToLLVM() : DebugOpsToLLVMBase() {}
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ModuleOp mod = getOperation();
+
+    mlir::LowerToLLVMOptions option(context);
+    TritonCPUToLLVMTypeConverter typeConverter(context, option);
+    TritonLLVMConversionTarget convTarget(*context);
+
+    RewritePatternSet patterns(context);
+    patterns.add<PrintOpConversion>(typeConverter);
+    // patterns.add<AssertOpConversion>(typeConverter);
+
+    if (failed(applyPartialConversion(mod, convTarget, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+} // anonymous namespace
+
+namespace mlir::triton::cpu {
+
+std::unique_ptr<OperationPass<ModuleOp>> createDebugOpsToLLVMPass() {
+  return std::make_unique<DebugOpsToLLVM>();
+}
+
+} // namespace mlir::triton::cpu

--- a/third_party/cpu/lib/TritonCPUToLLVM/GetProgramIdOpToLLVM.cpp
+++ b/third_party/cpu/lib/TritonCPUToLLVM/GetProgramIdOpToLLVM.cpp
@@ -1,4 +1,5 @@
 #include "TypeConverter.h"
+#include "Utility.h"
 
 #include "cpu/include/TritonCPUToLLVM/Passes.h"
 
@@ -43,39 +44,30 @@ public:
 };
 
 // TODO: use enums to access struct fields.
-struct GetProgramIdOpConversion : public OpConversionPattern<GetProgramIdOp> {
+struct GetProgramIdOpConversion
+    : public OpConversionPattern<triton::GetProgramIdOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(GetProgramIdOp op, OpAdaptor adaptor,
+  matchAndRewrite(triton::GetProgramIdOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto funcOp = op->getParentOfType<FunctionOpInterface>();
     assert(funcOp && "expected LLVM::FuncOp as a parent of GetProgramIdOp");
-    auto args = funcOp.getArguments();
-    // First three of last six args are x, y, z program ids.
-    auto argIdx = args.size() - 6 + op.getAxisAsInt();
-    assert(argIdx < args.size() && "out-of-bounds arg index");
-    assert(args[argIdx].getType().isInteger(32) && "unexpected arg type");
-    rewriter.replaceOp(op, args[argIdx]);
+    rewriter.replaceOp(op, getProgramId(funcOp, op.getAxisAsInt()));
     return success();
   }
 };
 
 struct GetNumProgramsOpConversion
-    : public OpConversionPattern<GetNumProgramsOp> {
+    : public OpConversionPattern<triton::GetNumProgramsOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(GetNumProgramsOp op, OpAdaptor adaptor,
+  matchAndRewrite(triton::GetNumProgramsOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto funcOp = op->getParentOfType<FunctionOpInterface>();
     assert(funcOp && "expected LLVM::FuncOp as a parent of GetNumProgramsOp");
-    auto args = funcOp.getArguments();
-    // Last three of args are gridX, gridY, gridZ (bounds) of grid.
-    auto argIdx = args.size() - 3 + op.getAxisAsInt();
-    assert(argIdx < args.size() && "out-of-bounds arg index");
-    assert(args[argIdx].getType().isInteger(32) && "unexpected arg type");
-    rewriter.replaceOp(op, args[argIdx]);
+    rewriter.replaceOp(op, getNumPrograms(funcOp, op.getAxisAsInt()));
     return success();
   }
 };

--- a/third_party/cpu/lib/TritonCPUToLLVM/Pipeline.cpp
+++ b/third_party/cpu/lib/TritonCPUToLLVM/Pipeline.cpp
@@ -12,7 +12,7 @@ void tritonCPUToLLVMPipelineBuilder(OpPassManager &pm) {
   pm.addPass(mlir::triton::cpu::createGetProgramIdOpToLLVMPass());
   pm.addPass(mlir::triton::cpu::createMemoryOpToLLVMPass());
   pm.addPass(mlir::triton::cpu::createAtomicOpsToLLVMPass());
-  // pm.addPass(mlir::createReconcileUnrealizedCastsPass());
+  pm.addPass(mlir::triton::cpu::createDebugOpsToLLVMPass());
 }
 
 void registerTritonCPUToLLVMPipeline() {

--- a/third_party/cpu/lib/TritonCPUToLLVM/Utility.cpp
+++ b/third_party/cpu/lib/TritonCPUToLLVM/Utility.cpp
@@ -1,0 +1,32 @@
+#include "Utility.h"
+
+using namespace mlir;
+using namespace mlir::triton;
+
+namespace mlir::triton::cpu {
+
+Value getProgramId(mlir::FunctionOpInterface funcOp, int axis) {
+  auto args = funcOp.getArguments();
+  assert(funcOp && args.size() >= 6);
+  assert(axis >= 0 && axis < 3);
+
+  // The first three of the last six args are x, y, z program ids.
+  auto argIdx = args.size() - 6 + axis;
+  assert(argIdx < args.size() && "out-of-bounds arg index");
+  assert(args[argIdx].getType().isInteger(32) && "unexpected arg type");
+  return args[argIdx];
+}
+
+Value getNumPrograms(mlir::FunctionOpInterface funcOp, int axis) {
+  auto args = funcOp.getArguments();
+  assert(funcOp && args.size() >= 6);
+  assert(axis >= 0 && axis < 3);
+
+  // The last three of the args are gridX, gridY, gridZ (bounds) of grid.
+  auto argIdx = args.size() - 3 + axis;
+  assert(argIdx < args.size() && "out-of-bounds arg index");
+  assert(args[argIdx].getType().isInteger(32) && "unexpected arg type");
+  return args[argIdx];
+}
+
+} // namespace mlir::triton::cpu

--- a/third_party/cpu/lib/TritonCPUToLLVM/Utility.h
+++ b/third_party/cpu/lib/TritonCPUToLLVM/Utility.h
@@ -1,0 +1,14 @@
+#ifndef TRITON_CONVERSION_TRITONCPU_TO_LLVM_UTILITY_H
+#define TRITON_CONVERSION_TRITONCPU_TO_LLVM_UTILITY_H
+
+#include "mlir/Analysis/DataFlowFramework.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+
+namespace mlir::triton::cpu {
+
+Value getProgramId(mlir::FunctionOpInterface funcOp, int axis);
+Value getNumPrograms(mlir::FunctionOpInterface funcOp, int axis);
+
+} // namespace mlir::triton::cpu
+
+#endif

--- a/third_party/cpu/triton_cpu.cc
+++ b/third_party/cpu/triton_cpu.cc
@@ -26,9 +26,6 @@ namespace py = pybind11;
 
 void init_triton_cpu_passes_ttcpuir(py::module &&m) {
   using namespace mlir::triton;
-  // m.def("add_to_llvmir", [](mlir::PassManager &pm) {
-  //   pm.addPass(mlir::triton::createConvertTritonCPUToLLVMPass());
-  // });
   m.def("add_triton_to_triton_cpu_pipeline", [](mlir::PassManager &pm) {
     mlir::triton::cpu::tritonToTritonCPUPipelineBuilder(pm);
   });
@@ -96,7 +93,9 @@ void init_triton_cpu(py::module &&m) {
   m.def("find_kernel_names", [](mlir::ModuleOp &mod) {
     std::vector<std::string> res;
     mod.walk([&](mlir::FunctionOpInterface funcOp) {
-      if (funcOp.getVisibility() == mlir::SymbolTable::Visibility::Public)
+      // Kernel functions are public and have a body.
+      if (!funcOp.getFunctionBody().empty() &&
+          funcOp.getVisibility() == mlir::SymbolTable::Visibility::Public)
         res.push_back(funcOp.getName().str());
     });
     return res;


### PR DESCRIPTION
As title, I'm adding device_print support. But for some reasons, printing tensors needed more work. So I'm firstly publishing the support for scalars. A minor refactoring is included.

---

`device_print` has an interesting behavior for GPU. Each thread prints its own scalar elements for a tensor. For CPUs including the interpreter, we can literally print tensors as is.

A quick testing:
```
def add_kernel(...)
    pid = tl.program_id(axis=0)  # We use a 1D launch grid so axis is 0.
    block_start = pid * BLOCK_SIZE
    offsets = block_start + tl.arange(0, BLOCK_SIZE)
    mask = offsets < n_elements
    x = tl.load(x_ptr + offsets, mask=mask)
    y = tl.load(y_ptr + offsets, mask=mask)
    output = x + y
    tl.device_print("test", n_elements, BLOCK_SIZE, pid)
    tl.store(output_ptr + offsets, output, mask=mask)
```
Similarly to GPUs, each `device_print` has a prefix of pids. And unlike the interpreter, I'm printing all the scalar variables in the same line.

```
> % python3 python/tutorials/01-vector-add.py
(3, 0, 0) test: 98432, 4096, 3
(4, 0, 0) test: 98432, 4096, 4
(15, 0, 0) test: 98432, 4096, 15
(13, 0, 0) test: 98432, 4096, 13
(7, 0, 0) test: 98432, 4096, 7
(10, 0, 0) test: 98432, 4096, 10
(24, 0, 0) test: 98432, 4096, 24
(6, 0, 0) test: 98432, 4096, 6
(9, 0, 0) test: 98432, 4096, 9
(5, 0, 0) test: 98432, 4096, 5
(16, 0, 0) test: 98432, 4096, 16
(18, 0, 0) test: 98432, 4096, 18
(12, 0, 0) test: 98432, 4096, 12
(8, 0, 0) test: 98432, 4096, 8
(20, 0, 0) test: 98432, 4096, 20
(11, 0, 0) test: 98432, 4096, 11
(17, 0, 0) test: 98432, 4096, 17
(22, 0, 0) test: 98432, 4096, 22
(0, 0, 0) test: 98432, 4096, 0
(2, 0, 0) test: 98432, 4096, 2
(23, 0, 0) test: 98432, 4096, 23
(1, 0, 0) test: 98432, 4096, 1
(19, 0, 0) test: 98432, 4096, 19
(21, 0, 0) test: 98432, 4096, 21
(14, 0, 0) test: 98432, 4096, 14
tensor([0.5151, 1.6826, 0.9153,  ..., 0.9852, 1.2714, 1.8192])
tensor([0.5151, 1.6826, 0.9153,  ..., 0.9852, 1.2714, 1.8192])
The maximum difference between torch-cpu and triton-cpu is 0.0
```

The interpreter currently prints each value as a separate line:
```
> % TRITON_INTERPRET=1 python3 python/tutorials/01-vector-add.py
(0, 0, 0)  test:  [98432]
(0, 0, 0)  test:  [4096]
(0, 0, 0)  test:  [0]
(1, 0, 0)  test:  [98432]
(1, 0, 0)  test:  [4096]
(1, 0, 0)  test:  [1]
(2, 0, 0)  test:  [98432]
(2, 0, 0)  test:  [4096]
(2, 0, 0)  test:  [2]
(3, 0, 0)  test:  [98432]
(3, 0, 0)  test:  [4096]
(3, 0, 0)  test:  [3]
(4, 0, 0)  test:  [98432]
(4, 0, 0)  test:  [4096]
(4, 0, 0)  test:  [4]
(5, 0, 0)  test:  [98432]
(5, 0, 0)  test:  [4096]
(5, 0, 0)  test:  [5]
```