### PR TITLE
Fix importlib issues

### DIFF
--- a/third_party/cpu/backend/driver.py
+++ b/third_party/cpu/backend/driver.py
@@ -11,7 +11,7 @@ from triton.backends.compiler import GPUTarget
 
 _dirname = os.getenv("TRITON_SYS_PATH", default="/usr/local")
 # for locating libTritonCPURuntime
-_triton_C_dir = importlib.resources.files(triton._C).joinpath("")
+_triton_C_dir = importlib.resources.files(triton).joinpath("_C")
 
 include_dirs = [os.path.join(_dirname, "include")]
 library_dirs = [os.path.join(_dirname, "lib"), _triton_C_dir]


### PR DESCRIPTION
The previous implementation worked on Python 3.11 but had a host of issues with other versions. It boiled down to `triton._C` not being a regular package -- it doesn't have an `__init__.py` file. However, it can still be imported as a [namespace package][1]. Namespace packages can map to multiple locations on the filesystem, so we cannot get a path to the package contents without materializing the package.

The solution is to look up the files of the top-level `triton` package instead, which is a regular package, and use that to find the location of the `_C` directory.

I've tested that this approach works on 3.9 and 3.12 in macOS.

Fixes #76.

[1]: https://packaging.python.org/en/latest/guides/packaging-namespace-packages/#native-namespace-packages