### PR TITLE
Add an option to use libsleef instead of libmvec.

### DIFF
--- a/python/test/unit/cpu/test_libmvec.py
+++ b/python/test/unit/cpu/test_libmvec.py
@@ -53,7 +53,8 @@ def test_tensor_math_fn(dtype_str, math_fn, size, device):
         num_vec_calls = 1
     if data_size > 64:
         num_vec_calls = data_size / 64
-    assert meta.asm["asm"].count("_ZGV") == num_vec_calls
+    prefix = "Sleef" if os.environ.get("TRITON_CPU_USE_SLEEF", "0") != "0" else "_ZGV"
+    assert meta.asm["asm"].count(prefix) == num_vec_calls
 
 
 @pytest.mark.parametrize("dtype_str", float_dtypes)
@@ -93,4 +94,5 @@ def test_libdevice_math_fn(dtype_str, math_fn, size, device):
         num_vec_calls = 1
     if data_size > 64:
         num_vec_calls = data_size / 64
-    assert meta.asm["asm"].count("_ZGV") == num_vec_calls
+    prefix = "Sleef" if os.environ.get("TRITON_CPU_USE_SLEEF", "0") != "0" else "_ZGV"
+    assert meta.asm["asm"].count(prefix) == num_vec_calls

--- a/third_party/cpu/include/TritonCPUToLLVM/Passes.h
+++ b/third_party/cpu/include/TritonCPUToLLVM/Passes.h
@@ -27,6 +27,8 @@ std::unique_ptr<OperationPass<triton::FuncOp>> createLowerMultiReductionPass();
 std::unique_ptr<OperationPass<ModuleOp>> createAtomicOpsToLLVMPass();
 std::unique_ptr<OperationPass<ModuleOp>> createDebugOpsToLLVMPass();
 std::unique_ptr<OperationPass<ModuleOp>> createMathToLibmvecPass();
+std::unique_ptr<OperationPass<ModuleOp>>
+createMathToLibmvecPass(bool use_sleef);
 
 #define GEN_PASS_REGISTRATION
 #include "cpu/include/TritonCPUToLLVM/Passes.h.inc"

--- a/third_party/cpu/include/TritonCPUToLLVM/Passes.td
+++ b/third_party/cpu/include/TritonCPUToLLVM/Passes.td
@@ -67,10 +67,16 @@ def DebugOpsToLLVM : Pass<"triton-cpu-debug-ops-to-llvm", "mlir::ModuleOp"> {
 }
 
 def MathToLibmvec : Pass<"triton-cpu-math-to-libmvec", "mlir::ModuleOp"> {
-    let summary = "Convert vector math operations to vector libm calls.";
+    let summary = "Convert vector math operations to vector libm or sleef calls.";
     let description = [{
     }];
     let constructor = "mlir::triton::cpu::createMathToLibmvecPass()";
+
+    let options = [
+        Option<"use_sleef", "use-sleef",
+               "bool", /*default*/"false",
+               "Use sleef library for vector math instead of libmvec.">,
+    ];
 
     let dependentDialects = ["mlir::vector::VectorDialect",
                              "mlir::triton::cpu::TritonCPUDialect",

--- a/third_party/cpu/triton_cpu.cc
+++ b/third_party/cpu/triton_cpu.cc
@@ -114,8 +114,8 @@ void init_triton_cpu_passes_ttcpuir(py::module &&m) {
   m.def("add_memref_to_llvmir", [](mlir::PassManager &pm) {
     pm.addPass(mlir::createFinalizeMemRefToLLVMConversionPass());
   });
-  m.def("add_math_to_libmvec", [](mlir::PassManager &pm) {
-    pm.addPass(mlir::triton::cpu::createMathToLibmvecPass());
+  m.def("add_math_to_libmvec", [](mlir::PassManager &pm, bool use_sleef) {
+    pm.addPass(mlir::triton::cpu::createMathToLibmvecPass(use_sleef));
   });
   m.def("add_math_to_libm", [](mlir::PassManager &pm) {
     pm.addPass(mlir::createConvertMathToLibmPass());


### PR DESCRIPTION
Sleef can be enabled with `TRITON_CPU_USE_SLEEF=1` or `TRITON_CPU_USE_SLEEF=/path/to/lib` if you want to specify library location. All libmvec tests pass with `TRITON_CPU_USE_SLEEF=1`.