### PR TITLE
Utilize vector math functions from libmvec.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -82,4 +82,6 @@ jobs:
           python -m pytest -s -n 32 --device cpu \
             python/test/unit/language/test_annotations.py \
             python/test/unit/language/test_block_pointer.py \
-            python/test/unit/language/test_conversions.py
+            python/test/unit/language/test_conversions.py \
+            python/test/unit/cpu/test_libdevice.py \
+            python/test/unit/cpu/test_libmvec.py

--- a/python/setup.py
+++ b/python/setup.py
@@ -555,6 +555,7 @@ def get_packages():
         "triton/compiler",
         "triton/language",
         "triton/language/extra",
+        "triton/language/extra/cpu",
         "triton/language/extra/cuda",
         "triton/language/extra/hip",
         "triton/runtime",

--- a/python/test/unit/cpu/test_libmvec.py
+++ b/python/test/unit/cpu/test_libmvec.py
@@ -1,0 +1,98 @@
+import os
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+from triton.language.extra import libdevice
+
+
+def is_interpreter():
+    return os.environ.get('TRITON_INTERPRET', '0') == '1'
+
+
+def is_cpu():
+    return not is_interpreter() and \
+        triton.runtime.driver.active.get_current_target().backend == "cpu"
+
+
+def is_x86():
+    return is_cpu() and \
+        triton.runtime.driver.active.get_current_target().arch == "x86_64"
+
+
+float_dtypes = ['bfloat16', 'float16', 'float32', 'float64']
+
+
+@pytest.mark.parametrize("dtype_str", float_dtypes)
+@pytest.mark.parametrize("math_fn", ["cos", "exp", "exp2", "log", "log2", "sin"])
+@pytest.mark.parametrize("size", [1, 2, 4, 8, 16, 32, 64, 128])
+def test_tensor_math_fn(dtype_str, math_fn, size, device):
+    if not is_x86():
+        pytest.skip("Vectorized libm calls are supported for x86 target only.")
+
+    @triton.jit
+    def kernel(src, dst, MATH_FN: tl.constexpr, BLOCK_SIZE: tl.constexpr):
+        idxs = tl.arange(0, BLOCK_SIZE)
+        x = tl.load(src + idxs)
+        y = getattr(x, MATH_FN)()
+        tl.store(dst + idxs, y)
+
+    src = torch.rand((size, ), dtype=getattr(torch, dtype_str), device=device)
+    res = torch.empty(src.shape, dtype=getattr(torch, dtype_str), device=device)
+    meta = kernel[(1, )](src, res, MATH_FN=math_fn, BLOCK_SIZE=size)
+    ref = getattr(src, math_fn)()
+    torch.testing.assert_close(ref, res)
+
+    # Check generated code calls vector math function
+    # FP16 and BF16 are casted to FP32 for math ops
+    elem_size = 8 if dtype_str == "float64" else 4
+    data_size = size * elem_size
+    num_vec_calls = 0
+    if data_size >= 16:
+        num_vec_calls = 1
+    if data_size > 64:
+        num_vec_calls = data_size / 64
+    asm_str = meta.asm["asm"].decode("utf-8")
+    assert asm_str.count("_ZGV") == num_vec_calls
+
+
+@pytest.mark.parametrize("dtype_str", float_dtypes)
+@pytest.mark.parametrize("math_fn", [
+    "acos", "acosh", "asin", "asinh", "atan", "atanh", "cbrt", "cos", "cosh", "erf", "exp", "exp2", "log", "log2",
+    "log10", "sin", "sinh", "tan", "tanh"
+])
+@pytest.mark.parametrize("size", [1, 2, 4, 8, 16, 32, 64, 128])
+def test_libdevice_math_fn(dtype_str, math_fn, size, device):
+    if not is_x86():
+        pytest.skip("Vectorized libm calls are supported for x86 target only.")
+
+    @triton.jit
+    def kernel(src, dst, MATH_FN: tl.constexpr, BLOCK_SIZE: tl.constexpr):
+        idxs = tl.arange(0, BLOCK_SIZE)
+        x = tl.load(src + idxs)
+        y = getattr(libdevice, MATH_FN)(x)
+        tl.store(dst + idxs, y)
+
+    src = torch.rand((size, ), dtype=getattr(torch, dtype_str), device=device)
+    if math_fn == "acosh":
+        src = src.abs() + 1
+    res = torch.empty(src.shape, dtype=getattr(torch, dtype_str), device=device)
+    meta = kernel[(1, )](src, res, MATH_FN=math_fn, BLOCK_SIZE=size)
+    if math_fn == "cbrt":
+        ref = src.pow(1 / 3)
+    else:
+        ref = getattr(src, math_fn)()
+    torch.testing.assert_close(ref, res)
+
+    # Check generated code calls vector math function
+    # FP16 and BF16 are casted to FP32 for math ops
+    elem_size = 8 if dtype_str == "float64" else 4
+    data_size = size * elem_size
+    num_vec_calls = 0
+    if data_size >= 16:
+        num_vec_calls = 1
+    if data_size > 64:
+        num_vec_calls = data_size / 64
+    asm_str = meta.asm["asm"].decode("utf-8")
+    assert asm_str.count("_ZGV") == num_vec_calls

