### PR TITLE
[Scalarization/Loops generation] Refactor and new pass/interfaces introduced

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -16,6 +16,7 @@
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 
+#include "cpu/include/ScalarizePass/ScalarizeInterfaceImpl.h"
 #include "cpu/include/TritonCPUToLLVM/Passes.h"
 #include "cpu/include/TritonCPUTransforms/Passes.h"
 #include "cpu/include/TritonToTritonCPU/Passes.h"
@@ -72,6 +73,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::triton::cpu::registerTritonToTritonCPUPasses();
   mlir::triton::cpu::registerTritonCPUTransformsPasses();
   mlir::triton::cpu::registerTritonCPUToLLVMPasses();
+  mlir::triton::cpu::registerTritonOpScalarizeExternalModels(registry);
 
   // TODO: register Triton & TritonGPU passes
   registry.insert<mlir::triton::TritonDialect, mlir::cf::ControlFlowDialect,

--- a/include/triton/Dialect/TritonCPU/IR/TritonCPUOps.td
+++ b/include/triton/Dialect/TritonCPU/IR/TritonCPUOps.td
@@ -78,6 +78,41 @@ def TTC_PtrToMemRefOp : TTC_Op<"ptr_to_memref", [NoMemoryEffect]> {
 
 def GlobalMemory : Resource<"::mlir::triton::GlobalMemory">;
 
+
+def TTC_LoadOp : TTC_Op<"load", [
+  MemoryEffects<[MemRead<GlobalMemory>]>,
+]> {
+  let summary = "Load from a memref to triton tensor";
+
+  let description = [{
+    Operation to allow load from allocated temporary buffer to triton tensor.
+  }];
+
+  let arguments = (ins AnyMemRef:$src);
+
+  let results = (outs TT_Type:$result);
+
+  let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
+}
+
+def TTC_StoreOp : TTC_Op<"store", [
+  MemoryEffects<[MemWrite<GlobalMemory>]>,
+]> {
+  let summary = "Store triton tensor to memref";
+
+  let description = [{
+    Operation to allow store triton tensor to allocated temporary buffer.
+  }];
+
+  let arguments = (
+    ins
+    TT_Type:$src,
+    AnyMemRef:$dst
+  );
+
+  let assemblyFormat = "$src `,` $dst attr-dict `:` type($src) `,` type($dst)";
+}
+
 def TTC_PrintOp : TTC_Op<"print", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
   let summary = "Print at most a single scalar or vector (converted from tensor) on each line";
 
@@ -100,7 +135,7 @@ def TTC_PrintOp : TTC_Op<"print", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
   let hasVerifier = 1;
 }
 
-def TT_AssertOp : TTC_Op<"assert", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+def TTC_AssertOp : TTC_Op<"assert", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
   let summary = "For correctness checking";
   let description = [{
     Takes a condition tensor, a message string, a file string, a function string, and a line number.

--- a/test/TritonCPU/convert-memory-ops.mlir
+++ b/test/TritonCPU/convert-memory-ops.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file -triton-cpu-convert-memory-ops=use-scalar-loops=false | FileCheck %s
+// RUN: triton-opt %s -split-input-file -triton-cpu-convert-memory-ops | FileCheck %s
 
 // Convert strided masked loads to scalar loads.
 

--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -122,7 +122,8 @@ class CPUBackend(BaseBackend):
         # TTIR -> TTCIR
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
-        cpu.passes.ttcpuir.add_convert_memory_ops(pm, True)
+        cpu.passes.ttcpuir.add_scalarize(pm)
+        cpu.passes.ttcpuir.add_convert_memory_ops(pm)
         cpu.passes.ttcpuir.add_convert_ptr_ops(pm)
         cpu.passes.ttcpuir.add_convert_elementwise_ops(pm)
         cpu.passes.ttcpuir.add_convert_elem_manip_ops(pm)

--- a/third_party/cpu/include/CMakeLists.txt
+++ b/third_party/cpu/include/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(ScalarizePass)
 add_subdirectory(TritonCPUToLLVM)
 add_subdirectory(TritonCPUTransforms)
 add_subdirectory(TritonToTritonCPU)

--- a/third_party/cpu/include/ScalarizePass/CMakeLists.txt
+++ b/third_party/cpu/include/ScalarizePass/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_mlir_interface(ScalarizeInterface)

--- a/third_party/cpu/include/ScalarizePass/ScalarizeInterface.h
+++ b/third_party/cpu/include/ScalarizePass/ScalarizeInterface.h
@@ -1,0 +1,33 @@
+#ifndef MLIR_INTERFACES_SCALARIZE_INTERFACE_H_
+#define MLIR_INTERFACES_SCALARIZE_INTERFACE_H_
+
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Support/LLVM.h"
+
+#include "mlir/IR/OpDefinition.h"
+
+/// Include the ODS generated interface header files.
+#include "cpu/include/ScalarizePass/ScalarizeInterface.h.inc"
+
+namespace mlir {
+namespace triton {
+namespace cpu {
+
+mlir::Value computeScalarValue(mlir::Operation *scalarizationOp,
+                               mlir::Value vals,
+                               mlir::ArrayRef<int64_t> indices,
+                               mlir::PatternRewriter &rewriter);
+
+mlir::Value computeScalarValue(mlir::Operation *scalarizationOp,
+                               mlir::Value vals, mlir::ValueRange indices,
+                               mlir::PatternRewriter &rewriter);
+
+bool canComputeScalarValue(mlir::Value vals);
+} // namespace cpu
+} // namespace triton
+} // namespace mlir
+
+#endif // MLIR_INTERFACES_SCALARIZE_INTERFACE_H_

--- a/third_party/cpu/include/ScalarizePass/ScalarizeInterface.td
+++ b/third_party/cpu/include/ScalarizePass/ScalarizeInterface.td
@@ -1,0 +1,52 @@
+#ifndef MLIR_SCALARIZEINTERFACE
+#define MLIR_SCALARIZEINTERFACE
+
+include "mlir/IR/OpBase.td"
+
+def ScalarizeInterface : OpInterface<"ScalarizeInterface"> {
+  let description = [{
+    Interface for allowing operations to expose information needed to
+    scalarize them or in simpler terms inserts SCF loops to reduce amount of
+    generated ir. Similar with checking operands of specific operations for
+    constancy - to understand is it possible to put it inside of loop's body.
+  }];
+  let cppNamespace = "mlir::triton::cpu";
+  let methods = [
+      InterfaceMethod<
+        /*desc=*/[{
+          Checks operand and is ScalarizeInterface registered for this operation.
+        }],
+        /*retType=*/"bool",
+        /*methodName=*/"canComputeScalarValue",
+        /*args=*/(ins
+          "mlir::Value ":$vals)
+      >,
+      InterfaceMethod<
+        /*desc=*/[{
+          Returns value that can be  put inside of generated cycle and creates required constants.
+          Can go throught operands to check type of passed values. Implementation for static indeces.
+        }],
+        /*retType=*/"mlir::Value",
+        /*methodName=*/"computeScalarValue",
+        /*args=*/(ins
+          "mlir::Value ":$vals,
+          "mlir::ArrayRef<int64_t>  ":$indices,
+          "mlir::PatternRewriter &":$rewriter)
+      >,
+      InterfaceMethod<
+        /*desc=*/[{
+          Returns value that can be  put inside of generated cycle and creates required constants.
+          Can go throught operands to check type of passed values. Implementation for dynamic indices
+          which is in common used in loops to iterate with Inductional Variable.
+        }],
+        /*retType=*/"mlir::Value",
+        /*methodName=*/"computeScalarValueForLoop",
+        /*args=*/(ins
+          "mlir::Value ":$vals,
+          "mlir::ValueRange  ":$indices,
+          "mlir::PatternRewriter &":$rewriter)
+      >
+  ];
+}
+
+#endif // MLIR_SCALARIZEINTERFACE

--- a/third_party/cpu/include/ScalarizePass/ScalarizeInterfaceImpl.h
+++ b/third_party/cpu/include/ScalarizePass/ScalarizeInterfaceImpl.h
@@ -1,0 +1,16 @@
+#ifndef MLIR_DIALECT_TRITON_SCALARIZEINTERFACEIMPL_H
+#define MLIR_DIALECT_TRITON_SCALARIZEINTERFACEIMPL_H
+
+namespace mlir {
+class DialectRegistry;
+
+namespace triton {
+namespace cpu {
+
+void registerTritonOpScalarizeExternalModels(DialectRegistry &registry);
+
+} // namespace cpu
+} // namespace triton
+} // namespace mlir
+
+#endif // MLIR_DIALECT_TRITON_SCALARIZEINTERFACEIMPL_H

--- a/third_party/cpu/include/TritonToTritonCPU/Passes.h
+++ b/third_party/cpu/include/TritonToTritonCPU/Passes.h
@@ -4,6 +4,8 @@
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "triton/Analysis/AxisInfo.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 #include <memory>
 
@@ -21,8 +23,6 @@ namespace cpu {
 std::unique_ptr<OperationPass<ModuleOp>> createConvertElementwiseOps();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertElemManipOps();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertMemoryOps();
-std::unique_ptr<OperationPass<ModuleOp>>
-createConvertMemoryOps(bool useScalarLoops);
 std::unique_ptr<OperationPass<ModuleOp>> createConvertPtrOps();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertDotOp();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertControlFlowOps();
@@ -34,8 +34,55 @@ std::unique_ptr<OperationPass<ModuleOp>> createConvertScanOp();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertAtomicOps();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertDebugOps();
 
+std::unique_ptr<OperationPass<ModuleOp>> createScalarizeUsingForOpPass();
+
 #define GEN_PASS_REGISTRATION
 #include "cpu/include/TritonToTritonCPU/Passes.h.inc"
+
+template <typename T, typename... Ts>
+constexpr bool is_one_of_v = (std::is_same_v<T, Ts> || ...);
+
+template <class OpTy>
+constexpr bool is_memory_op_v =
+    is_one_of_v<OpTy, triton::LoadOp, triton::StoreOp>;
+
+inline mlir::Type getMemoryOpType(triton::LoadOp operation) {
+  return operation.getType();
+}
+
+inline mlir::Type getMemoryOpType(triton::StoreOp operation) {
+  return operation.getValue().getType();
+}
+
+inline ArrayRef<int64_t> getShape(mlir::Type type) {
+  return llvm::TypeSwitch<Type, ArrayRef<int64_t>>(type)
+      .Case([](ShapedType t) { return t.getShape(); })
+      .Case([](RankedTensorType t) { return t.getShape(); })
+      .Default([](Type t) {
+        llvm::errs() << "Attempt to getShape from unknow type: " << t << "\n";
+        llvm_unreachable("Unsupported type in getShape");
+        return ArrayRef<int64_t>();
+      });
+}
+
+inline bool hasShape(mlir::Type type) {
+  return isa<ShapedType, RankedTensorType>(type);
+}
+
+template <class OpTy,
+          typename std::enable_if_t<is_memory_op_v<OpTy>, bool> = true>
+bool isContiguousRowMajorAccess(AxisInfo *axisInfo, OpTy op) {
+  if (!axisInfo)
+    return false;
+
+  mlir::Type type = getMemoryOpType(op);
+  if (!hasShape(type)) {
+    return false;
+  }
+  auto shape = getShape(type);
+  auto contiguity = axisInfo->getContiguity();
+  return (shape.back() > 1 && shape.back() == contiguity.back());
+}
 
 } // namespace cpu
 } // namespace triton

--- a/third_party/cpu/include/TritonToTritonCPU/Passes.td
+++ b/third_party/cpu/include/TritonToTritonCPU/Passes.td
@@ -10,12 +10,6 @@ def ConvertMemoryOps : Pass<"triton-cpu-convert-memory-ops", "mlir::ModuleOp"> {
     }];
     let constructor = "mlir::triton::cpu::createConvertMemoryOps()";
 
