### PR TITLE
Fix indices extraction from block pointer.

### DIFF
--- a/python/test/unit/language/test_block_pointer.py
+++ b/python/test/unit/language/test_block_pointer.py
@@ -54,6 +54,24 @@ def test_block_copy(dtypes_str, n, padding_option, device):
         assert torch.all(torch.isnan(b[n // 2:n]))
 
 
+def test_block_copy2d(device):
+
+    @triton.jit
+    def kernel(in_ptr, out_ptr, M: tl.constexpr, N: tl.constexpr, BLOCK_M: tl.constexpr):
+        block_offset = tl.program_id(0) * BLOCK_M
+        in_block_ptr = tl.make_block_ptr(base=in_ptr, shape=(M, N), strides=(N, 1), offsets=(block_offset, 0),
+                                         block_shape=(BLOCK_M, N), order=(1, 0))
+        out_block_ptr = tl.make_block_ptr(base=out_ptr, shape=(M, N), strides=(N, 1), offsets=(block_offset, 0),
+                                          block_shape=(BLOCK_M, N), order=(1, 0))
+        x = tl.load(in_block_ptr)
+        tl.store(out_block_ptr, x)
+
+    inp = torch.randn((256, 16), device=device, dtype=torch.float32)
+    res = torch.empty_like(inp)
+    kernel[(16, )](inp, res, M=16, N=16, BLOCK_M=16)
+    assert (inp == res).all()
+
+
 @triton.jit
 def matmul_no_scf_with_advance_kernel(  #
         a_ptr, b_ptr, c_ptr,  #

--- a/third_party/cpu/lib/TritonCPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/cpu/lib/TritonCPUToLLVM/MemoryOpToLLVM.cpp
@@ -98,11 +98,8 @@ struct ExtractIndicesOpConversion
     SmallVector<Value> indices;
 
     for (int64_t i = 0; i < rank; i++) {
-      Value offs = rewriter.create<LLVM::ExtractValueOp>(
-          loc, i64Ty, tensorPtrStruct, SmallVector<int64_t, 2>{1, i});
-      Value stride = rewriter.create<LLVM::ExtractValueOp>(
-          loc, i64Ty, tensorPtrStruct, SmallVector<int64_t, 2>{3, i});
-      indices.push_back(rewriter.create<LLVM::MulOp>(loc, offs, stride));
+      indices.push_back(rewriter.create<LLVM::ExtractValueOp>(
+          loc, i64Ty, tensorPtrStruct, SmallVector<int64_t, 2>{1, i}));
     }
 
     rewriter.replaceOp(op, indices);


### PR DESCRIPTION
There is a bug in indices extraction from block pointers. Indices are scaled by strides which is not required and it's a part of old code left from those times when indices and strides were used to compute an offset for memref. This bug causes a segfault in the fused attention tutorial.