--- a/python/test/unit/cpu/test_libmvec.py
+++ b/python/test/unit/cpu/test_libmvec.py
@@ -53,8 +53,7 @@ def test_tensor_math_fn(dtype_str, math_fn, size, device):
         num_vec_calls = 1
     if data_size > 64:
         num_vec_calls = data_size / 64
-    asm_str = meta.asm["asm"].decode("utf-8")
-    assert asm_str.count("_ZGV") == num_vec_calls
+    assert meta.asm["asm"].count("_ZGV") == num_vec_calls
 
 
 @pytest.mark.parametrize("dtype_str", float_dtypes)
@@ -94,5 +93,4 @@ def test_libdevice_math_fn(dtype_str, math_fn, size, device):
         num_vec_calls = 1
     if data_size > 64:
         num_vec_calls = data_size / 64
-    asm_str = meta.asm["asm"].decode("utf-8")
-    assert asm_str.count("_ZGV") == num_vec_calls
+    assert meta.asm["asm"].count("_ZGV") == num_vec_calls

--- a/python/triton/language/extra/__init__.py
+++ b/python/triton/language/extra/__init__.py
@@ -1,4 +1,5 @@
 from . import cuda
 from . import hip
+from . import cpu
 
-__all__ = ['cuda', 'hip']
+__all__ = ['cuda', 'hip', 'cpu']

--- a/python/triton/language/extra/cpu/libdevice.py
+++ b/python/triton/language/extra/cpu/libdevice.py
@@ -1,96 +1,96 @@
-from triton.language import core, tensor
+from triton.language import core
 
 
 @core.extern
 def acos(arg0, _builder=None):
-    return tensor(_builder.create_acos(arg0.handle), arg0.type)
+    return core.tensor(_builder.create_acos(arg0.handle), arg0.type)
 
 
 @core.extern
 def acosh(arg0, _builder=None):
-    return tensor(_builder.create_acosh(arg0.handle), arg0.type)
+    return core.tensor(_builder.create_acosh(arg0.handle), arg0.type)
 
 
 @core.extern
 def asin(arg0, _builder=None):
-    return tensor(_builder.create_asin(arg0.handle), arg0.type)
+    return core.tensor(_builder.create_asin(arg0.handle), arg0.type)
 
 
 @core.extern
 def asinh(arg0, _builder=None):
-    return tensor(_builder.create_asinh(arg0.handle), arg0.type)
+    return core.tensor(_builder.create_asinh(arg0.handle), arg0.type)
 
 
 @core.extern
 def atan(arg0, _builder=None):
