### PR TITLE
Remove specific dwarf version from -g option.

### DIFF
--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -57,7 +57,8 @@ def _build(name, src, srcdir, library_dirs, include_dirs, libraries):
     if src.endswith(".cpp") or src.endswith(".cc"):
         cc_cmd += ["-std=c++17", "-fopenmp"]
     if src.endswith(".s"):
-        cc_cmd += ["-gdwarf-5"]
+        # This is required to properly parse .file directives
+        cc_cmd += ["-g"]
         if system == "Linux" and machine in ("aarch64", "arm64"):
             # On Arm backend, some CPU (neoverse-v2) needs to be specified through -mcpu
             cc_cmd += ["-mcpu=native"]


### PR DESCRIPTION
There were a few reports with assembly file build error during TritonCPU usage:
```
/tmp/tmpvo4arrkd/kernel.s:4363: Error: junk at end of line, first unrecognized character is `"'
```
I don't have a confirmation of a root cause and couldn't reproduce the issue, but my suspicion is that a toolchain with no dwarf5 support is used and our `-gdwarf-5` option doesn't work. I realized that we don't have to specify a dwarf version and can simply use `-g`. So hopefully it will fix the issue.