### PR TITLE
[CPU] Fix TypeConverter in TritonCPUToLLVM + minor refactoring

### DIFF
--- a/third_party/cpu/lib/TritonCPUToLLVM/TypeConverter.h
+++ b/third_party/cpu/lib/TritonCPUToLLVM/TypeConverter.h
@@ -17,6 +17,7 @@ public:
                                const DataLayoutAnalysis *analysis = nullptr);
 
   Type convertTritonPointerType(triton::PointerType type);
+  Type convertTritonTensorType(RankedTensorType type);
 };
 
 #endif

--- a/third_party/cpu/lib/TritonToTritonCPU/TypeConverter.h
+++ b/third_party/cpu/lib/TritonToTritonCPU/TypeConverter.h
@@ -13,7 +13,7 @@ public:
 
   TritonToTritonCPUTypeConverter();
 
-  Type convertTritonPointerType(triton::PointerType type);
+  Type convertTritonTensorType(RankedTensorType type);
 };
 
 #endif


### PR DESCRIPTION
A quick fix for the TypeConverter in TritonCPUToLLVM, where tensor types were not converted (returned std::nullptr).

And I did some minor refactoring in the other TypeConvert.cpp.