### PR TITLE
Add load/store scalarization through loops.

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3047,9 +3047,6 @@ def test_permute(dtype_str, shape, perm, num_ctas, device):
     check_type_supported(dtype_str, device)  # bfloat16 on cc < 80 will not be tested
     if is_hip() and shape == (128, 128) and dtype_str == 'float32':
         pytest.skip("TODO Out of LDS for float32 with shape 128x128")
-    if is_cpu():
-        # FIXME: compilation time for big shapes is too long
-        shape = tuple(dim // 4 for dim in shape)
 
     # triton kernel
     @triton.jit

--- a/test/TritonCPU/convert-memory-ops.mlir
+++ b/test/TritonCPU/convert-memory-ops.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file -triton-cpu-convert-memory-ops | FileCheck %s
+// RUN: triton-opt %s -split-input-file -triton-cpu-convert-memory-ops=use-scalar-loops=false | FileCheck %s
 
 // Convert strided masked loads to scalar loads.
 

--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -96,7 +96,7 @@ class CPUBackend(BaseBackend):
         # TTIR -> TTCIR
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
-        cpu.passes.ttcpuir.add_convert_memory_ops(pm)
+        cpu.passes.ttcpuir.add_convert_memory_ops(pm, True)
         cpu.passes.ttcpuir.add_convert_ptr_ops(pm)
         cpu.passes.ttcpuir.add_convert_elementwise_ops(pm)
         cpu.passes.ttcpuir.add_convert_elem_manip_ops(pm)

--- a/third_party/cpu/include/TritonToTritonCPU/Passes.h
+++ b/third_party/cpu/include/TritonToTritonCPU/Passes.h
@@ -21,6 +21,8 @@ namespace cpu {
 std::unique_ptr<OperationPass<ModuleOp>> createConvertElementwiseOps();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertElemManipOps();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertMemoryOps();
+std::unique_ptr<OperationPass<ModuleOp>>
+createConvertMemoryOps(bool useScalarLoops);
 std::unique_ptr<OperationPass<ModuleOp>> createConvertPtrOps();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertDotOp();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertControlFlowOps();

--- a/third_party/cpu/include/TritonToTritonCPU/Passes.td
+++ b/third_party/cpu/include/TritonToTritonCPU/Passes.td
@@ -10,6 +10,12 @@ def ConvertMemoryOps : Pass<"triton-cpu-convert-memory-ops", "mlir::ModuleOp"> {
     }];
     let constructor = "mlir::triton::cpu::createConvertMemoryOps()";
 
+    let options = [
+        Option<"useScalarLoops", "use-scalar-loops",
+               "bool", /*default*/"true",
+               "Enable lowering of tensor loads and stores to scalar loops.">,
+    ];
+
     let dependentDialects = ["mlir::arith::ArithDialect",
                              "mlir::memref::MemRefDialect",
                              "mlir::vector::VectorDialect",

--- a/third_party/cpu/triton_cpu.cc
+++ b/third_party/cpu/triton_cpu.cc
@@ -24,9 +24,10 @@ namespace py = pybind11;
 
 void init_triton_cpu_passes_ttcpuir(py::module &&m) {
   using namespace mlir::triton;
-  m.def("add_convert_memory_ops", [](mlir::PassManager &pm) {
-    pm.addPass(mlir::triton::cpu::createConvertMemoryOps());
-  });
+  m.def("add_convert_memory_ops",
+        [](mlir::PassManager &pm, bool useScalarLoops) {
+          pm.addPass(mlir::triton::cpu::createConvertMemoryOps(useScalarLoops));
+        });
   m.def("add_convert_ptr_ops", [](mlir::PassManager &pm) {
     pm.addPass(mlir::triton::cpu::createConvertPtrOps());
   });


### PR DESCRIPTION
Currently, if we cannot detect contiguous memory access, we generate a sequence of scalar operations. In some cases, it might produce a lot of codes and cause a really long compilation. E.g. we use reduced input size in `test_permute` because of this problem.

This patch adds an option to generate scalar loops for such loads and stores. It helps to significantly reduce compilation time for scalarized loads/stores for big tensor sizes. We can now run the permute test with the original input size in a few seconds compared to several minutes when loops are not used.

Here is a store loop generated for perm_test:
```
    %alloca = memref.alloca() {alignment = 64 : i64} : memref<128x128xf32> loc(#loc4)
    vector.transfer_write %765, %alloca[%c0, %c0] {in_bounds = [true, true]} : vector<128x128xf32>, memref<128x128xf32> loc(#loc4)
    scf.for %arg4 = %c0 to %c128 step %c1 {
      scf.for %arg5 = %c0 to %c128 step %c1 {
        %766 = arith.index_castui %arg4 : index to i32 loc(#loc7)
        %767 = tt.addptr %arg2, %766 : !tt.ptr<f32>, i32 loc(#loc8)
        %768 = arith.index_castui %arg5 : index to i32 loc(#loc7)
        %769 = arith.muli %768, %arg3 : i32 loc(#loc9)
        %770 = tt.addptr %767, %769 : !tt.ptr<f32>, i32 loc(#loc10)
        %771 = memref.load %alloca[%arg4, %arg5] : memref<128x128xf32> loc(#loc4)
        tt.store %770, %771 : !tt.ptr<f32> loc(#loc6)
      } loc(#loc6)
    } loc(#loc6)
```
Here is the corresponding ASM code:
```
.LBB0_1:
        movslq  %eax, %rsi
        leaq    (%r9,%rsi,4), %rsi
        xorl    %edi, %edi
        xorl    %r8d, %r8d
.LBB0_2:
        movslq  %edi, %rdi
        vmovss  (%rdx,%r8,4), %xmm0
        vmovss  %xmm0, (%rsi,%rdi,4)
        incq    %r8
        addl    %ecx, %edi
        cmpq    $128, %r8
        jne     .LBB0_2
        incq    %rax
        addq    $512, %rdx
        cmpq    $128, %rax
        jne     .LBB0_1
```

Right now, it's done in memory op conversion pass. But I think we should introduce a more generic scalarization pass that would work on TTIR before transitioning to vectors. The goal of the pass would be to find operations that cannot be vectorized and generate scalar loops.

This patch should resolve #86 