### PR TITLE
[cpu] Make runtime library build on Linux too

### DIFF
--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -52,7 +52,7 @@ def _build(name, src, srcdir, library_dirs, include_dirs, libraries):
     cc_cmd += [f"-L{dir}" for dir in library_dirs]
     cc_cmd += [f"-I{dir}" for dir in include_dirs]
     for dir in library_dirs:
-        cc_cmd.extend(["-rpath", dir])
+        cc_cmd.extend(["-Wl,-rpath", dir])
     # CPU backend uses C++ (driver.cpp). Some old version compilers need a specific C++17 flag.
     if src.endswith(".cpp") or src.endswith(".cc"):
         cc_cmd += ["-std=c++17", "-fopenmp"]


### PR DESCRIPTION
macOS gcc supports `-rpath` directly in the compilation driver, but on Linux we need to pass it directly to the linker. Fortunately this works on macOS too.