### PR TITLE
Add an option to choose between default reduction lowering and our own.

### DIFF
--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -123,7 +123,7 @@ class CPUBackend(BaseBackend):
         cpu.passes.ttcpuir.add_convert_elem_manip_ops(pm)
         cpu.passes.ttcpuir.add_convert_dot_op(pm)
         cpu.passes.ttcpuir.add_convert_histogram_op(pm)
-        cpu.passes.ttcpuir.add_convert_reduction_op(pm)
+        cpu.passes.ttcpuir.add_convert_reduction_op(pm, False)
         cpu.passes.ttcpuir.add_convert_scan_op(pm)
         cpu.passes.ttcpuir.add_convert_cf_ops(pm)
         cpu.passes.ttcpuir.add_convert_atomic_ops(pm)

--- a/third_party/cpu/include/TritonToTritonCPU/Passes.h
+++ b/third_party/cpu/include/TritonToTritonCPU/Passes.h
@@ -28,6 +28,8 @@ std::unique_ptr<OperationPass<ModuleOp>> createConvertDotOp();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertControlFlowOps();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertHistogramOp();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertReductionOp();
+std::unique_ptr<OperationPass<ModuleOp>>
+createConvertReductionOp(bool useMultiDimReductionOp);
 std::unique_ptr<OperationPass<ModuleOp>> createConvertScanOp();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertAtomicOps();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertDebugOps();

--- a/third_party/cpu/include/TritonToTritonCPU/Passes.td
+++ b/third_party/cpu/include/TritonToTritonCPU/Passes.td
@@ -113,6 +113,12 @@ def ConvertReductionOp : Pass<"triton-cpu-convert-reduction", "mlir::ModuleOp"> 
     }];
     let constructor = "mlir::triton::cpu::createConvertReductionOp()";
 
+    let options = [
+        Option<"useMultiDimReductionOp", "use-multidim-reduction-op",
+               "bool", /*default*/"false",
+               "Use vector::MultiDimReductionOp and its default lowering when possible.">,
+    ];
+
     let dependentDialects = ["mlir::arith::ArithDialect",
                              "mlir::vector::VectorDialect",
                              "mlir::scf::SCFDialect",

--- a/third_party/cpu/triton_cpu.cc
+++ b/third_party/cpu/triton_cpu.cc
@@ -46,9 +46,11 @@ void init_triton_cpu_passes_ttcpuir(py::module &&m) {
   m.def("add_convert_histogram_op", [](mlir::PassManager &pm) {
     pm.addPass(mlir::triton::cpu::createConvertHistogramOp());
   });
-  m.def("add_convert_reduction_op", [](mlir::PassManager &pm) {
-    pm.addPass(mlir::triton::cpu::createConvertReductionOp());
-  });
+  m.def("add_convert_reduction_op",
+        [](mlir::PassManager &pm, bool use_multidim_reduction_op) {
+          pm.addPass(mlir::triton::cpu::createConvertReductionOp(
+              use_multidim_reduction_op));
+        });
   m.def("add_convert_scan_op", [](mlir::PassManager &pm) {
     pm.addPass(mlir::triton::cpu::createConvertScanOp());
   });


### PR DESCRIPTION
I found that the default reduction lowering we use right now doesn't provide the best performance. It utilizes `llvm.vector.reduce.*` intrinsics and those can be lowered to a scalar code. So, instead of using it, we might always rely on our generic reduction lowering. It showed better results in my softmax measurements. I still leave an option to use LLVM lowering for future experiments, it might become better.

Here is a code for add reduction (16 x fp32 vector).
The current one (using MultiDimReductionOp):
```
        vxorps  %xmm0, %xmm0, %xmm0
        vaddss  (%rdi), %xmm0, %xmm0
        vaddss  4(%rdi), %xmm0, %xmm0
        vaddss  8(%rdi), %xmm0, %xmm0
        vaddss  12(%rdi), %xmm0, %xmm0
        vaddss  16(%rdi), %xmm0, %xmm0
        vaddss  20(%rdi), %xmm0, %xmm0
        vaddss  24(%rdi), %xmm0, %xmm0
        vaddss  28(%rdi), %xmm0, %xmm0
        vaddss  32(%rdi), %xmm0, %xmm0
        vaddss  36(%rdi), %xmm0, %xmm0
        vaddss  40(%rdi), %xmm0, %xmm0
        vaddss  44(%rdi), %xmm0, %xmm0
        vaddss  48(%rdi), %xmm0, %xmm0
        vaddss  52(%rdi), %xmm0, %xmm0
        vaddss  56(%rdi), %xmm0, %xmm0
        vaddss  60(%rdi), %xmm0, %xmm0
        vmovss  %xmm0, (%rsi)

```
Our generic reduction:
```
        vmovupd (%rdi), %zmm0
        vshuff64x2      $78, %zmm0, %zmm0, %zmm1
        vaddps  %zmm1, %zmm0, %zmm0
        vextractf128    $1, %ymm0, %xmm1
        vaddps  %xmm1, %xmm0, %xmm0
        vshufpd $1, %xmm0, %xmm0, %xmm1
        vaddps  %xmm1, %xmm0, %xmm0
        vmovshdup       %xmm0, %xmm1
        vaddss  %xmm1, %xmm0, %xmm0
        vmovss  %xmm0, (%rsi)
```