-    return tensor(_builder.create_atan(arg0.handle), arg0.type)
+    return core.tensor(_builder.create_atan(arg0.handle), arg0.type)
 
 
 @core.extern
 def atanh(arg0, _builder=None):
-    return tensor(_builder.create_atanh(arg0.handle), arg0.type)
+    return core.tensor(_builder.create_atanh(arg0.handle), arg0.type)
 
 
 @core.extern
 def cbrt(arg0, _builder=None):
-    return tensor(_builder.create_cbrt(arg0.handle), arg0.type)
+    return core.tensor(_builder.create_cbrt(arg0.handle), arg0.type)
 
 
 @core.extern
 def cos(arg0, _builder=None):
-    return tensor(_builder.create_cos(arg0.handle), arg0.type)
+    return core.tensor(_builder.create_cos(arg0.handle), arg0.type)
 
 
 @core.extern
 def cosh(arg0, _builder=None):
-    return tensor(_builder.create_cosh(arg0.handle), arg0.type)
+    return core.tensor(_builder.create_cosh(arg0.handle), arg0.type)
 
 
 @core.extern
 def erf(arg0, _builder=None):
-    return tensor(_builder.create_erf(arg0.handle), arg0.type)
+    return core.tensor(_builder.create_erf(arg0.handle), arg0.type)
 
 
 @core.extern
 def exp(arg0, _builder=None):
-    return tensor(_builder.create_exp(arg0.handle), arg0.type)
+    return core.tensor(_builder.create_exp(arg0.handle), arg0.type)
 
 
 @core.extern
 def exp2(arg0, _builder=None):
-    return tensor(_builder.create_exp2(arg0.handle), arg0.type)
+    return core.tensor(_builder.create_exp2(arg0.handle), arg0.type)
 
 
 @core.extern
 def log(arg0, _builder=None):
-    return tensor(_builder.create_log(arg0.handle), arg0.type)
+    return core.tensor(_builder.create_log(arg0.handle), arg0.type)
 
 
 @core.extern
 def log2(arg0, _builder=None):
-    return tensor(_builder.create_log2(arg0.handle), arg0.type)
+    return core.tensor(_builder.create_log2(arg0.handle), arg0.type)
 
 
 @core.extern
 def log10(arg0, _builder=None):
-    return tensor(_builder.create_log10(arg0.handle), arg0.type)
+    return core.tensor(_builder.create_log10(arg0.handle), arg0.type)
 
 
 @core.extern
 def sin(arg0, _builder=None):
-    return tensor(_builder.create_sin(arg0.handle), arg0.type)
+    return core.tensor(_builder.create_sin(arg0.handle), arg0.type)
 
 
 @core.extern
 def sinh(arg0, _builder=None):
-    return tensor(_builder.create_sinh(arg0.handle), arg0.type)
+    return core.tensor(_builder.create_sinh(arg0.handle), arg0.type)
 
 
 @core.extern
 def tan(arg0, _builder=None):
-    return tensor(_builder.create_tan(arg0.handle), arg0.type)
+    return core.tensor(_builder.create_tan(arg0.handle), arg0.type)
 
 
 @core.extern
 def tanh(arg0, _builder=None):
-    return tensor(_builder.create_tanh(arg0.handle), arg0.type)
+    return core.tensor(_builder.create_tanh(arg0.handle), arg0.type)

--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -106,7 +106,10 @@ class CPUBackend(BaseBackend):
         promote_bf16_to_fp32 = self.cpu_arch == "x86_64" and "avx512bf16" not in self.cpu_features
         # We don't have any lowering for mixed precision matmuls, so always use casts for now
         convert_mixed_precision_matmul = True
