### PR TITLE
Add pass to optimize masked loads and stores.

### DIFF
--- a/test/TritonCPU/optimize-masks.mlir
+++ b/test/TritonCPU/optimize-masks.mlir
@@ -1,0 +1,35 @@
+// RUN: triton-opt %s -split-input-file -triton-cpu-optimize-masks | FileCheck %s
+
+// Convert strided masked loads to scalar loads.
+
+// CHECK-LABEL: @remove_masks_in_for_loop
+// CHECK:       %[[VAL:.+]] = vector.load {{.+}} : memref<16xf32>, vector<16xf32>
+// CHECK:       vector.store %[[VAL]], {{.+}} : memref<16xf32>, vector<16xf32>
+
+module {
+  tt.func public @remove_masks_in_for_loop(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32 {tt.divisibility = 16 : i32}) {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> : vector<16xi32>
+    %c15_i32 = arith.constant 15 : i32
+    %c16_i32 = arith.constant 16 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %cst_0 = arith.constant dense<0.000000e+00> : vector<16xf32>
+    %0 = arith.addi %arg2, %c15_i32 : i32
+    %1 = arith.divsi %0, %c16_i32 : i32
+    %2 = vector.splat %arg2 : vector<16xi32>
+    scf.for %arg3 = %c0_i32 to %1 step %c1_i32  : i32 {
+      %3 = arith.muli %arg3, %c16_i32 : i32
+      %4 = vector.splat %3 : vector<16xi32>
+      %5 = arith.addi %4, %cst : vector<16xi32>
+      %6 = arith.cmpi slt, %5, %2 : vector<16xi32>
+      %7 = tt.addptr %arg0, %3 : !tt.ptr<f32>, i32
+      %8 = triton_cpu.ptr_to_memref %7 : <f32> -> memref<16xf32>
+      %9 = vector.maskedload %8[%c0], %6, %cst_0 : memref<16xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
+      %10 = tt.addptr %arg1, %3 : !tt.ptr<f32>, i32
+      %11 = triton_cpu.ptr_to_memref %10 : <f32> -> memref<16xf32>
+      vector.maskedstore %11[%c0], %6, %9 : memref<16xf32>, vector<16xi1>, vector<16xf32>
+    }
+    tt.return
+  }
+}

--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -112,6 +112,7 @@ class CPUBackend(BaseBackend):
         # TTCIR -> Target TTCIR
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
+        cpu.passes.ttcpuir.add_optimize_masks(pm)
         promote_bf16_to_fp32 = self.cpu_arch == "x86_64" and "avx512bf16" not in self.cpu_features
         # We don't have any lowering for mixed precision matmuls, so always use casts for now
         convert_mixed_precision_matmul = True

--- a/third_party/cpu/include/TritonCPUTransforms/Passes.h
+++ b/third_party/cpu/include/TritonCPUTransforms/Passes.h
@@ -27,6 +27,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createDecomposeFpConversions();
 std::unique_ptr<OperationPass<ModuleOp>>
 createDecomposeFpConversions(bool decomposeBf16Conversions,
                              bool decomposeFp8Conversions);
+std::unique_ptr<OperationPass<ModuleOp>> createOptimizeMasks();
 
 #define GEN_PASS_REGISTRATION
 #include "cpu/include/TritonCPUTransforms/Passes.h.inc"

--- a/third_party/cpu/include/TritonCPUTransforms/Passes.td
+++ b/third_party/cpu/include/TritonCPUTransforms/Passes.td
@@ -57,4 +57,22 @@ def DecomposeFpConversions : Pass<"triton-cpu-decompose-fp-conversions", "mlir::
                              "mlir::triton::cpu::TritonCPUDialect"];
 }
 