-    let options = [
-        Option<"useScalarLoops", "use-scalar-loops",
-               "bool", /*default*/"true",
-               "Enable lowering of tensor loads and stores to scalar loops.">,
-    ];
-
     let dependentDialects = ["mlir::arith::ArithDialect",
                              "mlir::memref::MemRefDialect",
                              "mlir::vector::VectorDialect",
@@ -170,5 +164,21 @@ def ConvertDebugOps : Pass<"triton-cpu-convert-debug-ops", "mlir::ModuleOp"> {
                              "mlir::triton::TritonDialect",
                              "mlir::triton::cpu::TritonCPUDialect"];
 }
+
+def ScalarizeUsingForOp : Pass<"triton-cpu-scalarize", "mlir::ModuleOp"> {
+    let summary = "Insert Loops for ops, that are not vectorizable";
+    let description = [{
+        This pass is used to reduce compile time by generating loops for
+        operations that cannot be handled as vectors, and simply increases
+        the amount of IR without any further optimization.
+    }];
+
+    let constructor = "mlir::triton::cpu::createScalarizeUsingForOpPass()";
+
+    let dependentDialects = ["mlir::arith::ArithDialect",
+                             "mlir::triton::TritonDialect",
+                             "mlir::triton::cpu::TritonCPUDialect"];
+}
+
 
 #endif