-        cpu.passes.ttcpuir.add_convert_unsupported_ops(pm, promote_bf16_to_fp32, convert_mixed_precision_matmul)
+        # We don't have math lib functions for FP8, FP16, BF16. Promote such operations to FP32.
+        promote_lib_math_to_fp32 = True
+        cpu.passes.ttcpuir.add_convert_unsupported_ops(pm, promote_bf16_to_fp32, convert_mixed_precision_matmul,
+                                                       promote_lib_math_to_fp32)
         decompose_bf16_conv = self.cpu_arch == "x86_64" and "avx512bf16" not in self.cpu_features
         decompose_fp8_conv = True
         cpu.passes.ttcpuir.add_decompose_fp_conversions(pm, decompose_bf16_conv, decompose_fp8_conv)

--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -116,8 +116,7 @@ class CPUBackend(BaseBackend):
         pm.run(mod)
         return mod
 
-    @staticmethod
-    def make_llir(src, metadata, options):
+    def make_llir(self, src, metadata, options):
         # warp-specialization mutates num_warps
         num_warp_groups = src.get_int_attr("triton_gpu.num-warp-groups-per-cta")
         if num_warp_groups is not None:
@@ -133,6 +132,8 @@ class CPUBackend(BaseBackend):
         passes.convert.add_scf_to_cf(pm)
         passes.convert.add_index_to_llvmir(pm)
         cpu.passes.ttcpuir.add_triton_cpu_to_llvmir_pipeline(pm)
+        if self.cpu_arch == "x86_64" and "avx512f" in self.cpu_features:
+            cpu.passes.ttcpuir.add_math_to_libmvec(pm)
         passes.convert.add_math_to_llvmir(pm)
         cpu.passes.ttcpuir.add_math_to_libm(pm)
         cpu.passes.ttcpuir.add_vector_to_llvmir(pm, options.enable_fast_math)

--- a/third_party/cpu/backend/driver.py
+++ b/third_party/cpu/backend/driver.py
@@ -10,6 +10,8 @@ from triton.runtime.cache import get_cache_manager
 from triton.backends.driver import DriverBase
 from triton.backends.compiler import GPUTarget
 
+from triton._C.libtriton import llvm
+
 _dirname = os.getenv("TRITON_SYS_PATH", default="/usr/local")
 # for locating libTritonCPURuntime
 _triton_C_dir = importlib.resources.files(triton).joinpath("_C")
@@ -359,7 +361,8 @@ class CPUDriver(DriverBase):
     def get_current_target(self):
         # Capability and warp size are zeros for CPU.
         # TODO: GPUTarget naming isn't obviously good.
-        return GPUTarget("cpu", 0, 0)
+        cpu_arch = llvm.get_cpu_tripple().split("-")[0]
+        return GPUTarget("cpu", cpu_arch, 0)
 
     @staticmethod
     def is_active():

--- a/third_party/cpu/include/TritonCPUToLLVM/Passes.h
+++ b/third_party/cpu/include/TritonCPUToLLVM/Passes.h
@@ -26,6 +26,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createGetProgramIdOpToLLVMPass();
 std::unique_ptr<OperationPass<triton::FuncOp>> createLowerMultiReductionPass();
 std::unique_ptr<OperationPass<ModuleOp>> createAtomicOpsToLLVMPass();
 std::unique_ptr<OperationPass<ModuleOp>> createDebugOpsToLLVMPass();
+std::unique_ptr<OperationPass<ModuleOp>> createMathToLibmvecPass();
 
 void tritonCPUToLLVMPipelineBuilder(OpPassManager &pm);
 void registerTritonCPUToLLVMPipeline();

--- a/third_party/cpu/include/TritonCPUToLLVM/Passes.td
+++ b/third_party/cpu/include/TritonCPUToLLVM/Passes.td
@@ -66,4 +66,17 @@ def DebugOpsToLLVM : Pass<"triton-cpu-debug-ops-to-llvm", "mlir::ModuleOp"> {
                              "mlir::triton::TritonDialect"];
 }
 