+def OptimizeMasks : Pass<"triton-cpu-optimize-masks", "mlir::ModuleOp"> {
+    let summary = "Optimize masked memory accesses.";
+    let description = [{
+        This pass tries to detect masked memory accesses with mask values that
+        can be proven to be all-ones or all-zeros.
+    }];
+
+    let options = [
+    ];
+
+    let constructor = "mlir::triton::cpu::createOptimizeMasks()";
+
+    let dependentDialects = ["mlir::arith::ArithDialect",
+                             "mlir::vector::VectorDialect",
+                             "mlir::triton::TritonDialect",
+                             "mlir::triton::cpu::TritonCPUDialect"];
+}
+
 #endif

--- a/third_party/cpu/lib/TritonCPUTransforms/CMakeLists.txt
+++ b/third_party/cpu/lib/TritonCPUTransforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_triton_library(TritonCPUTransforms
     ConvertUnsupportedOps.cpp
     DecomposeFpConversions.cpp
+    OptimizeMasks.cpp
 
     DEPENDS
     TritonCPUTransformsPassIncGen

--- a/third_party/cpu/lib/TritonCPUTransforms/OptimizeMasks.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/OptimizeMasks.cpp
@@ -1,0 +1,393 @@
+#include "cpu/include/TritonCPUTransforms/OptCommon.h"
+#include "cpu/include/TritonCPUTransforms/Passes.h"
+
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonCPU/IR/Dialect.h"
+
+namespace mlir {
+namespace triton {
+namespace cpu {
+#define GEN_PASS_DEF_OPTIMIZEMASKS
+#include "cpu/include/TritonCPUTransforms/Passes.h.inc"
+} // namespace cpu
+} // namespace triton
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::triton;
+using namespace mlir::triton::cpu;
+
+namespace {
+
+int64_t getDivisibility(Value val) {
+  BlockArgument blockArg = dyn_cast<BlockArgument>(val);
+  if (!blockArg)
+    return 1;
+
+  Operation *argOp = blockArg.getOwner()->getParentOp();
+  if (auto fn = dyn_cast<FunctionOpInterface>(argOp)) {
+    Attribute attr = fn.getArgAttr(blockArg.getArgNumber(), "tt.divisibility");
+    if (auto iattr = dyn_cast_or_null<IntegerAttr>(attr)) {
+      return iattr.getInt();
+    }
+  }
+
+  return 1;
+}
+
+bool isAlwaysDivisible(Value val, int64_t divisor) {
+  if (auto cst = val.getDefiningOp<arith::ConstantOp>()) {
+    auto intAttr = dyn_cast<IntegerAttr>(cst.getValue());
+    return intAttr && (intAttr.getInt() % divisor == 0);
+  }
+  return getDivisibility(val) % divisor == 0;
+}
+
+bool isAlwaysDivisible(Value val, Value divisor) {
+  if (auto cst = divisor.getDefiningOp<arith::ConstantOp>()) {
+    auto intAttr = dyn_cast<IntegerAttr>(cst.getValue());
+    if (intAttr)
+      return isAlwaysDivisible(val, intAttr.getInt());
+  }
+  return false;
+}
+
+// Optimize cdiv pattern using divisibility hints. If value is known to be
+// divisible by N then we can transform
+//   (val + K - 1) / K
+// to
+//   val / K
+// if N % K == 0 and val is not negative. Usually, we cannot prove value to be
+// non-negative but still can apply transformation for contexts that assume
+// positive value (e.g. as an upper bound in a for-loop with non-negative
+// lower bound).
+struct CdivToDiv : public OpRewritePattern<arith::DivSIOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(arith::DivSIOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    Value lhs = op.getLhs();
+    Value rhs = op.getRhs();
+    auto addOpDef = lhs.getDefiningOp<arith::AddIOp>();
+    auto divisorDef = rhs.getDefiningOp<arith::ConstantOp>();
+    if (!addOpDef || !divisorDef)
+      return failure();
+
+    arith::ConstantOp addCstDef;
+    Value addOtherVal;
+    if (addCstDef = addOpDef.getLhs().getDefiningOp<arith::ConstantOp>())
+      addOtherVal = addOpDef.getRhs();
+    else if (addCstDef = addOpDef.getRhs().getDefiningOp<arith::ConstantOp>())
+      addOtherVal = addOpDef.getLhs();
+    else
+      return failure();
+
+    int64_t divisorCst = cast<IntegerAttr>(divisorDef.getValue()).getInt();
+    int64_t addCst = cast<IntegerAttr>(addCstDef.getValue()).getInt();
+    if (divisorCst <= addCst)
+      return failure();
+
+    if (!isAlwaysDivisible(addOtherVal, divisorCst))
+      return failure();
+
+    Value res = op.getResult();
+    Value newRes =
+        rewriter.create<arith::DivSIOp>(loc, addOtherVal, divisorDef);
+    int replaced = 0;
+    rewriter.replaceUsesWithIf(res, newRes, [&](OpOperand &use) {
+      if (auto forOp = dyn_cast<scf::ForOp>(use.getOwner())) {
+        auto lowerDef =
+            forOp.getLowerBound().getDefiningOp<arith::ConstantOp>();
+        if (lowerDef && use.getOperandNumber() == 1 &&
+            cast<IntegerAttr>(lowerDef.getValue()).getInt() >= 0) {
+          ++replaced;
+          return true;
+        }
+      }
+      return false;
+    });
+    if (!replaced)
+      return failure();
+
+    return success();
+  }
+};
+
+// This pattern rewrites for-loops used for tiling to optimize out division
+// and multiplication using divisibility hints.
+// Typical tiled loop looks like:
+//   for i in range(0, tl.cdiv(size, TILE_SIZE)):
+//     offs = i * TILE_SIZE
+//     ...
+// If size is known to be divisible by TILE_SIZE then it can be written as:
+//   for offs in range(0, size, TILE_SIZE):
+//     ...
+// This pattern is used after an attempt to replace cdiv with a regular
+// division. Possible input pattern is:
+//   %c0 = arith.constant 0 : index
+//   %c1 = arith.constant 1 : index
+//   %c16 = arith.constant 16 : index
+//   %init = arith.constant dense<0x00000000> : vector<16xf32>
+//   %1 = arith.divsi %arg4, %c16
+//   %2 = scf.for %arg5 = %c0 to %1 step %c1 iter_args(%arg6 = %init) ->
+//   (vector<16xf32>) : i32 {
+//     %3 = arith.muli %arg5, %c16 : i32
+//     ...
+//   }
+// where %arg4 is known to be divisible by 16. The resulting code would be:
+//   %c0 = arith.constant 0 : index
+//   %c16 = arith.constant 16 : index
+//   %init = arith.constant dense<0x00000000> : vector<16xf32>
+//   %2 = scf.for %arg5 = %c0 to %arg4 step %c16 iter_args(%arg6 = %init) ->
+//   (vector<16xf32>) : i32 {
+//     ...
+//   }
+// This removes division and simplifies the following analysis to optimize
+// masked memory acccess for the tile.
+struct ScaleInductionVariable : public OpRewritePattern<scf::ForOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(scf::ForOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    Value iv = op.getInductionVar();
+    Value lower = op.getLowerBound();
+    Value upper = op.getUpperBound();
+    Value step = op.getStep();
+    auto lowerDef = lower.getDefiningOp<arith::ConstantOp>();
+    auto upperDef = upper.getDefiningOp<arith::DivSIOp>();
+    if (!lowerDef || !upperDef)
+      return failure();
+
+    int64_t lowerVal = cast<IntegerAttr>(lowerDef.getValue()).getInt();
+    if (lowerVal < 0)
+      return failure();
+
+    // TODO: This is a strong requirement. With more generic value range
+    // analysis we should be able to not rely on this transformation.
+    if (!iv.hasOneUse())
+      return failure();
+
+    auto ivUse = dyn_cast<arith::MulIOp>(*iv.getUsers().begin());
+    if (!ivUse)
+      return failure();
+
+    Value scale = ivUse.getLhs() == iv ? ivUse.getRhs() : ivUse.getLhs();
+    auto scaleDef = scale.getDefiningOp<arith::ConstantOp>();
+    auto divRhsDef = upperDef.getRhs().getDefiningOp<arith::ConstantOp>();
+    auto divLhs = upperDef.getLhs();
+    if (!scaleDef || !divRhsDef)
+      return failure();
+
+    int64_t scaleVal = cast<IntegerAttr>(scaleDef.getValue()).getInt();
+    int64_t divisorVal = cast<IntegerAttr>(divRhsDef.getValue()).getInt();
+    if (scaleVal != divisorVal || !isAlwaysDivisible(divLhs, scaleVal) ||
+        lowerVal % scaleVal != 0)
+      return failure();
+
+    // Build new lower bound.
+    Value newLower = lower;
+    if (lowerVal != 0) {
+      rewriter.setInsertionPointAfterValue(lower);
+      newLower = rewriter.create<arith::ConstantIntOp>(
+          lower.getLoc(), lowerVal * scaleVal, lower.getType());
+    }
+    // New Upper bound.
+    Value newUpper = divLhs;
+    // Build new step.
+    rewriter.setInsertionPoint(op);
+    auto newStep = rewriter.create<arith::MulIOp>(ivUse.getLoc(), step, scale);
+
+    // Modify ForOp.
+    rewriter.startOpModification(op);
+    op.setLowerBound(newLower);
+    op.setUpperBound(newUpper);
+    op.setStep(newStep);
+    rewriter.finalizeOpModification(op);
+
+    // Replace iv uses.
+    rewriter.replaceAllUsesWith(ivUse, iv);
+
+    return success();
+  }
+};
+
+// Build affine expression to express min/max value of the given SSA name.
+// symbolTable is used to map SSA names to affine symbols.
+AffineExpr buildMinOrMaxExpr(Value val, bool isSigned, bool isMax,
+                             llvm::DenseMap<Value, unsigned> &symbolTable) {
+  if (auto def = val.getDefiningOp<vector::SplatOp>()) {
+    return buildMinOrMaxExpr(def.getInput(), isSigned, isMax, symbolTable);
+  } else if (auto def = val.getDefiningOp<arith::ConstantOp>()) {
+    auto attr = def.getValueAttr();
+    if (auto intAttr = dyn_cast<IntegerAttr>(attr))
+      return getAffineConstantExpr(intAttr.getInt(), val.getContext());
+    if (auto denseAttr = dyn_cast<DenseIntOrFPElementsAttr>(attr)) {
+      auto valueBegin = denseAttr.value_begin<APInt>();
+      auto valueEnd = denseAttr.value_end<APInt>();
+      auto cmpVals = [isSigned](const APInt &lhs, const APInt &rhs) {
+        return isSigned ? lhs.slt(rhs) : lhs.ult(rhs);
+      };
+      auto valueIt = isMax ? std::max_element(valueBegin, valueEnd, cmpVals)
+                           : std::min_element(valueBegin, valueEnd, cmpVals);
+      return getAffineConstantExpr((*valueIt).getSExtValue(), val.getContext());
+    }
+  } else if (auto def = val.getDefiningOp<arith::AddIOp>()) {
+    return buildMinOrMaxExpr(def.getLhs(), isSigned, isMax, symbolTable) +
+           buildMinOrMaxExpr(def.getRhs(), isSigned, isMax, symbolTable);
+  } else if (auto def = val.getDefiningOp<arith::SubIOp>()) {
+    return buildMinOrMaxExpr(def.getLhs(), isSigned, isMax, symbolTable) -
+           buildMinOrMaxExpr(def.getRhs(), isSigned, !isMax, symbolTable);
+  } else if (auto blockArg = dyn_cast<BlockArgument>(val)) {
+    auto op = blockArg.getOwner()->getParentOp();
+    if (auto forOp = dyn_cast<scf::ForOp>(op)) {
+      if (val == forOp.getInductionVar()) {
+        Value lower = forOp.getLowerBound();
+        Value upper = forOp.getUpperBound();
+        Value step = forOp.getStep();
+
+        // For min value return lower bound.
+        if (!isMax)
+          return buildMinOrMaxExpr(forOp.getLowerBound(), isSigned, isMax,
+                                   symbolTable);
+
+        // For max value we use upper bound - 1 in generic case and bound - step
+        // if both bounds are divisible by the step.
+        if (isAlwaysDivisible(lower, step) && isAlwaysDivisible(upper, step)) {
+          return buildMinOrMaxExpr(upper, isSigned, isMax, symbolTable) -
+                 buildMinOrMaxExpr(step, isSigned, false, symbolTable);
+        }
+        return buildMinOrMaxExpr(upper, isSigned, isMax, symbolTable) -
+               getAffineConstantExpr(1, val.getContext());
+      }
+    }
+  }
+
+  if (symbolTable.count(val))
+    return getAffineSymbolExpr(symbolTable.at(val), val.getContext());
+
+  unsigned pos = symbolTable.size();
+  symbolTable.insert(std::make_pair(val, pos));
+  return getAffineSymbolExpr(pos, val.getContext());
+}
+
+// Check if vector mask is all-ones by checking compared values ranges.
+// Only simplest cases are covered here, so affine expression is used
+// to represent a range for now.
+bool isAlwaysAllOnes(Value mask) {
+  auto maskDef = mask.getDefiningOp<arith::CmpIOp>();
+  if (!maskDef)
+    return false;
+
+  auto pred = maskDef.getPredicate();
+  if (pred == arith::CmpIPredicate::eq || pred == arith::CmpIPredicate::ne)
+    return false;
+
+  bool isSigned =
+      pred == arith::CmpIPredicate::sgt || pred == arith::CmpIPredicate::sge ||
+      pred == arith::CmpIPredicate::sle || pred == arith::CmpIPredicate::slt;
+  llvm::DenseMap<Value, unsigned> symbolTable;
+  AffineExpr maxOffs;
+  AffineExpr minLen;
+  if (pred == arith::CmpIPredicate::slt || pred == arith::CmpIPredicate::sle ||
+      pred == arith::CmpIPredicate::ult || pred == arith::CmpIPredicate::ule) {
+    maxOffs = buildMinOrMaxExpr(maskDef.getLhs(), isSigned, true, symbolTable);
+    minLen = buildMinOrMaxExpr(maskDef.getRhs(), isSigned, false, symbolTable);
+  } else {
+    maxOffs = buildMinOrMaxExpr(maskDef.getRhs(), isSigned, true, symbolTable);
+    minLen = buildMinOrMaxExpr(maskDef.getLhs(), isSigned, false, symbolTable);
+  }
+
+  // The mask is all-ones if max offset is always less than min length.
+  auto diff = maxOffs - minLen;
+  if (auto diffCst = dyn_cast<AffineConstantExpr>(diff)) {
+    int64_t diffVal = diffCst.getValue();
+    if (pred == arith::CmpIPredicate::slt ||
+        pred == arith::CmpIPredicate::ult ||
+        pred == arith::CmpIPredicate::sgt || pred == arith::CmpIPredicate::ugt)
+      return diffVal < 0;
+    else
+      return diffVal <= 0;
+  }
+
+  return false;
+}
+
+struct OptimizeMaskedLoad : public OpRewritePattern<vector::MaskedLoadOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::MaskedLoadOp op,
+                                PatternRewriter &rewriter) const override {
+    if (!isAlwaysAllOnes(op.getMask()))
+      return failure();
+
+    rewriter.replaceOpWithNewOp<vector::LoadOp>(op, op.getType(), op.getBase(),
+                                                op.getIndices());
+    return success();
+  }
+};
+
+struct OptimizeMaskedStore : public OpRewritePattern<vector::MaskedStoreOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::MaskedStoreOp op,
+                                PatternRewriter &rewriter) const override {
+    if (!isAlwaysAllOnes(op.getMask()))
+      return failure();
+
+    rewriter.replaceOpWithNewOp<vector::StoreOp>(op, op.getValueToStore(),
+                                                 op.getBase(), op.getIndices());
+    return success();
+  }
+};
+
+struct OptimizeMasks
+    : public triton::cpu::impl::OptimizeMasksBase<OptimizeMasks> {
+  OptimizeMasks() = default;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ModuleOp mod = getOperation();
+
+    // TODO: This pass optimizes out masks applying a set of very strict
+    // patterns. We should use more generic range and divisibility analysis
+    // to cover more cases and remove dependency on other transformations.
+    RewritePatternSet patterns1(context);
+    patterns1.add<CdivToDiv>(context);
+    if (failed(mlir::applyPatternsAndFoldGreedily(mod, std::move(patterns1))))
+      return signalPassFailure();
+
+    RewritePatternSet patterns2(context);
+    patterns2.add<ScaleInductionVariable>(context);
+    if (failed(mlir::applyPatternsAndFoldGreedily(mod, std::move(patterns2))))
+      return signalPassFailure();
+
+    RewritePatternSet patterns3(context);
+    patterns3.add<OptimizeMaskedLoad>(context);
+    patterns3.add<OptimizeMaskedStore>(context);
+    if (failed(mlir::applyPatternsAndFoldGreedily(mod, std::move(patterns3))))
+      return signalPassFailure();
+
+    // TODO: if masks removal failed for loads/stores in a for-loop, we might
+    // still optimize it using loop peeling.
+  }
+};
+
+} // namespace
+
+namespace mlir {
+namespace triton {
+namespace cpu {
+
+std::unique_ptr<OperationPass<ModuleOp>> createOptimizeMasks() {
+  return std::make_unique<OptimizeMasks>();
+}
+
+} // namespace cpu
+} // namespace triton
+} // namespace mlir

