### PR TITLE
Enable rsqrt and floor for BF16.

### DIFF
--- a/python/test/unit/cpu/test_libdevice.py
+++ b/python/test/unit/cpu/test_libdevice.py
@@ -29,10 +29,6 @@ def test_libdevice(dtype_str, math_fn, size, device):
     if not is_cpu():
         pytest.skip("This test is CPU-specific")
 
-    if dtype_str == "bfloat16":
-        if math_fn == "floor" or math_fn == "rsqrt":
-            pytest.skip("libgcc < 13 does not define __truncsfbf2, which this op needs")
-
     @triton.jit
     def kernel(src, dst, MATH_FN: tl.constexpr, BLOCK_SIZE: tl.constexpr):
         idxs = tl.arange(0, BLOCK_SIZE)

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertUnsupportedOps.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertUnsupportedOps.cpp
@@ -381,6 +381,7 @@ struct ConvertUnsupportedOps
       patterns.add<PromoteOpToFp32<math::Log10Op>>(context);
       patterns.add<PromoteOpToFp32<math::Log1pOp>>(context);
       patterns.add<PromoteOpToFp32<math::PowFOp>>(context);
+      patterns.add<PromoteOpToFp32<math::RsqrtOp>>(context);
       patterns.add<PromoteOpToFp32<math::SinOp>>(context);
       patterns.add<PromoteOpToFp32<math::SinhOp>>(context);
       patterns.add<PromoteOpToFp32<math::SqrtOp>>(context);


### PR DESCRIPTION
This adds BF16 conversion for rsqrt call. I also had to decompose Fp32->Bf16 conversion because otherwise, LLVM optimizes
extf + floor into floor + extf.