+def MathToLibmvec : Pass<"triton-cpu-math-to-libmvec", "mlir::ModuleOp"> {
+    let summary = "Convert vector math operations to vector libm calls.";
+    let description = [{
+    }];
+    let constructor = "mlir::triton::cpu::createMathToLibmvecPass()";
+
+    let dependentDialects = ["mlir::vector::VectorDialect",
+                             "mlir::triton::cpu::TritonCPUDialect",
+                             "mlir::triton::TritonDialect",
+                             "mlir::func::FuncDialect",
+                             "mlir::LLVM::LLVMDialect"];
+}
+
 #endif

--- a/third_party/cpu/include/TritonCPUTransforms/Passes.h
+++ b/third_party/cpu/include/TritonCPUTransforms/Passes.h
@@ -21,7 +21,8 @@ namespace cpu {
 std::unique_ptr<OperationPass<ModuleOp>> createConvertUnsupportedOps();
 std::unique_ptr<OperationPass<ModuleOp>>
 createConvertUnsupportedOps(bool promoteBf16ToFp32,
-                            bool convertMixedPrecisionMatmul);
+                            bool convertMixedPrecisionMatmul,
+                            bool promoteLibMathToFp32);
 std::unique_ptr<OperationPass<ModuleOp>> createDecomposeFpConversions();
 std::unique_ptr<OperationPass<ModuleOp>>
 createDecomposeFpConversions(bool decomposeBf16Conversions,

--- a/third_party/cpu/include/TritonCPUTransforms/Passes.td
+++ b/third_party/cpu/include/TritonCPUTransforms/Passes.td
@@ -18,6 +18,9 @@ def ConvertUnsupportedOps : Pass<"triton-cpu-add-casts-for-unsupported-ops", "ml
         Option<"convertMixedPrecisionMatmul", "convert-mixed-precision-matmul",
                "bool", /*default*/"false",
                "Convert inputs of a mixed-precision matmul to a destination type.">,
+        Option<"promoteLibMathToFp32", "promote-lib-math-to-fp32",
+               "bool", /*default*/"true",
+               "Promote FP8, FP16, BF16 math operations mapped to libm function to FP32.">,
     ];
 
     let constructor = "mlir::triton::cpu::createConvertUnsupportedOps()";

