### PR TITLE
[cpu] Add RewriteTensorPointerPass

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -79,4 +79,6 @@ jobs:
       - name: Run python unit tests
         run: |
           python -m pytest -s -n 32 --device cpu python/test/unit/language/test_core.py -m cpu
-          python -m pytest -s -n 32 --device cpu python/test/unit/language/test_conversions.py
+          python -m pytest -s -n 32 --device cpu \
+            python/test/unit/language/test_block_pointer.py
+            python/test/unit/language/test_conversions.py

--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -77,6 +77,7 @@ class CPUBackend(BaseBackend):
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
         passes.common.add_inliner(pm)
+        passes.ttir.add_rewrite_tensor_pointer(pm)
         passes.ttir.add_combine(pm)
         passes.common.add_canonicalizer(pm)
         passes.ttir.add_reorder_broadcast(pm)


### PR DESCRIPTION
The other backends all use it. This makes test_block_pointer.py pass.

Fixes https://github.com/triton-lang/triton-cpu/issues/60.