--- a/third_party/cpu/lib/TritonToTritonCPU/CMakeLists.txt
+++ b/third_party/cpu/lib/TritonToTritonCPU/CMakeLists.txt
@@ -6,6 +6,8 @@ add_triton_library(TritonToTritonCPU
     ConvertElementwiseOps.cpp
     ConvertElemManipOps.cpp
     ConvertHistogramOp.cpp
+    ScalarizeInterface.cpp
+    ScalarizeUsingForOps.cpp
     ConvertMemoryOps.cpp
     ConvertPtrOps.cpp
     ConvertReductionOp.cpp
@@ -14,6 +16,8 @@ add_triton_library(TritonToTritonCPU
 
     DEPENDS
     TritonToTritonCPUPassIncGen
+    MLIRScalarizeInterfaceIncGen
+    MLIRDialectUtils
 
     LINK_LIBS PUBLIC
     TritonCPUIR

--- a/third_party/cpu/lib/TritonToTritonCPU/ConvertMemoryOps.cpp
+++ b/third_party/cpu/lib/TritonToTritonCPU/ConvertMemoryOps.cpp
@@ -20,6 +20,8 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonCPU/IR/Dialect.h"
 
+#include "cpu/include/ScalarizePass/ScalarizeInterface.h"
+
 namespace mlir {
 namespace triton {
 namespace cpu {
@@ -43,11 +45,9 @@ struct MemoryOpConversion : public OpConversionPattern<OpT> {
 
   MemoryOpConversion(ModuleAxisInfoAnalysis &axisInfoAnalysis,
                      ModuleTensorPtrShapeInfoAnalysis &shapeInfoAnalysis,
-                     TypeConverter &typeConverter, bool useScalarLoops,
-                     MLIRContext *context)
+                     TypeConverter &typeConverter, MLIRContext *context)
       : OpConversionPattern<OpT>(typeConverter, context),
-        axisAnalysis(axisInfoAnalysis), shapeAnalysis(shapeInfoAnalysis),
-        genScalarLoops(useScalarLoops) {}
+        axisAnalysis(axisInfoAnalysis), shapeAnalysis(shapeInfoAnalysis) {}
 
   Value extractScalarPointer(Location loc, Value ptrs,
                              ArrayRef<int64_t> indices,
@@ -56,8 +56,9 @@ struct MemoryOpConversion : public OpConversionPattern<OpT> {
     // compiler doesn't always optimize it to a simple scalar pointer
     // computation. Here we try to follow a data flow of the tensor to rebuild a
     // scalar pointer for more efficient resulting code.
-    if (canComputeScalarValue(ptrs))
-      return computeScalarValue(ptrs, indices, rewriter);
+    if (canComputeScalarValue(ptrs)) {
+      return computeScalarValue(ptrs.getDefiningOp(), ptrs, indices, rewriter);
+    }
 
     // Fall back to a scalar pointer extraction from the vector.
     Value ptr = rewriter.create<vector::ExtractOp>(
@@ -65,206 +66,6 @@ struct MemoryOpConversion : public OpConversionPattern<OpT> {
     auto ptrTy = dyn_cast<RankedTensorType>(ptrs.getType()).getElementType();
     ptr = rewriter.create<IntToPtrOp>(loc, ptrTy, ptr);
     return ptr;
-  }
-
-  bool canComputeScalarValue(Value vals) const {
-    auto def = vals.getDefiningOp();
-    if (!def)
-      return false;
-
-    if (isa<AddPtrOp, BroadcastOp, ExpandDimsOp, TransOp, arith::AddFOp,
-            arith::AddIOp, arith::CmpFOp, arith::CmpIOp, arith::DivFOp,
-            arith::DivSIOp, arith::MulIOp, arith::MulFOp, arith::RemFOp,
-            arith::RemUIOp, arith::RemSIOp>(*def)) {
-      for (auto op : def->getOperands()) {
-        if (!canComputeScalarValue(op))
-          return false;
-      }
-      return true;
-    }
-
-    if (isa<SplatOp, MakeRangeOp>(*def))
-      return true;
-
-    if (auto cst = dyn_cast<arith::ConstantOp>(def)) {
-      if (auto denseVal = dyn_cast<DenseElementsAttr>(cst.getValue())) {
-        return denseVal.isSplat();
-      }
-      return false;
-    }
-
-    return false;
-  }
-
-  Value computeScalarValue(Value vals, ArrayRef<int64_t> indices,
-                           ConversionPatternRewriter &rewriter) const {
-    if (auto def = vals.getDefiningOp<SplatOp>()) {
-      return def.getSrc();
-    }
-
-    if (auto def = vals.getDefiningOp<MakeRangeOp>()) {
-      int32_t start = static_cast<int32_t>(def.getStart());
-      assert(indices.size() == 1);
-      Type elemTy = cast<RankedTensorType>(def.getType()).getElementType();
-      return rewriter.create<arith::ConstantOp>(
-          def.getLoc(), elemTy,
-          rewriter.getIntegerAttr(elemTy, start + indices[0]));
-    }
-
-    if (auto def = vals.getDefiningOp<BroadcastOp>()) {
-      // Find broadcasted dimensions and replace indices for those dimensions
-      // with 0 (broadcasted dimension always has size 1).
-      SmallVector<int64_t> newIndices;
-      auto sourceTy = cast<RankedTensorType>(def.getSrc().getType());
-      auto targetTy = cast<RankedTensorType>(def.getType());
-      assert(sourceTy.getRank() == indices.size() && "Mismatched rank");
-      for (int64_t i = 0; i < sourceTy.getRank(); ++i) {
-        if (sourceTy.getShape()[i] != targetTy.getShape()[i])
-          newIndices.push_back(0);
-        else
-          newIndices.push_back(indices[i]);
-      }
-      return computeScalarValue(def.getSrc(), newIndices, rewriter);
-    }
-
-    if (auto def = vals.getDefiningOp<ExpandDimsOp>()) {
-      // Remove index at expanded dimension.
-      SmallVector<int64_t> newIndices(indices);
-      newIndices.erase(newIndices.begin() + def.getAxis());
-      return computeScalarValue(def.getSrc(), newIndices, rewriter);
-    }
-
-    if (auto def = vals.getDefiningOp<arith::ConstantOp>()) {
-      auto denseVal = cast<DenseElementsAttr>(def.getValue());
-      assert(denseVal.isSplat());
-      auto scalarAttr = denseVal.getSplatValue<TypedAttr>();
-      Value res = rewriter.create<arith::ConstantOp>(
-          def.getLoc(), scalarAttr.getType(), scalarAttr);
-      return res;
-    }
-
-    if (auto def = vals.getDefiningOp<TransOp>()) {
-      // Permute indices.
-      SmallVector<int64_t> newIndices;
-      auto order = def.getOrder();
-      assert(indices.size() == order.size() && "Mismatched rank");
-      for (auto idx : order)
-        newIndices.push_back(indices[idx]);
-      return computeScalarValue(def.getSrc(), newIndices, rewriter);
-    }
-
-    // Generic case where we copy defining op with scalar operands.
-    auto def = vals.getDefiningOp();
-    OperationState newState(def->getLoc(), def->getName());
-    for (auto op : def->getOperands()) {
-      newState.operands.push_back(computeScalarValue(op, indices, rewriter));
-    }
-    assert(def->getResults().size() == 1);
-    newState.types.push_back(
-        cast<ShapedType>(def->getResultTypes()[0]).getElementType());
-    newState.attributes = def->getAttrs();
-    return rewriter.create(newState)->getResult(0);
-  }
-
-  Value computeScalarValue(Value vals, ValueRange indices,
-                           ConversionPatternRewriter &rewriter,
-                           DenseMap<Value, Value> &valMap) const {
-    if (valMap.count(vals))
-      return valMap.at(vals);
-
-    if (auto def = vals.getDefiningOp<SplatOp>()) {
-      return def.getSrc();
-    }
-
-    if (auto def = vals.getDefiningOp<arith::ConstantOp>()) {
-      auto denseVal = cast<DenseElementsAttr>(def.getValue());
-      assert(denseVal.isSplat());
-      auto scalarAttr = denseVal.getSplatValue<TypedAttr>();
-      Value res = rewriter.create<arith::ConstantOp>(
-          def.getLoc(), scalarAttr.getType(), scalarAttr);
-      valMap[vals] = res;
-      return res;
-    }
-
-    if (auto def = vals.getDefiningOp<MakeRangeOp>()) {
-      assert(indices.size() == 1);
-      int32_t start = static_cast<int32_t>(def.getStart());
-      Type elemTy = cast<RankedTensorType>(def.getType()).getElementType();
-      Value startVal = rewriter.create<arith::ConstantOp>(
-          def.getLoc(), elemTy, rewriter.getIntegerAttr(elemTy, start));
-      Value index = indices[0];
-      if (!elemTy.isIndex())
-        index =
-            rewriter.create<arith::IndexCastUIOp>(def.getLoc(), elemTy, index);
-      Value res =
-          rewriter.create<arith::AddIOp>(def.getLoc(), elemTy, startVal, index);
-      valMap[vals] = res;
-      return res;
-    }
-
-    if (auto def = vals.getDefiningOp<BroadcastOp>()) {
-      // Find broadcasted dimensions and replace indices for those dimensions
-      // with 0 (broadcasted dimension has always size 1).
-      SmallVector<Value> newIndices;
-      auto sourceTy = cast<RankedTensorType>(def.getSrc().getType());
-      auto targetTy = cast<RankedTensorType>(def.getType());
-      assert(sourceTy.getRank() == indices.size() && "Mismatched rank");
-      for (int64_t i = 0; i < sourceTy.getRank(); ++i) {
-        if (sourceTy.getShape()[i] != targetTy.getShape()[i])
-          newIndices.push_back(
-              rewriter.create<arith::ConstantIndexOp>(def.getLoc(), 0));
-        else
-          newIndices.push_back(indices[i]);
-      }
-      // The original cache is only used for the original set of indices.
-      DenseMap<Value, Value> tmpValMap;
-      Value res =
-          computeScalarValue(def.getSrc(), newIndices, rewriter, tmpValMap);
-      valMap[vals] = res;
-      return res;
-    }
-
-    if (auto def = vals.getDefiningOp<ExpandDimsOp>()) {
-      // Remove index at expanded dimension.
-      SmallVector<Value> newIndices = indices;
-      newIndices.erase(newIndices.begin() + def.getAxis());
-      // The original cache is only used for the original set of indices.
-      DenseMap<Value, Value> tmpValMap;
-      Value res =
-          computeScalarValue(def.getSrc(), newIndices, rewriter, tmpValMap);
-      valMap[vals] = res;
-      return res;
-    }
-
-    if (auto def = vals.getDefiningOp<TransOp>()) {
-      // Permute indices.
-      SmallVector<Value> newIndices;
-      auto order = def.getOrder();
-      assert(indices.size() == order.size() && "Mismatched rank");
-      for (auto idx : order)
-        newIndices.push_back(indices[idx]);
-      // The original cache is only used for the original set of indices.
-      DenseMap<Value, Value> tmpValMap;
-      Value res =
-          computeScalarValue(def.getSrc(), newIndices, rewriter, tmpValMap);
-      valMap[vals] = res;
-      return res;
-    }
-
-    // Generic case where we copy defining op with scalar operands.
-    auto def = vals.getDefiningOp();
-    OperationState newState(def->getLoc(), def->getName());
-    for (auto op : def->getOperands()) {
-      newState.operands.push_back(
-          computeScalarValue(op, indices, rewriter, valMap));
-    }
-    assert(def->getResults().size() == 1);
-    newState.types.push_back(
-        cast<ShapedType>(def->getResultTypes()[0]).getElementType());
-    newState.attributes = def->getAttrs();
-    Value res = rewriter.create(newState)->getResult(0);
-    valMap[vals] = res;
-    return res;
   }
 
   Value extractMemRef(Location loc, Value ptr,
@@ -333,215 +134,9 @@ struct MemoryOpConversion : public OpConversionPattern<OpT> {
     return memRef;
   }
 
-  // Load scalar element from a temporary buffer or recompute it if the
-  // buffer doesn't exist.
-  Value computeOrLoadScalarValue(Value vals, Value tmpVals, ValueRange indices,
-                                 ConversionPatternRewriter &rewriter,
-                                 DenseMap<Value, Value> &valMap) const {
-    // Allow null value for easier handling of optional arguments.
-    if (!vals)
-      return nullptr;
-
-    // Load value from a temp buffer if any.
-    if (tmpVals) {
-      Value val =
-          rewriter.create<memref::LoadOp>(vals.getLoc(), tmpVals, indices);
-      // If we load a pointer then additional cast is needed because tensor of
-      // pointers is transformed into a vector of integers.
-      auto elemTy = dyn_cast<RankedTensorType>(vals.getType()).getElementType();
-      if (isa<PointerType>(elemTy))
-        val = rewriter.create<IntToPtrOp>(vals.getLoc(), elemTy, val);
-      // We need to transform loaded i8 back to i1.
-      else if (elemTy.isInteger(1))
-        val = rewriter.create<arith::TruncIOp>(val.getLoc(),
-                                               rewriter.getI1Type(), val);
-      return val;
-    }
-
-    return computeScalarValue(vals, indices, rewriter, valMap);
-  }
-
-  LogicalResult scalarizeWithLoop(triton::LoadOp loadOp,
-                                  ConversionPatternRewriter &rewriter) const {
-    auto loc = loadOp.getLoc();
-    auto vecTy =
-        dyn_cast<VectorType>(getTypeConverter()->convertType(loadOp.getType()));
-
-    auto ptrs = loadOp.getPtr();
-    auto mask = loadOp.getMask();
-    auto other = loadOp.getOther();
-    auto cache = loadOp.getCache();
-    auto evict = loadOp.getEvict();
-    auto isVolatile = loadOp.getIsVolatile();
-
-    // Create some reused constants.
-    Value zeroIdx = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value oneIdx = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-
-    // There is alloca_scope operation to control alloca scopes. But its usage
-    // in combination with nested SCF and multi-dimensional vectors make it
-    // impossible to lower scopes to LLVM using existing MLIR passes. For now,
-    // simply allocate temp memory in the function's region.
-    // TODO: Use alloc for big buffers and revisit alloca scoping.
-    Operation *allocaPoint = loadOp;
-    while (!isa<triton::FuncOp>(allocaPoint->getParentOp()))
-      allocaPoint = allocaPoint->getParentOp();
-
-    // Allocate temp buffer for the result. Write the other value there if
-    // we cannot write it in a loop.
-    auto resMemRefTy =
-        MemRefType::get(vecTy.getShape(), vecTy.getElementType());
-    Value resMemRef = createAlloca(loc, resMemRefTy, allocaPoint, rewriter);
-    bool storeOtherInLoop = static_cast<bool>(mask);
-    if (other && !canComputeScalarValue(other)) {
-      SmallVector<Value> indices(vecTy.getRank(), zeroIdx);
-      rewriter.create<vector::TransferWriteOp>(
-          loc, rewriter.getRemappedValue(other), resMemRef, indices);
-      storeOtherInLoop = false;
-    }
-
-    // Store a tensor of pointers and mask into a temp buf if we can't
-    // compute them in a loop.
-    Value tmpPtrs =
-        maybeStoreVecToTempBuf(loc, ptrs, zeroIdx, allocaPoint, rewriter);
-    Value tmpMask =
-        maybeStoreVecToTempBuf(loc, mask, zeroIdx, allocaPoint, rewriter);
-
-    // Create for-loops to iterate through all vector dimensions.
-    SmallVector<scf::ForOp> forOps;
-    SmallVector<Value> ivs;
-    for (int64_t i = 0; i < vecTy.getRank(); ++i) {
-      Value upperBound =
-          rewriter.create<arith::ConstantIndexOp>(loc, vecTy.getShape()[i]);
-      auto forOp =
-          rewriter.create<scf::ForOp>(loc, zeroIdx, upperBound, oneIdx);
-      forOps.push_back(forOp);
-      ivs.push_back(forOp.getInductionVar());
-      rewriter.setInsertionPointToStart(forOp.getBody());
-    }
-
-    // Compute or load a scalar arguments.
-    DenseMap<Value, Value> valMap;
-    Value scalarPtr =
-        computeOrLoadScalarValue(ptrs, tmpPtrs, ivs, rewriter, valMap);
-    Value scalarMask =
-        computeOrLoadScalarValue(mask, tmpMask, ivs, rewriter, valMap);
-    Value scalarOther;
-    if (storeOtherInLoop) {
-      if (other) {
-        scalarOther = computeScalarValue(other, ivs, rewriter, valMap);
-      } else {
-        scalarOther = rewriter.create<arith::ConstantOp>(
-            loc, vecTy.getElementType(),
-            rewriter.getZeroAttr(vecTy.getElementType()));
-      }
-    }
-
-    if (!mask) {
-      // Regular load case.
-      Value val = rewriter.create<triton::LoadOp>(loc, scalarPtr, cache, evict,
-                                                  isVolatile);
-      rewriter.create<memref::StoreOp>(loc, val, resMemRef, ivs);
-    } else {
-      // Conditional load case
-      rewriter.create<scf::IfOp>(
-          loc, scalarMask,
-          [&](OpBuilder &builder, Location loc) {
-            Value val = builder.create<triton::LoadOp>(loc, scalarPtr, cache,
-                                                       evict, isVolatile);
-            builder.create<memref::StoreOp>(loc, val, resMemRef, ivs);
-            builder.create<scf::YieldOp>(loc);
-          },
-          [&](OpBuilder &builder, Location loc) {
-            if (storeOtherInLoop)
-              builder.create<memref::StoreOp>(loc, scalarOther, resMemRef, ivs);
-            builder.create<scf::YieldOp>(loc);
-          });
-    }
-
-    // Load vector from the temp storage and return it from alloca scope.
-    rewriter.setInsertionPointAfter(forOps.front());
-    SmallVector<Value> indices(vecTy.getRank(), zeroIdx);
-    Value res =
-        rewriter.create<vector::TransferReadOp>(loc, vecTy, resMemRef, indices);
-
-    rewriter.replaceOp(loadOp, res);
-    return success();
-  }
-
-  LogicalResult scalarizeWithLoop(triton::StoreOp storeOp,
-                                  ConversionPatternRewriter &rewriter) const {
-    auto loc = storeOp.getLoc();
-    auto vecTy = dyn_cast<VectorType>(
-        getTypeConverter()->convertType(storeOp.getValue().getType()));
-
-    auto ptrs = storeOp.getPtr();
-    auto mask = storeOp.getMask();
-    auto vals = storeOp.getValue();
-    auto cache = storeOp.getCache();
-    auto evict = storeOp.getEvict();
-
-    // Create some reused constants.
-    Value zeroIdx = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value oneIdx = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-
-    // Alloca is inserted similar to the load case.
-    Operation *allocaPoint = storeOp;
-    while (!isa<triton::FuncOp>(allocaPoint->getParentOp()))
-      allocaPoint = allocaPoint->getParentOp();
-
-    // Store a tensor of pointers, mask, and values into a temp buf if we can't
-    // compute them in a loop.
-    Value tmpPtrs =
-        maybeStoreVecToTempBuf(loc, ptrs, zeroIdx, allocaPoint, rewriter);
-    Value tmpMask =
-        maybeStoreVecToTempBuf(loc, mask, zeroIdx, allocaPoint, rewriter);
-    Value tmpVals =
-        maybeStoreVecToTempBuf(loc, vals, zeroIdx, allocaPoint, rewriter);
-
-    // Create for-loops to iterate through all vector dimensions.
-    SmallVector<scf::ForOp> forOps;
-    SmallVector<Value> ivs;
-    for (int64_t i = 0; i < vecTy.getRank(); ++i) {
-      Value upperBound =
-          rewriter.create<arith::ConstantIndexOp>(loc, vecTy.getShape()[i]);
-      auto forOp =
-          rewriter.create<scf::ForOp>(loc, zeroIdx, upperBound, oneIdx);
-      forOps.push_back(forOp);
-      ivs.push_back(forOp.getInductionVar());
-      rewriter.setInsertionPointToStart(forOp.getBody());
-    }
-
-    // Compute or load scalar args.
-    DenseMap<Value, Value> valMap;
-    Value scalarPtr =
-        computeOrLoadScalarValue(ptrs, tmpPtrs, ivs, rewriter, valMap);
-    Value scalarMask =
-        computeOrLoadScalarValue(mask, tmpMask, ivs, rewriter, valMap);
-    Value scalarVal =
-        computeOrLoadScalarValue(vals, tmpVals, ivs, rewriter, valMap);
-
-    if (!mask) {
-      // Regular store case.
-      rewriter.create<triton::StoreOp>(loc, scalarPtr, scalarVal, cache, evict);
-    } else {
-      // Conditional store case
-      rewriter.create<scf::IfOp>(loc, scalarMask,
-                                 [&](OpBuilder &builder, Location loc) {
-                                   builder.create<triton::StoreOp>(
-                                       loc, scalarPtr, scalarVal, cache, evict);
-                                   builder.create<scf::YieldOp>(loc);
-                                 });
-    }
-
-    rewriter.eraseOp(storeOp);
-    return success();
-  }
-
 protected:
   ModuleAxisInfoAnalysis &axisAnalysis;
   ModuleTensorPtrShapeInfoAnalysis &shapeAnalysis;
-  bool genScalarLoops;
 };
 
 struct LoadOpConversion : public MemoryOpConversion<triton::LoadOp> {
@@ -579,8 +174,8 @@ struct LoadOpConversion : public MemoryOpConversion<triton::LoadOp> {
 
     if (!triton::isTensorPointerType(ptr.getType())) {
       auto axisInfo = axisAnalysis.getAxisInfo(ptr);
-      if (axisInfo) {
-        return lowerUsingAxisInfo(axisInfo, loadOp, rewriter);
+      if (isContiguousRowMajorAccess(axisInfo, loadOp)) {
+        return lowerToContiguousRowMajor(loadOp, rewriter);
       }
       return lowerToScalarLoads(loadOp, rewriter);
     }
@@ -607,8 +202,9 @@ struct LoadOpConversion : public MemoryOpConversion<triton::LoadOp> {
     return success();
   }
 
-  LogicalResult lowerUsingAxisInfo(AxisInfo *axisInfo, triton::LoadOp loadOp,
-                                   ConversionPatternRewriter &rewriter) const {
+  LogicalResult
+  lowerToContiguousRowMajor(triton::LoadOp loadOp,
+                            ConversionPatternRewriter &rewriter) const {
     // This is an experimental code that covers only a simple case of axis info
     // usage to demostrate load by tensor of pointers transformation into vector
     // loads.
@@ -618,53 +214,47 @@ struct LoadOpConversion : public MemoryOpConversion<triton::LoadOp> {
     auto vecTy =
         dyn_cast<VectorType>(getTypeConverter()->convertType(loadOp.getType()));
     auto shape = vecTy.getShape();
-    auto contiguity = axisInfo->getContiguity();
-    if (shape.back() > 1 && shape.back() == contiguity.back()) {
-      auto strides = computeStrides(shape);
-      int64_t numElems = vecTy.getNumElements();
-      Type subVecTy = VectorType::get(shape.back(), vecTy.getElementType());
-      Type memRefTy = MemRefType::get(shape.back(), vecTy.getElementType());
-      Value mask = loadOp.getMask()
-                       ? rewriter.getRemappedValue(loadOp.getMask())
-                       : nullptr;
-      Value zeroIdx = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-      Value defaultVal = convertOtherVal(loadOp, rewriter);
-      Value res = defaultVal;
-      for (int64_t idx = 0; idx < numElems; idx += shape.back()) {
-        auto indices = delinearize(idx, strides);
-        SmallVector<int64_t> subIndices(indices.begin(),
-                                        indices.begin() + indices.size() - 1);
-        auto ptr =
-            extractScalarPointer(loc, loadOp.getPtr(), indices, rewriter);
-        Value memRef =
-            rewriter.create<triton::cpu::PtrToMemRefOp>(loc, memRefTy, ptr);
-        Value vec;
-        if (mask) {
-          Value subMask = mask;
-          Value passThru = defaultVal;
-          if (shape.size() > 1) {
-            subMask = rewriter.create<vector::ExtractOp>(loc, mask, subIndices);
-            passThru =
-                rewriter.create<vector::ExtractOp>(loc, defaultVal, subIndices);
-          }
-          vec = rewriter.create<vector::MaskedLoadOp>(
-              loc, subVecTy, memRef, zeroIdx, subMask, passThru);
-        } else {
-          vec = rewriter.create<vector::LoadOp>(loc, subVecTy, memRef, zeroIdx);
-        }
 
+    auto strides = computeStrides(shape);
+    int64_t numElems = vecTy.getNumElements();
+    Type subVecTy = VectorType::get(shape.back(), vecTy.getElementType());
+    Type memRefTy = MemRefType::get(shape.back(), vecTy.getElementType());
+    Value mask = loadOp.getMask() ? rewriter.getRemappedValue(loadOp.getMask())
+                                  : nullptr;
+    Value zeroIdx = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value defaultVal = convertOtherVal(loadOp, rewriter);
+    Value res = defaultVal;
+    for (int64_t idx = 0; idx < numElems; idx += shape.back()) {
+      auto indices = delinearize(idx, strides);
+      SmallVector<int64_t> subIndices(indices.begin(),
+                                      indices.begin() + indices.size() - 1);
+      auto ptr = extractScalarPointer(loc, loadOp.getPtr(), indices, rewriter);
+      Value memRef =
+          rewriter.create<triton::cpu::PtrToMemRefOp>(loc, memRefTy, ptr);
+      Value vec;
+      if (mask) {
+        Value subMask = mask;
+        Value passThru = defaultVal;
         if (shape.size() > 1) {
-          res = rewriter.create<vector::InsertOp>(loc, vec, res, subIndices);
-        } else {
-          res = vec;
+          subMask = rewriter.create<vector::ExtractOp>(loc, mask, subIndices);
+          passThru =
+              rewriter.create<vector::ExtractOp>(loc, defaultVal, subIndices);
         }
+        vec = rewriter.create<vector::MaskedLoadOp>(loc, subVecTy, memRef,
+                                                    zeroIdx, subMask, passThru);
+      } else {
+        vec = rewriter.create<vector::LoadOp>(loc, subVecTy, memRef, zeroIdx);
       }
 
-      rewriter.replaceOp(loadOp, res);
-      return success();
+      if (shape.size() > 1) {
+        res = rewriter.create<vector::InsertOp>(loc, vec, res, subIndices);
+      } else {
+        res = vec;
+      }
     }
 
-    return lowerToScalarLoads(loadOp, rewriter);
+    rewriter.replaceOp(loadOp, res);
+    return success();
   }
 
   LogicalResult lowerToScalarLoads(triton::LoadOp loadOp,
@@ -676,12 +266,6 @@ struct LoadOpConversion : public MemoryOpConversion<triton::LoadOp> {
     auto loc = loadOp.getLoc();
     auto vecTy =
         dyn_cast<VectorType>(getTypeConverter()->convertType(loadOp.getType()));
-
-    // We want to avoid a code explosion when scalarize loads of big vectors,
-    // so try to build a scalar loop.
-    if (genScalarLoops && vecTy.getNumElements() >= 16 &&
-        succeeded(scalarizeWithLoop(loadOp, rewriter)))
-      return success();
 
     auto ptrs = rewriter.getRemappedValue(loadOp.getPtr());
     auto mask = loadOp.getMask() ? rewriter.getRemappedValue(loadOp.getMask())
@@ -742,8 +326,8 @@ struct StoreOpConversion : public MemoryOpConversion<triton::StoreOp> {
 
     if (!triton::isTensorPointerType(ptr.getType())) {
       auto axisInfo = axisAnalysis.getAxisInfo(ptr);
-      if (axisInfo) {
-        return lowerUsingAxisInfo(axisInfo, storeOp, rewriter);
+      if (isContiguousRowMajorAccess(axisInfo, storeOp)) {
+        return lowerToContiguousRowMajor(storeOp, rewriter);
       }
       return lowerToScalarStores(storeOp, rewriter);
     }
@@ -767,8 +351,9 @@ struct StoreOpConversion : public MemoryOpConversion<triton::StoreOp> {
     return success();
   }
 
-  LogicalResult lowerUsingAxisInfo(AxisInfo *axisInfo, triton::StoreOp storeOp,
-                                   ConversionPatternRewriter &rewriter) const {
+  LogicalResult
+  lowerToContiguousRowMajor(triton::StoreOp storeOp,
+                            ConversionPatternRewriter &rewriter) const {
     // This is an experimental code that covers only a simple case of axis info
     // usage to demostrate load by tensor of pointers transformation into vector
     // loads.
@@ -778,44 +363,38 @@ struct StoreOpConversion : public MemoryOpConversion<triton::StoreOp> {
     auto vals = rewriter.getRemappedValue(storeOp.getValue());
     auto vecTy = dyn_cast<VectorType>(vals.getType());
     auto shape = vecTy.getShape();
-    auto contiguity = axisInfo->getContiguity();
-    if (shape.back() > 1 && shape.back() == contiguity.back()) {
-      auto strides = computeStrides(shape);
-      int64_t numElems = vecTy.getNumElements();
-      Type memRefTy = MemRefType::get(shape.back(), vecTy.getElementType());
-      Value mask = storeOp.getMask()
-                       ? rewriter.getRemappedValue(storeOp.getMask())
-                       : nullptr;
-      Value zeroIdx = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-      auto vals = rewriter.getRemappedValue(storeOp.getValue());
-      for (int64_t idx = 0; idx < numElems; idx += shape.back()) {
-        auto indices = delinearize(idx, strides);
-        auto ptr =
-            extractScalarPointer(loc, storeOp.getPtr(), indices, rewriter);
-        Value memRef =
-            rewriter.create<triton::cpu::PtrToMemRefOp>(loc, memRefTy, ptr);
-        indices.pop_back();
-        auto val = rewriter.create<vector::ExtractOp>(loc, vals, indices);
 
-        if (mask) {
-          Value subMask = mask;
-          if (shape.size() > 1) {
-            SmallVector<int64_t> subIndices = indices;
-            subIndices.pop_back();
-            subMask = rewriter.create<vector::ExtractOp>(loc, mask, indices);
-          }
-          rewriter.create<vector::MaskedStoreOp>(loc, memRef, zeroIdx, subMask,
-                                                 val);
-        } else {
-          rewriter.create<vector::StoreOp>(loc, val, memRef, zeroIdx);
+    auto strides = computeStrides(shape);
+    int64_t numElems = vecTy.getNumElements();
+    Type memRefTy = MemRefType::get(shape.back(), vecTy.getElementType());
+    Value mask = storeOp.getMask()
+                     ? rewriter.getRemappedValue(storeOp.getMask())
+                     : nullptr;
+    Value zeroIdx = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    for (int64_t idx = 0; idx < numElems; idx += shape.back()) {
+      auto indices = delinearize(idx, strides);
+      auto ptr = extractScalarPointer(loc, storeOp.getPtr(), indices, rewriter);
+      Value memRef =
+          rewriter.create<triton::cpu::PtrToMemRefOp>(loc, memRefTy, ptr);
+      indices.pop_back();
+      auto val = rewriter.create<vector::ExtractOp>(loc, vals, indices);
+
+      if (mask) {
+        Value subMask = mask;
+        if (shape.size() > 1) {
+          SmallVector<int64_t> subIndices = indices;
+          subIndices.pop_back();
+          subMask = rewriter.create<vector::ExtractOp>(loc, mask, indices);
         }
+        rewriter.create<vector::MaskedStoreOp>(loc, memRef, zeroIdx, subMask,
+                                               val);
+      } else {
+        rewriter.create<vector::StoreOp>(loc, val, memRef, zeroIdx);
       }
-
-      rewriter.eraseOp(storeOp);
-      return success();
     }
 
-    return lowerToScalarStores(storeOp, rewriter);
+    rewriter.eraseOp(storeOp);
+    return success();
   }
 
   LogicalResult lowerToScalarStores(triton::StoreOp storeOp,
@@ -826,12 +405,6 @@ struct StoreOpConversion : public MemoryOpConversion<triton::StoreOp> {
 
     auto loc = storeOp.getLoc();
     auto tensorTy = dyn_cast<RankedTensorType>(storeOp.getPtr().getType());
-
-    // We want to avoid a code explosion when scalarize stores of big vectors,
-    // so try to build a scalar loop.
-    if (genScalarLoops && tensorTy.getNumElements() >= 16 &&
-        succeeded(scalarizeWithLoop(storeOp, rewriter)))
-      return success();
 
     auto ptrs = rewriter.getRemappedValue(storeOp.getPtr());
     auto mask = storeOp.getMask() ? rewriter.getRemappedValue(storeOp.getMask())
@@ -871,6 +444,46 @@ struct StoreOpConversion : public MemoryOpConversion<triton::StoreOp> {
   }
 };
 
+struct CpuStoreOpConversion : public MemoryOpConversion<triton::cpu::StoreOp> {
+  using MemoryOpConversion::MemoryOpConversion;
+
+  LogicalResult
+  matchAndRewrite(triton::cpu::StoreOp storeOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = storeOp.getLoc();
+    auto value = rewriter.getRemappedValue(storeOp.getSrc());
+    auto memRef = storeOp.getDst();
+    auto rank = dyn_cast<MemRefType>(memRef.getType()).getRank();
+    Value zeroIdx = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    SmallVector<Value> indices(rank, zeroIdx);
+    auto vecWrite =
+        rewriter.create<vector::TransferWriteOp>(loc, value, memRef,
+                                                 indices); //, inBounds);
+    rewriter.replaceOp(storeOp, vecWrite);
+    return success();
+  }
+};
+
+struct CpuLoadOpConversion : public MemoryOpConversion<triton::cpu::LoadOp> {
+  using MemoryOpConversion::MemoryOpConversion;
+
+  LogicalResult
+  matchAndRewrite(triton::cpu::LoadOp loadOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = loadOp.getLoc();
+    auto memRef = loadOp.getSrc();
+    auto rank = dyn_cast<MemRefType>(memRef.getType()).getRank();
+    auto resTy = dyn_cast<VectorType>(
+        getTypeConverter()->convertType(loadOp.getResult().getType()));
+    Value zeroIdx = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    SmallVector<Value> indices(resTy.getRank(), zeroIdx);
+    auto vecRead =
+        rewriter.create<vector::TransferReadOp>(loc, resTy, memRef, indices);
+    rewriter.replaceOp(loadOp, vecRead);
+    return success();
+  }
+};
+
 class MemoryOpConversionTarget : public ConversionTarget {
 public:
   explicit MemoryOpConversionTarget(MLIRContext &ctx) : ConversionTarget(ctx) {
@@ -881,6 +494,8 @@ public:
     addLegalDialect<TritonDialect>();
     addLegalDialect<TritonCPUDialect>();
     addLegalOp<mlir::UnrealizedConversionCastOp>();
+
+    addIllegalOp<mlir::triton::cpu::StoreOp, mlir::triton::cpu::LoadOp>();
 
     // Allow only scalar loads and stores.
     addDynamicallyLegalOp<triton::LoadOp>([](triton::LoadOp loadOp) {
@@ -896,10 +511,6 @@ struct ConvertMemoryOps
     : public triton::cpu::impl::ConvertMemoryOpsBase<ConvertMemoryOps> {
   ConvertMemoryOps() = default;
 
-  ConvertMemoryOps(bool useScalarLoops) {
-    this->useScalarLoops = useScalarLoops;
-  }
-
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     ModuleOp mod = getOperation();
@@ -909,10 +520,9 @@ struct ConvertMemoryOps
     MemoryOpConversionTarget convTarget(*context);
     TritonToTritonCPUTypeConverter pointerConverter;
     RewritePatternSet patterns(context);
-    patterns.add<LoadOpConversion>(axisInfoAnalysis, shapeInfoAnalysis,
-                                   pointerConverter, useScalarLoops, context);
-    patterns.add<StoreOpConversion>(axisInfoAnalysis, shapeInfoAnalysis,
-                                    pointerConverter, useScalarLoops, context);
+    patterns.add<LoadOpConversion, StoreOpConversion, CpuStoreOpConversion,
+                 CpuLoadOpConversion>(axisInfoAnalysis, shapeInfoAnalysis,
+                                      pointerConverter, context);
 
     if (failed(applyPartialConversion(mod, convTarget, std::move(patterns))))
       return signalPassFailure();
@@ -927,11 +537,6 @@ namespace cpu {
 
 std::unique_ptr<OperationPass<ModuleOp>> createConvertMemoryOps() {
   return std::make_unique<ConvertMemoryOps>();
-}
-
-std::unique_ptr<OperationPass<ModuleOp>>
-createConvertMemoryOps(bool useScalarLoops) {
-  return std::make_unique<ConvertMemoryOps>(useScalarLoops);
 }
 
 } // namespace cpu

--- a/third_party/cpu/lib/TritonToTritonCPU/ScalarizeInterface.cpp
+++ b/third_party/cpu/lib/TritonToTritonCPU/ScalarizeInterface.cpp
@@ -1,0 +1,277 @@
+#include "cpu/include/ScalarizePass/ScalarizeInterfaceImpl.h"
+
+#include "cpu/include/ScalarizePass/ScalarizeInterface.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+using namespace mlir;
+
+#include "cpu/include/ScalarizePass/ScalarizeInterface.cpp.inc"
+
+using namespace mlir::triton;
+using namespace mlir::triton::cpu;
+
+Value mlir::triton::cpu::computeScalarValue(Operation *scalarizationOp,
+                                            Value vals,
+                                            ArrayRef<int64_t> indices,
+                                            PatternRewriter &rewriter) {
+  auto scalarized = cast<ScalarizeInterface>(scalarizationOp);
+  return scalarized.computeScalarValue(vals, indices, rewriter);
+}
+
+Value mlir::triton::cpu::computeScalarValue(Operation *scalarizationOp,
+                                            Value vals, ValueRange indices,
+                                            PatternRewriter &rewriter) {
+  auto scalarized = cast<ScalarizeInterface>(scalarizationOp);
+  return scalarized.computeScalarValueForLoop(vals, indices, rewriter);
+}
+
+bool mlir::triton::cpu::canComputeScalarValue(Value vals) {
+  auto def = vals.getDefiningOp();
+  if (!def)
+    return false;
+  auto scalarized = dyn_cast<ScalarizeInterface>(def);
+  if (!scalarized)
+    return false;
+  return scalarized.canComputeScalarValue(vals);
+}
+
+namespace {
+
+namespace detail {
+
+template <typename T> struct value_type_trait {
+  using type = typename T::value_type;
+};
+
+template <> struct value_type_trait<ValueRange> {
+  using type = Value;
+};
+
+template <typename T>
+T createZeroIndex(mlir::Location loc, PatternRewriter &rewriter) {
+  llvm_unreachable("Default implementation should be overwritten.");
+}
+
+template <>
+int64_t createZeroIndex(mlir::Location loc, PatternRewriter &rewriter) {
+  return 0;
+}
+
+template <>
+Value createZeroIndex(mlir::Location loc, PatternRewriter &rewriter) {
+  return rewriter.create<arith::ConstantIndexOp>(loc, 0);
+}
+
+} // namespace detail
+
+// Using ScalariztionFunctor class to partially specialize helper method
+template <typename OpTy> struct ScalariztionFunctor {
+  template <typename T>
+  static Value getScalarValue(OpTy operation, Value vals, T indices,
+                              PatternRewriter &rewriter) {
+    auto def = vals.getDefiningOp<OpTy>();
+    OperationState newState(def->getLoc(), def->getName());
+    for (auto operand : def->getOperands()) {
+      newState.operands.push_back(computeScalarValue(
+          operand.getDefiningOp(), operand, indices, rewriter));
+    }
+    assert(def->getResults().size() == 1 &&
+           "[Unsupported] Opearation have multiple outputs.");
+    newState.types.push_back(
+        cast<ShapedType>(def->getResultTypes()[0]).getElementType());
+    newState.attributes = def->getAttrs();
+    return rewriter.create(newState)->getResult(0);
+  }
+};
+
+/// External model implementation of ScalarizeInterface for TritonOps. An
+/// external model implementation is used for now till the use of
+/// `ScalarizeInterface` is on-par with the current ScalarizeUsingForOp. This
+/// allows to register this Interface for all required ops depending on it's
+/// type.
+template <typename OpTy>
+struct TritonOpScalarizeInterface
+    : public ScalarizeInterface::ExternalModel<TritonOpScalarizeInterface<OpTy>,
+                                               OpTy> {
+  bool canComputeScalarValue(Operation *op, Value vals) const {
+    for (auto operand : op->getOperands()) {
+      if (isa<BlockArgument>(operand)) {
+        return false;
+      }
+      auto scalarized = dyn_cast<ScalarizeInterface>(operand.getDefiningOp());
+      if (!scalarized) {
+        return false;
+      }
+      if (!scalarized.canComputeScalarValue(operand)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  Value computeScalarValue(Operation *op, Value vals, ArrayRef<int64_t> indices,
+                           PatternRewriter &rewriter) const {
+    OpTy def = vals.getDefiningOp<OpTy>();
+    return ScalariztionFunctor<OpTy>().getScalarValue(def, vals, indices,
+                                                      rewriter);
+  }
+
+  Value computeScalarValueForLoop(Operation *op, Value vals, ValueRange indices,
+                                  PatternRewriter &rewriter) const {
+    OpTy def = vals.getDefiningOp<OpTy>();
+    return ScalariztionFunctor<OpTy>().getScalarValue(def, vals, indices,
+                                                      rewriter);
+  }
+};
+template <> struct ScalariztionFunctor<SplatOp> {
+  template <typename T>
+  Value getScalarValue(SplatOp def, Value vals, T indices,
+                       PatternRewriter &rewriter) {
+
+    return def.getSrc();
+  }
+};
+
+template <>
+bool TritonOpScalarizeInterface<SplatOp>::canComputeScalarValue(
+    Operation *op, Value vals) const {
+  return true;
+}
+
+template <>
+struct TritonOpScalarizeInterface<MakeRangeOp>
+    : public ScalarizeInterface::ExternalModel<
+          TritonOpScalarizeInterface<MakeRangeOp>, MakeRangeOp> {
+
+  bool canComputeScalarValue(Operation *op, Value vals) const { return true; }
+
+  Value computeScalarValue(Operation *op, Value vals, ArrayRef<int64_t> indices,
+                           PatternRewriter &rewriter) const {
+    MakeRangeOp def = vals.getDefiningOp<MakeRangeOp>();
+    int32_t start = static_cast<int32_t>(def.getStart());
+    assert(indices.size() == 1);
+    Type elemTy = cast<RankedTensorType>(def.getType()).getElementType();
+    return rewriter.create<arith::ConstantOp>(
+        def.getLoc(), elemTy,
+        rewriter.getIntegerAttr(elemTy, start + indices[0]));
+  }
+
+  Value computeScalarValueForLoop(Operation *op, Value vals, ValueRange indices,
+                                  PatternRewriter &rewriter) const {
+    MakeRangeOp def = vals.getDefiningOp<MakeRangeOp>();
+    assert(indices.size() == 1);
+    int32_t start = static_cast<int32_t>(def.getStart());
+    Type elemTy = cast<RankedTensorType>(def.getType()).getElementType();
+    Value startVal = rewriter.create<arith::ConstantOp>(
+        def.getLoc(), elemTy, rewriter.getIntegerAttr(elemTy, start));
+    Value index = indices[0];
+    if (!elemTy.isIndex())
+      index =
+          rewriter.create<arith::IndexCastUIOp>(def.getLoc(), elemTy, index);
+    return rewriter.create<arith::AddIOp>(def.getLoc(), elemTy, startVal,
+                                          index);
+  }
+};
+
+template <> struct ScalariztionFunctor<BroadcastOp> {
+  template <typename T>
+  Value getScalarValue(BroadcastOp operation, Value vals, T indices,
+                       PatternRewriter &rewriter) {
+    BroadcastOp def = operation;
+    using UnderlyingIndicesType = typename detail::value_type_trait<T>::type;
+    // Find broadcasted dimensions and replace indices for those
+    // dimensions with 0 (broadcasted dimension has always size 1).
+    SmallVector<UnderlyingIndicesType> newIndices;
+    auto sourceTy = cast<RankedTensorType>(def.getSrc().getType());
+    auto targetTy = cast<RankedTensorType>(def.getType());
+    assert(sourceTy.getRank() == indices.size() && "Mismatched rank");
+    for (int64_t i = 0; i < sourceTy.getRank(); ++i) {
+      if (sourceTy.getShape()[i] != targetTy.getShape()[i])
+        newIndices.push_back(detail::createZeroIndex<UnderlyingIndicesType>(
+            std::move(def.getLoc()), rewriter));
+      else
+        newIndices.push_back(indices[i]);
+    }
+    Value src = def.getSrc();
+    return computeScalarValue(src.getDefiningOp(), src, newIndices, rewriter);
+  }
+};
+
+template <> struct ScalariztionFunctor<ExpandDimsOp> {
+  template <typename T>
+  Value getScalarValue(ExpandDimsOp def, Value vals, T indices,
+                       PatternRewriter &rewriter) {
+    using UnderlyingIndicesType = typename detail::value_type_trait<T>::type;
+    // Remove index at expanded dimension.
+    SmallVector<UnderlyingIndicesType> newIndices(indices);
+    newIndices.erase(newIndices.begin() + def.getAxis());
+    Value src = def.getSrc();
+    return computeScalarValue(src.getDefiningOp(), src, newIndices, rewriter);
+  }
+};
+
+template <> struct ScalariztionFunctor<arith::ConstantOp> {
+  template <typename T>
+  Value getScalarValue(arith::ConstantOp def, Value vals, T indices,
+                       PatternRewriter &rewriter) {
+    auto denseVal = cast<DenseElementsAttr>(def.getValue());
+    assert(denseVal.isSplat());
+    auto scalarAttr = denseVal.getSplatValue<TypedAttr>();
+    Value res = rewriter.create<arith::ConstantOp>(
+        def.getLoc(), scalarAttr.getType(), scalarAttr);
+    return res;
+  }
+};
+
+template <>
+bool TritonOpScalarizeInterface<arith::ConstantOp>::canComputeScalarValue(
+    Operation *op, Value vals) const {
+  auto cst = static_cast<arith::ConstantOp>(op);
+  if (auto denseVal = dyn_cast<DenseElementsAttr>(cst.getValue())) {
+    return denseVal.isSplat();
+  }
+  return false;
+}
+
+template <> struct ScalariztionFunctor<TransOp> {
+  template <typename T>
+  Value getScalarValue(TransOp def, Value vals, T indices,
+                       PatternRewriter &rewriter) {
+
+    using UnderlyingIndicesType = typename detail::value_type_trait<T>::type;
+
+    // Permute indices.
+    SmallVector<UnderlyingIndicesType> newIndices;
+    auto order = def.getOrder();
+    assert(indices.size() == order.size() && "Mismatched rank");
+    for (auto idx : order)
+      newIndices.push_back(indices[idx]);
+    Value src = def.getSrc();
+    return computeScalarValue(src.getDefiningOp(), src, newIndices, rewriter);
+  }
+};
+
+} // namespace
+
+template <typename OpType> static void registerOne(MLIRContext *ctx) {
+  OpType::template attachInterface<TritonOpScalarizeInterface<OpType>>(*ctx);
+}
+
+template <typename... OpTypes> static void registerAll(MLIRContext *ctx) {
+  (registerOne<OpTypes>(ctx), ...);
+}
+
+void mlir::triton::cpu::registerTritonOpScalarizeExternalModels(
+    DialectRegistry &registry) {
+  registry.addExtension(+[](MLIRContext *ctx, TritonDialect *dialect) {
+    registerAll<AddPtrOp, BroadcastOp, ExpandDimsOp, TransOp, SplatOp,
+                MakeRangeOp>(ctx);
+  });
+  registry.addExtension(+[](MLIRContext *ctx, arith::ArithDialect *dialect) {
+    registerAll<arith::AddFOp, arith::AddIOp, arith::CmpFOp, arith::CmpIOp,
+                arith::DivFOp, arith::DivSIOp, arith::MulIOp, arith::MulFOp,
+                arith::RemFOp, arith::RemUIOp, arith::RemSIOp,
+                arith::ConstantOp>(ctx);
+  });
+}

--- a/third_party/cpu/lib/TritonToTritonCPU/ScalarizeUsingForOps.cpp
+++ b/third_party/cpu/lib/TritonToTritonCPU/ScalarizeUsingForOps.cpp
@@ -1,0 +1,387 @@
+#include "TypeConverter.h"
+
+#include "cpu/include/TritonToTritonCPU/Passes.h"
+
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "triton/Analysis/AxisInfo.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonCPU/IR/Dialect.h"
+
+#include "cpu/include/ScalarizePass/ScalarizeInterface.h"
+
+namespace mlir {
+namespace triton {
+#define GEN_PASS_DEF_SCALARIZEUSINGFOROP
+#include "cpu/include/TritonToTritonCPU/Passes.h.inc"
+} // namespace triton
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::triton;
+using namespace mlir::triton::cpu;
+
+namespace {
+
+template <typename OpTy>
+struct ScalarizeOpConversion : public OpRewritePattern<OpTy> {
+
+  ScalarizeOpConversion(ModuleAxisInfoAnalysis &axisInfoAnalysis,
+                        MLIRContext *context)
+      : OpRewritePattern<OpTy>(context), axisAnalysis(axisInfoAnalysis) {}
+
+  Value createAlloca(Location loc, MemRefType ty, Operation *before,
+                     PatternRewriter &rewriter) const {
+    OpBuilder::InsertionGuard g(rewriter);
+    rewriter.setInsertionPoint(before);
+    return rewriter.create<memref::AllocaOp>(
+        loc, ty, rewriter.getIntegerAttr(rewriter.getI64Type(), 64));
+  }
+
+  // If tensor is not null and its element cannot be recomputed in a scalar
+  // loop, then store it to a temporary buffer.
+  Value storeIfNonScalarizable(Location loc, Value vals, Value zeroIdx,
+                               Operation *allocaPoint,
+                               PatternRewriter &rewriter) const {
+    // To skip optional values and scalarizable value, that can be computed
+    // inside loop
+    if (!vals || canComputeScalarValue(vals))
+      return nullptr;
+
+    auto tensor = vals;
+    auto tensorTy = cast<RankedTensorType>(vals.getType());
+    auto elemTy = tensorTy.getElementType();
+    if (isa<triton::PointerType>(elemTy)) {
+      elemTy = IntegerType::get(elemTy.getContext(), 64);
+    }
+    // Memref of i1 assumes one element per byte when we load/store element,
+    // but vector store (through transfer write) would write 1 bit per element.
+    if (elemTy.isInteger(1)) {
+      elemTy = rewriter.getI8Type();
+      tensor = rewriter.create<arith::ExtUIOp>(
+          loc,
+          RankedTensorType::get(tensorTy.getShape(), elemTy,
+                                tensorTy.getEncoding()),
+          tensor);
+    }
+    auto memRefTy = MemRefType::get(tensorTy.getShape(), elemTy);
+    Value memRef = createAlloca(vals.getLoc(), memRefTy, allocaPoint, rewriter);
+    SmallVector<Value> indices(tensorTy.getRank(), zeroIdx);
+    rewriter.create<triton::cpu::StoreOp>(vals.getLoc(), tensor, memRef);
+    return memRef;
+  }
+
+  // Load scalar element from a temporary buffer or recompute it if the
+  // buffer doesn't exist.
+  Value loadOrComputeScalarValue(Value vals, Value tmpVals, ValueRange indices,
+                                 PatternRewriter &rewriter) const {
+    // Allow null value for easier handling of optional arguments.
+    if (!vals)
+      return nullptr;
+
+    // If nothing loaded, value should be scalar computable
+    if (!tmpVals) {
+      if (!canComputeScalarValue(vals)) {
+        llvm::errs()
+            << "Passed value was not loaded and can't be computed as scalar: "
+            << vals << "\n";
+        llvm::report_fatal_error("Cannot proceed such value");
+        return nullptr;
+      }
+      return computeScalarValue(vals.getDefiningOp(), vals, indices, rewriter);
+    }
+
+    // Load value from a temp buffer if any.
+    Value val =
+        rewriter.create<memref::LoadOp>(vals.getLoc(), tmpVals, indices);
+    // If we load a pointer then additional cast is needed because tensor of
+    // pointers is transformed into a vector of integers.
+    auto elemTy = dyn_cast<RankedTensorType>(vals.getType()).getElementType();
+    if (isa<PointerType>(elemTy))
+      val = rewriter.create<IntToPtrOp>(vals.getLoc(), elemTy, val);
+    // We need to transform loaded i8 back to i1.
+    else if (elemTy.isInteger(1))
+      val = rewriter.create<arith::TruncIOp>(val.getLoc(), rewriter.getI1Type(),
+                                             val);
+    return val;
+  }
+
+  // This is core methods that generates SCF::For
+  // We are checking arguments and results of operation
+  // to scalarize them if possible and load/store if they are dynamical
+  LogicalResult scalarizeWithLoop(OpTy scalarizeOp,
+                                  PatternRewriter &rewriter) const {
+    llvm_unreachable("nope");
+    return failure();
+  }
+
+  // Method that describes how to check arguments and results of operation
+  // for scalarization
+  bool shouldScalarizeOp(OpTy scalarizeOp) const {
+    llvm_unreachable("nope");
+    return false;
+  }
+
+  // code for Memory Ops, as requires getPtr method
+  bool shouldScalarizeOpGeneric(OpTy scalarizeOp) const {
+
+    auto ptr = scalarizeOp.getPtr();
+    if (triton::isTensorPointerType(ptr.getType())) {
+      return false;
+    }
+
+    auto axisInfo = axisAnalysis.getAxisInfo(ptr);
+    if (isContiguousRowMajorAccess(axisInfo, scalarizeOp)) {
+      return false;
+    }
+
+    // Scalar memory ops and boundary checks are not expected.
+    if (!scalarizeOp.getBoundaryCheck().empty()) {
+      return false;
+    }
+
+    return ScalarizeOpConversion<OpTy>::shouldScalarizeOp(scalarizeOp);
+  }
+
+  LogicalResult matchAndRewrite(OpTy scalarOp,
+                                PatternRewriter &rewriter) const override {
+
+    // We want to avoid a code explosion when scalarize loads of big vectors,
+    // so try to build a scalar loop.
+    if (shouldScalarizeOpGeneric(scalarOp) &&
+        succeeded(scalarizeWithLoop(scalarOp, rewriter)))
+      return success();
+    return failure();
+  }
+
+protected:
+  ModuleAxisInfoAnalysis &axisAnalysis;
+};
+
+template <>
+LogicalResult ScalarizeOpConversion<triton::StoreOp>::scalarizeWithLoop(
+    triton::StoreOp storeOp, PatternRewriter &rewriter) const {
+  auto loc = storeOp.getLoc();
+
+  auto ptrs = storeOp.getPtr();
+  auto mask = storeOp.getMask();
+  auto vals = storeOp.getValue();
+  auto cache = storeOp.getCache();
+  auto evict = storeOp.getEvict();
+
+  auto tensorTy = cast<RankedTensorType>(vals.getType());
+
+  // Create some reused constants.
+  Value zeroIdx = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value oneIdx = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+
+  // Alloca is inserted similar to the load case.
+  Operation *allocaPoint = storeOp;
+  while (!isa<triton::FuncOp>(allocaPoint->getParentOp()))
+    allocaPoint = allocaPoint->getParentOp();
+
+  // Store a tensor of pointers, mask, and values into a temp buf if we can't
+  // compute them in a loop.
+  Value tmpPtrs =
+      storeIfNonScalarizable(loc, ptrs, zeroIdx, allocaPoint, rewriter);
+  Value tmpMask =
+      storeIfNonScalarizable(loc, mask, zeroIdx, allocaPoint, rewriter);
+  Value tmpVals =
+      storeIfNonScalarizable(loc, vals, zeroIdx, allocaPoint, rewriter);
+
+  // Create for-loops to iterate through all vector dimensions.
+  SmallVector<scf::ForOp> forOps;
+  SmallVector<Value> ivs;
+  for (int64_t i = 0; i < tensorTy.getRank(); ++i) {
+    Value upperBound =
+        rewriter.create<arith::ConstantIndexOp>(loc, tensorTy.getShape()[i]);
+    auto forOp = rewriter.create<scf::ForOp>(loc, zeroIdx, upperBound, oneIdx);
+    forOps.push_back(forOp);
+    ivs.push_back(forOp.getInductionVar());
+    rewriter.setInsertionPointToStart(forOp.getBody());
+  }
+
+  // Compute or load scalar args.
+  Value scalarPtr = loadOrComputeScalarValue(ptrs, tmpPtrs, ivs, rewriter);
+  Value scalarMask = loadOrComputeScalarValue(mask, tmpMask, ivs, rewriter);
+  Value scalarVal = loadOrComputeScalarValue(vals, tmpVals, ivs, rewriter);
+
+  if (!mask) {
+    // Regular store case.
+    auto store_op = rewriter.create<triton::StoreOp>(loc, scalarPtr, scalarVal,
+                                                     cache, evict);
+  } else {
+    // Conditional store case
+    rewriter.create<scf::IfOp>(loc, scalarMask,
+                               [&](OpBuilder &builder, Location loc) {
+                                 builder.create<triton::StoreOp>(
+                                     loc, scalarPtr, scalarVal, cache, evict);
+                                 builder.create<scf::YieldOp>(loc);
+                               });
+  }
+
+  rewriter.eraseOp(storeOp);
+  return success();
+}
+
+template <>
+bool ScalarizeOpConversion<triton::StoreOp>::shouldScalarizeOp(
+    triton::StoreOp scalarOp) const {
+
+  if (!isa<RankedTensorType>(scalarOp.getValue().getType())) {
+    return false;
+  }
+
+  auto tensorTy = cast<RankedTensorType>(scalarOp.getPtr().getType());
+  return tensorTy.getNumElements() >= 16;
+}
+
+template <>
+LogicalResult ScalarizeOpConversion<triton::LoadOp>::scalarizeWithLoop(
+    triton::LoadOp loadOp, PatternRewriter &rewriter) const {
+  auto loc = loadOp.getLoc();
+  auto tensorTy = cast<RankedTensorType>(loadOp.getType());
+
+  auto ptrs = loadOp.getPtr();
+  auto mask = loadOp.getMask();
+  auto other = loadOp.getOther();
+  auto cache = loadOp.getCache();
+  auto evict = loadOp.getEvict();
+  auto isVolatile = loadOp.getIsVolatile();
+
+  // Create some reused constants.
+  Value zeroIdx = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value oneIdx = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+
+  // There is alloca_scope operation to control alloca scopes. But its usage
+  // in combination with nested SCF and multi-dimensional vectors make it
+  // impossible to lower scopes to LLVM using existing MLIR passes. For now,
+  // simply allocate temp memory in the function's region.
+  // TODO: Use alloc for big buffers and revisit alloca scoping.
+  Operation *allocaPoint = loadOp;
+  while (!isa<triton::FuncOp>(allocaPoint->getParentOp()))
+    allocaPoint = allocaPoint->getParentOp();
+
+  // Allocate temp buffer for the result. Write the other value there if
+  // we cannot write it in a loop.
+  auto resMemRefTy =
+      MemRefType::get(tensorTy.getShape(), tensorTy.getElementType());
+  Value resMemRef = createAlloca(loc, resMemRefTy, allocaPoint, rewriter);
+  bool storeOtherInLoop = static_cast<bool>(mask);
+  if (other && !canComputeScalarValue(other)) {
+    rewriter.create<triton::cpu::StoreOp>(loc, other, resMemRef);
+    storeOtherInLoop = false;
+  }
+
+  // Store a tensor of pointers and mask into a temp buf if we can't
+  // compute them in a loop.
+  Value tmpPtrs =
+      storeIfNonScalarizable(loc, ptrs, zeroIdx, allocaPoint, rewriter);
+  Value tmpMask =
+      storeIfNonScalarizable(loc, mask, zeroIdx, allocaPoint, rewriter);
+
+  // Create for-loops to iterate through all vector dimensions.
+  SmallVector<scf::ForOp> forOps;
+  SmallVector<Value> ivs;
+  for (int64_t i = 0; i < tensorTy.getRank(); ++i) {
+    Value upperBound =
+        rewriter.create<arith::ConstantIndexOp>(loc, tensorTy.getShape()[i]);
+    auto forOp = rewriter.create<scf::ForOp>(loc, zeroIdx, upperBound, oneIdx);
+    forOps.push_back(forOp);
+    ivs.push_back(forOp.getInductionVar());
+    rewriter.setInsertionPointToStart(forOp.getBody());
+  }
+
+  // Compute or load a scalar arguments.
+  Value scalarPtr = loadOrComputeScalarValue(ptrs, tmpPtrs, ivs, rewriter);
+  Value scalarMask = loadOrComputeScalarValue(mask, tmpMask, ivs, rewriter);
+  Value scalarOther;
+  if (storeOtherInLoop) {
+    if (other) {
+      scalarOther =
+          computeScalarValue(other.getDefiningOp(), other, ivs, rewriter);
+    } else {
+      scalarOther = rewriter.create<arith::ConstantOp>(
+          loc, tensorTy.getElementType(),
+          rewriter.getZeroAttr(tensorTy.getElementType()));
+    }
+  }
+
+  if (!mask) {
+    // Regular load case.
+    Value val = rewriter.create<triton::LoadOp>(loc, scalarPtr, cache, evict,
+                                                isVolatile);
+    rewriter.create<memref::StoreOp>(loc, val, resMemRef, ivs);
+  } else {
+    // Conditional load case
+    rewriter.create<scf::IfOp>(
+        loc, scalarMask,
+        [&](OpBuilder &builder, Location loc) {
+          Value val = builder.create<triton::LoadOp>(loc, scalarPtr, cache,
+                                                     evict, isVolatile);
+          builder.create<memref::StoreOp>(loc, val, resMemRef, ivs);
+          builder.create<scf::YieldOp>(loc);
+        },
+        [&](OpBuilder &builder, Location loc) {
+          if (storeOtherInLoop)
+            builder.create<memref::StoreOp>(loc, scalarOther, resMemRef, ivs);
+          builder.create<scf::YieldOp>(loc);
+        });
+  }
+
+  // Load vector from the temp storage and return it from alloca scope.
+  rewriter.setInsertionPointAfter(forOps.front());
+  SmallVector<Value> indices(tensorTy.getRank(), zeroIdx);
+  Value res = rewriter.create<triton::cpu::LoadOp>(loc, tensorTy, resMemRef);
+  rewriter.replaceOp(loadOp, res);
+  return success();
+}
+
+template <>
+bool ScalarizeOpConversion<triton::LoadOp>::shouldScalarizeOp(
+    triton::LoadOp scalarOp) const {
+  if (!isa<RankedTensorType>(scalarOp.getType())) {
+    return false;
+  }
+  auto tensorTy = cast<RankedTensorType>(scalarOp.getType());
+  return tensorTy.getNumElements() >= 16;
+}
+
+struct ScalarizeUsingForOpPass
+    : public triton::impl::ScalarizeUsingForOpBase<ScalarizeUsingForOpPass> {
+  using ScalarizeUsingForOpBase::ScalarizeUsingForOpBase;
+
+  ScalarizeUsingForOpPass() : ScalarizeUsingForOpBase() {}
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ModuleOp mod = getOperation();
+
+    ModuleAxisInfoAnalysis axisInfoAnalysis(mod);
+    RewritePatternSet patterns(context);
+    patterns.add<ScalarizeOpConversion<triton::LoadOp>,
+                 ScalarizeOpConversion<triton::StoreOp>>(axisInfoAnalysis,
+                                                         context);
+
+    if (applyPatternsAndFoldGreedily(mod, std::move(patterns)).failed()) {
+      return signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+namespace mlir {
+namespace triton {
+namespace cpu {
+
+std::unique_ptr<OperationPass<ModuleOp>> createScalarizeUsingForOpPass() {
+  return std::make_unique<ScalarizeUsingForOpPass>();
+}
+
+} // namespace cpu
+} // namespace triton
+} // namespace mlir

--- a/third_party/cpu/triton_cpu.cc
+++ b/third_party/cpu/triton_cpu.cc
@@ -1,3 +1,4 @@
+#include "ScalarizePass/ScalarizeInterfaceImpl.h"
 #include "TritonCPUToLLVM/Passes.h"
 #include "TritonCPUTransforms/Passes.h"
 #include "TritonToTritonCPU/Passes.h"
@@ -27,10 +28,12 @@ void init_triton_cpu_passes_ttcpuir(py::module &&m) {
       .value("libsleef", cpu::VecLib::Sleef)
       .value("libmvec", cpu::VecLib::Mvec);
 
-  m.def("add_convert_memory_ops",
-        [](mlir::PassManager &pm, bool useScalarLoops) {
-          pm.addPass(mlir::triton::cpu::createConvertMemoryOps(useScalarLoops));
-        });
+  m.def("add_scalarize", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::triton::cpu::createScalarizeUsingForOpPass());
+  });
+  m.def("add_convert_memory_ops", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::triton::cpu::createConvertMemoryOps());
+  });
   m.def("add_convert_ptr_ops", [](mlir::PassManager &pm) {
     pm.addPass(mlir::triton::cpu::createConvertPtrOps());
   });
@@ -147,6 +150,7 @@ void init_triton_cpu(py::module &&m) {
     mlir::DialectRegistry registry;
     registry.insert<mlir::triton::cpu::TritonCPUDialect,
                     mlir::vector::VectorDialect>();
+    mlir::triton::cpu::registerTritonOpScalarizeExternalModels(registry);
     context.appendDialectRegistry(registry);
     context.loadAllAvailableDialects();
   });


### PR DESCRIPTION
This commit reworks functionality introduced in PR #119.
The current approach decides to insert SCF cycles earlier - with TTC IR
and with tensors instead of vectors.

This allows the analysis to be separated by operation type and applied
via an external interface, avoiding changes to the original operations. (ScalarizeInterface)

The original scalarization logic is now separated and placed in ScalarizeUsingForOpPass.
This reduces the complexity of the ConvertMemoryOps pass.
Thus, the conversion is now separated from the transformation of TTC IR.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
  
- [x] I have modified lit tests.