--- a/third_party/cpu/lib/TritonCPUToLLVM/CMakeLists.txt
+++ b/third_party/cpu/lib/TritonCPUToLLVM/CMakeLists.txt
@@ -4,6 +4,7 @@ add_triton_library(TritonCPUToLLVM
     FuncOpToLLVM.cpp
     GetProgramIdOpToLLVM.cpp
     LowerMultiReduction.cpp
+    MathToLibmvec.cpp
     MemoryOpToLLVM.cpp
     Pipeline.cpp
     TypeConverter.cpp

--- a/third_party/cpu/lib/TritonCPUToLLVM/MathToLibmvec.cpp
+++ b/third_party/cpu/lib/TritonCPUToLLVM/MathToLibmvec.cpp
@@ -1,0 +1,258 @@
+#include "TypeConverter.h"
+
+#include "cpu/include/TritonCPUToLLVM/Passes.h"
+
+#include "mlir/Dialect/Utils/IndexingUtils.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonCPU/IR/Dialect.h"
+
+namespace mlir {
+namespace triton {
+namespace cpu {
+#define GEN_PASS_DEF_MATHTOLIBMVEC
+#include "cpu/include/TritonCPUToLLVM/Passes.h.inc"
+} // namespace cpu
+} // namespace triton
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::triton;
+using namespace mlir::triton::cpu;
+
+namespace {
+
+template <typename OpT> struct VecOpToFp32 : public OpRewritePattern<OpT> {
+public:
+  using OpRewritePattern<OpT>::OpRewritePattern;
+
+  VecOpToFp32(MLIRContext *context) : OpRewritePattern<OpT>(context) {}
+
+  LogicalResult matchAndRewrite(OpT op, PatternRewriter &rewriter) const {
+    Location loc = op.getLoc();
+    VectorType vecTy = dyn_cast<VectorType>(op.getType());
+    if (!vecTy)
+      return failure();
+
+    Type elemTy = vecTy.getElementType();
+    if (!elemTy.isBF16() && !elemTy.isF16())
+      return failure();
+
+    Type fp32VecTy = vecTy.cloneWith(std::nullopt, rewriter.getF32Type());
+    SmallVector<Value> fp32Ops;
+    for (auto operand : op->getOperands())
+      fp32Ops.push_back(
+          rewriter.create<arith::ExtFOp>(loc, fp32VecTy, operand));
+    auto newOp = rewriter.create<OpT>(loc, fp32VecTy, fp32Ops);
+    rewriter.replaceOpWithNewOp<arith::TruncFOp>(op, vecTy, newOp);
+    return success();
+  }
+};
+
+// Decompose vector operation to singe-dimensional vector operations
+// with a native AVX512 vector size.
+template <typename OpT>
+struct DecomposeToNativeVecs : public OpRewritePattern<OpT> {
+public:
+  using OpRewritePattern<OpT>::OpRewritePattern;
+
+  DecomposeToNativeVecs(MLIRContext *context)
+      : OpRewritePattern<OpT>(context) {}
+
+  LogicalResult matchAndRewrite(OpT op, PatternRewriter &rewriter) const {
+    Location loc = op.getLoc();
+    VectorType vecTy = dyn_cast<VectorType>(op.getType());
+    if (!vecTy)
+      return failure();
+
+    Type elemTy = vecTy.getElementType();
+    if (!elemTy.isF32() && !elemTy.isF64())
+      return failure();
+
+    int64_t numElems = vecTy.getNumElements();
+    if (numElems * elemTy.getIntOrFloatBitWidth() < 128)
+      return failure();
+
+    // Produce a new shape where trailing dimensions wouldn't exceed the native
+    // vector size.
+    auto shape = vecTy.getShape();
+    SmallVector<int64_t> newShape(1, 1);
+    int64_t elemsPerVec = 512 / elemTy.getIntOrFloatBitWidth();
+    for (int64_t i = shape.size() - 1; i >= 0; --i) {
+      int64_t size = shape[i];
+      if (newShape.size() > 1) {
+        newShape.insert(newShape.begin(), size);
+      } else {
+        int64_t combined = newShape[0] * size;
+        if (combined > elemsPerVec) {
+          newShape[0] = elemsPerVec;
+          newShape.insert(newShape.begin(), combined / elemsPerVec);
+        } else {
+          newShape[0] = combined;
+        }
+      }
+    }
+    if (newShape == shape)
+      return failure();
+
+    // Convert input operand to the new shape.
+    SmallVector<Value> reshapedInputs;
+    for (auto operand : op->getOperands()) {
+      auto operandTy = cast<VectorType>(operand.getType());
+      auto newOperandTy = VectorType::get(newShape, operandTy.getElementType());
+      reshapedInputs.push_back(
+          rewriter.create<vector::ShapeCastOp>(loc, newOperandTy, operand));
+    }
+
+    // Decompose the original operation to a set of operations on native
+    // vectors.
+    auto newOpTy = VectorType::get(newShape, elemTy);
+    auto subResTy = VectorType::get(newShape.back(), elemTy);
+    Value newRes = rewriter.create<arith::ConstantOp>(
+        loc, SplatElementsAttr::get(newOpTy, rewriter.getFloatAttr(elemTy, 0)));
+    auto strides = computeStrides(newShape);
+    // Remove the last stride to produce sub-vector indices.
+    strides.pop_back();
+    for (int64_t idx = 0; idx < numElems; idx += newShape.back()) {
+      auto indices = delinearize(idx, strides);
+      SmallVector<Value> subInputs(reshapedInputs.size());
+      std::transform(reshapedInputs.begin(), reshapedInputs.end(),
+                     subInputs.begin(), [&](auto val) {
+                       return rewriter.create<vector::ExtractOp>(loc, val,
+                                                                 indices);
+                     });
+      Value subRes = rewriter.create<OpT>(loc, subResTy, subInputs);
+      newRes = rewriter.create<vector::InsertOp>(loc, subRes, newRes, indices);
+    }
+
+    // Reshape the result back to the original type.
+    rewriter.replaceOpWithNewOp<vector::ShapeCastOp>(op, vecTy, newRes);
+    return success();
+  }
+};
+
+template <typename OpT>
+struct VecOpToLibmvecCall : public OpRewritePattern<OpT> {
+public:
+  using OpRewritePattern<OpT>::OpRewritePattern;
+
+  VecOpToLibmvecCall(MLIRContext *context, StringRef fp32FnBaseName,
+                     StringRef fp64FnBaseName)
+      : OpRewritePattern<OpT>(context) {
+    this->fp32FnBaseName = fp32FnBaseName;
+    this->fp64FnBaseName = fp64FnBaseName;
+  }
+
+  LogicalResult matchAndRewrite(OpT op, PatternRewriter &rewriter) const {
+    VectorType vecTy = dyn_cast<VectorType>(op.getType());
+    if (!vecTy || vecTy.getRank() > 1)
+      return failure();
+
+    Type elemTy = vecTy.getElementType();
+    if (!elemTy.isF32() && !elemTy.isF64())
+      return failure();
+
+    auto baseName = elemTy.isF32() ? fp32FnBaseName : fp64FnBaseName;
+    int64_t vecSize = vecTy.getNumElements() * vecTy.getElementTypeBitWidth();
+    std::string isaPrefix;
+    if (vecSize == 128) {
+      isaPrefix = "b";
+    } else if (vecSize == 256) {
+      isaPrefix = "d";
+    } else if (vecSize == 512) {
+      isaPrefix = "e";
+    } else {
+      return failure();
+    }
+    std::string fnName =
+        "_ZGV" + isaPrefix + "N" + std::to_string(vecTy.getNumElements());
+    for (auto operand : op->getOperands())
+      fnName += "v";
+    fnName += "_" + baseName;
+
+    auto module = SymbolTable::getNearestSymbolTable(op);
+    auto opFunc = dyn_cast_or_null<SymbolOpInterface>(
+        SymbolTable::lookupSymbolIn(module, fnName));
+    // Generate function declaration if it doesn't exists yet.
+    if (!opFunc) {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(&module->getRegion(0).front());
+      auto fnTy = FunctionType::get(
+          rewriter.getContext(), op->getOperandTypes(), op->getResultTypes());
+      opFunc =
+          rewriter.create<func::FuncOp>(rewriter.getUnknownLoc(), fnName, fnTy);
+      opFunc.setPrivate();
+      opFunc->setAttr(LLVM::LLVMDialect::getReadnoneAttrName(),
+                      UnitAttr::get(rewriter.getContext()));
+    }
+
+    rewriter.replaceOpWithNewOp<func::CallOp>(op, fnName, op.getType(),
+                                              op->getOperands());
+    return success();
+  }
+
+private:
+  std::string fp32FnBaseName;
+  std::string fp64FnBaseName;
+};
+
+template <typename OpTy>
+void populatePatternsForOp(RewritePatternSet &patterns, StringRef fp32FnName,
+                           StringRef fp64FnName) {
+  patterns.add<VecOpToFp32<OpTy>>(patterns.getContext());
+  patterns.add<DecomposeToNativeVecs<OpTy>>(patterns.getContext());
+  patterns.add<VecOpToLibmvecCall<OpTy>>(patterns.getContext(), fp32FnName,
+                                         fp64FnName);
+}
+
+struct MathToLibmvecPass
+    : public mlir::triton::cpu::impl::MathToLibmvecBase<MathToLibmvecPass> {
+  using MathToLibmvecBase::MathToLibmvecBase;
+
+  void runOnOperation() override {
+    Operation *op = getOperation();
+    MLIRContext *context = op->getContext();
+
+    RewritePatternSet patterns(context);
+    populatePatternsForOp<math::AcosOp>(patterns, "acosf", "acos");
+    populatePatternsForOp<math::AcoshOp>(patterns, "acoshf", "acosh");
+    populatePatternsForOp<math::AsinOp>(patterns, "asinf", "asin");
+    populatePatternsForOp<math::AsinhOp>(patterns, "asinhf", "asinh");
+    populatePatternsForOp<math::AtanOp>(patterns, "atanf", "atan");
+    populatePatternsForOp<math::AtanhOp>(patterns, "atanhf", "atanh");
+    populatePatternsForOp<math::CbrtOp>(patterns, "cbrtf", "cbrt");
+    populatePatternsForOp<math::CosOp>(patterns, "cosf", "cos");
+    populatePatternsForOp<math::CoshOp>(patterns, "coshf", "cosh");
+    populatePatternsForOp<math::ErfOp>(patterns, "erff", "erf");
+    populatePatternsForOp<math::ExpOp>(patterns, "expf", "exp");
+    populatePatternsForOp<math::Exp2Op>(patterns, "exp2f", "exp2");
+    populatePatternsForOp<math::LogOp>(patterns, "logf", "log");
+    populatePatternsForOp<math::Log2Op>(patterns, "log2f", "log2");
+    populatePatternsForOp<math::Log10Op>(patterns, "log10f", "log10");
+    populatePatternsForOp<math::Log1pOp>(patterns, "log1pf", "log1p");
+    populatePatternsForOp<math::SinOp>(patterns, "sinf", "sin");
+    populatePatternsForOp<math::SinhOp>(patterns, "sinhf", "sinh");
+    populatePatternsForOp<math::TanOp>(patterns, "tanf", "tan");
+    populatePatternsForOp<math::TanhOp>(patterns, "tanhf", "tanh");
+
+    if (failed(applyPatternsAndFoldGreedily(op, std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
+} // anonymous namespace
+
+namespace mlir {
+namespace triton {
+namespace cpu {
+
+std::unique_ptr<OperationPass<ModuleOp>> createMathToLibmvecPass() {
+  return std::make_unique<MathToLibmvecPass>();
+}
+
+} // namespace cpu
+} // namespace triton
+} // namespace mlir

--- a/third_party/cpu/triton_cpu.cc
+++ b/third_party/cpu/triton_cpu.cc
@@ -32,9 +32,10 @@ void init_triton_cpu_passes_ttcpuir(py::module &&m) {
   });
   m.def("add_convert_unsupported_ops",
         [](mlir::PassManager &pm, bool promote_bf16_to_fp32,
-           bool convert_mixed_precision_matmul) {
+           bool convert_mixed_precision_matmul, bool promote_lib_math_to_fp32) {
           pm.addPass(mlir::triton::cpu::createConvertUnsupportedOps(
-              promote_bf16_to_fp32, convert_mixed_precision_matmul));
+              promote_bf16_to_fp32, convert_mixed_precision_matmul,
+              promote_lib_math_to_fp32));
         });
   m.def("add_decompose_fp_conversions",
         [](mlir::PassManager &pm, bool decomposeBf16Conversions,

--- a/third_party/cpu/triton_cpu.cc
+++ b/third_party/cpu/triton_cpu.cc
@@ -71,6 +71,9 @@ void init_triton_cpu_passes_ttcpuir(py::module &&m) {
   m.def("add_memref_to_llvmir", [](mlir::PassManager &pm) {
     pm.addPass(mlir::createFinalizeMemRefToLLVMConversionPass());
   });
+  m.def("add_math_to_libmvec", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::triton::cpu::createMathToLibmvecPass());
+  });
   m.def("add_math_to_libm", [](mlir::PassManager &pm) {
     pm.addPass(mlir::createConvertMathToLibmPass());
   });


### PR DESCRIPTION
This patch adds a pass similar to math_to_libm_calls but using libmvec functions (libmvec is a part of libm added for OpenMP 4.0: https://sourceware.org/glibc/wiki/libmvec).
