### PR TITLE
Compute a scalar pointer for vector load instead of extracting it from a tensor

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -84,7 +84,8 @@ jobs:
             python/test/unit/language/test_block_pointer.py \
             python/test/unit/language/test_conversions.py \
             python/test/unit/cpu/test_libdevice.py \
-            python/test/unit/cpu/test_libmvec.py
+            python/test/unit/cpu/test_libmvec.py \
+            python/test/unit/cpu/test_opt.py
 
       - name: Run lit tests
         run: |

--- a/python/test/unit/cpu/test_opt.py
+++ b/python/test/unit/cpu/test_opt.py
@@ -1,0 +1,37 @@
+import os
+import torch
+
+import triton
+import triton.language as tl
+
+
+def is_interpreter():
+    return os.environ.get('TRITON_INTERPRET', '0') == '1'
+
+
+def is_cpu():
+    return not is_interpreter() and \
+        triton.runtime.driver.active.get_current_target().backend == "cpu"
+
+
+def is_x86():
+    return is_cpu() and \
+        triton.runtime.driver.active.get_current_target().arch == "x86_64"
+
+
+def test_scalar_pointer_arith(device):
+
+    @triton.jit
+    def kernel(src, dst, BLOCK_SIZE: tl.constexpr):
+        offs = tl.arange(0, BLOCK_SIZE)
+        x = tl.load(src + offs)
+        tl.store(dst + offs, x)
+
+    src = torch.rand((128, ), dtype=torch.float32, device=device)
+    res = torch.empty_like(src)
+    meta = kernel[(1, )](src, res, BLOCK_SIZE=128)
+    assert (src == res).all()
+
+    # Check TTCIR doesn't have pointer extraction from a tensor.
+    ttcir = meta.asm["ttcir"]
+    assert ttcir.count("extract") == 0

--- a/test/TritonCPU/convert-memory-ops.mlir
+++ b/test/TritonCPU/convert-memory-ops.mlir
@@ -69,3 +69,26 @@ module {
     tt.return
   }
 }
+
+// -----
+
+// Check that pointer for vector load/store is not extracted from a vector
+
+// CHECK-LABEL: @scalar_ptrs
+// CHECK-NOT:   vector.extract {{.+}} : i64 from vector<128xi64>
+// CHECK:       {{.+}} = vector.load {{.+}} : memref<128xf32>, vector<128xf32>
+// CHECK-NOT:   vector.extract {{.+}} : i64 from vector<128xi64>
+// CHECK:       vector.store {{.+}}, {{.+}} : memref<128xf32>, vector<128xf32>
+
+module {
+  tt.func public @scalar_ptrs(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %2 = tt.addptr %1, %0 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    %3 = tt.load %2 : tensor<128x!tt.ptr<f32>>
+    %4 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %5 = tt.addptr %4, %0 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    tt.store %5, %3 : tensor<128x!tt.ptr<f32>>
+    tt.return
+  }
+}


### PR DESCRIPTION
Currently, if we detect a vector load/store, we extract a pointer from a tensor, then use it to build a memref, then make a load/store. The original tensor of pointers computation stays intact, and LLVM is not always capable of optimizing it to a scalar code. As a result, we might get a vector of pointers computations to just extract a single pointer from it to make a load.

This patch tries to rebuild a scalar pointer by going through the original tensor's data flow. This showed a nice improvement for softmax.