### PR TITLE
[FIX Pytest] Resolve 'importlib' issue

### DIFF
--- a/third_party/cpu/backend/driver.py
+++ b/third_party/cpu/backend/driver.py
@@ -1,6 +1,7 @@
 import os
 import hashlib
 import importlib
+import importlib.resources
 import tempfile
 
 import triton._C


### PR DESCRIPTION
This commit resolves issue, that occurs on main 'pytest run'.
```
    _triton_C_dir = importlib.resources.files(triton._C).joinpath("")
E   AttributeError: module 'importlib' has no attribute 'resources'
```

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