--- a/third_party/cpu/triton_cpu.cc
+++ b/third_party/cpu/triton_cpu.cc
@@ -54,6 +54,9 @@ void init_triton_cpu_passes_ttcpuir(py::module &&m) {
   m.def("add_convert_atomic_ops", [](mlir::PassManager &pm) {
     pm.addPass(mlir::triton::cpu::createConvertAtomicOps());
   });
+  m.def("add_optimize_masks", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::triton::cpu::createOptimizeMasks());
+  });
   m.def("add_convert_unsupported_ops",
         [](mlir::PassManager &pm, bool promote_bf16_to_fp32,
            bool convert_mixed_precision_matmul, bool promote_lib_math_to_fp32) {


### PR DESCRIPTION
This patch adds a few patterns that can optimize out masks in a typical tiled loop of the following form:
```
  for i in range(0, tl.cdiv(size, TILE_SIZE)):
    offs = i * TILE_SIZE + tl.arange(0, TILE_SIZE)
    mask = offs < size
    val = tl.load(in_ptr + offs, mask=mask, other=0)
    res = ...
    tl.sotre(out_ptr + offs, res, mask=mask)
```
given a hint that `size` is divisible by `TILE_SIZE`. The first couple of patterns try to remove the cdiv-mul pair and transform the loop into something like:
```
  for i in range(0, size, TILE_SIZE):
    offs = i + tl.arange(0, TILE_SIZE)
    mask = offs < size
    val = tl.load(in_ptr + offs, mask=mask, other=0)
    res = ...
    tl.sotre(out_ptr + offs, res, mask=mask)
```
The last one tries to prove that the maximum possible value of `offs` is always less than `size`. If `size` is divisible by `TILE_SIZE` then `i <= size - TILE_SIZE` and `offs <= size - TILE_SIZE + TILE_SIZE - 1`, so we get `size - offs >= 1` which means the mask is always all-ones.

Example of TTIR before the optimization pass:
```
module {
  tt.func public @kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc(unknown), %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc(unknown), %arg2: i32 {tt.divisibility = 16 : i32} loc(unknown)) attrib\
utes {noinline = false} {
    %c0 = arith.constant 0 : index loc(#loc)
    %cst = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> : vector<16xi32> loc(#loc)
    %c15_i32 = arith.constant 15 : i32 loc(#loc)
    %c16_i32 = arith.constant 16 : i32 loc(#loc)
    %c0_i32 = arith.constant 0 : i32 loc(#loc)
    %c1_i32 = arith.constant 1 : i32 loc(#loc)
    %cst_0 = arith.constant dense<0.000000e+00> : vector<16xf32> loc(#loc)
    %0 = arith.addi %arg2, %c15_i32 : i32 loc(#loc)
    %1 = arith.divsi %0, %c16_i32 : i32 loc(#loc)
    %2 = vector.splat %arg2 : vector<16xi32> loc(#loc)
    scf.for %arg3 = %c0_i32 to %1 step %c1_i32  : i32 {
      %3 = arith.muli %arg3, %c16_i32 : i32 loc(#loc)
      %4 = vector.splat %3 : vector<16xi32> loc(#loc)
      %5 = arith.addi %4, %cst : vector<16xi32> loc(#loc)
      %6 = arith.cmpi slt, %5, %2 : vector<16xi32> loc(#loc)
      %7 = tt.addptr %arg0, %3 : !tt.ptr<f32>, i32 loc(#loc)
      %8 = triton_cpu.ptr_to_memref %7 : <f32> -> memref<16xf32> loc(#loc)
      %9 = vector.maskedload %8[%c0], %6, %cst_0 : memref<16xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32> loc(#loc)
      %10 = tt.addptr %arg1, %3 : !tt.ptr<f32>, i32 loc(#loc)
      %11 = triton_cpu.ptr_to_memref %10 : <f32> -> memref<16xf32> loc(#loc)
      vector.maskedstore %11[%c0], %6, %9 : memref<16xf32>, vector<16xi1>, vector<16xf32> loc(#loc)
    } loc(#loc)
    tt.return loc(#loc)
  } loc(#loc)
} loc(#loc)
```
After the pass:
```
module {
  tt.func public @kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc(unknown), %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc(unknown), %arg2: i32 {tt.divisibility = 16 : i32} loc(unknown)) attrib\
utes {noinline = false} {
    %c16_i32 = arith.constant 16 : i32 loc(#loc)
    %c0 = arith.constant 0 : index loc(#loc)
    %c0_i32 = arith.constant 0 : i32 loc(#loc)
    scf.for %arg3 = %c0_i32 to %arg2 step %c16_i32  : i32 {
      %0 = tt.addptr %arg0, %arg3 : !tt.ptr<f32>, i32 loc(#loc)
      %1 = triton_cpu.ptr_to_memref %0 : <f32> -> memref<16xf32> loc(#loc)
      %2 = vector.load %1[%c0] : memref<16xf32>, vector<16xf32> loc(#loc)
      %3 = tt.addptr %arg1, %arg3 : !tt.ptr<f32>, i32 loc(#loc)
      %4 = triton_cpu.ptr_to_memref %3 : <f32> -> memref<16xf32> loc(#loc)
      vector.store %2, %4[%c0] : memref<16xf32>, vector<16xf32> loc(#loc)
    } loc(#loc)
    tt.return loc(#loc)
  } loc(#loc)
} loc(#loc)
```
