### PR TITLE
Offload a part of masks optimization to the canonicalizer.

### DIFF
--- a/test/TritonCPU/optimize-masks.mlir
+++ b/test/TritonCPU/optimize-masks.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file -triton-cpu-optimize-masks | FileCheck %s
+// RUN: triton-opt %s -split-input-file -triton-cpu-optimize-masks -canonicalize | FileCheck %s
 
 // Convert strided masked loads to scalar loads.
 
@@ -30,6 +30,44 @@ module {
       %11 = triton_cpu.ptr_to_memref %10 : <f32> -> memref<16xf32>
       vector.maskedstore %11[%c0], %6, %9 : memref<16xf32>, vector<16xi1>, vector<16xf32>
     }
+    tt.return
+  }
+}
+
+// -----
+
+// Replace masked load with a regular load and optimize out arith.select.
+
+// CHECK-LABEL: @optimize_select
+// CHECK:       vector.load
+// CHECK-NEXT:  arith.addf
+// CHECK-NEXT:  arith.addf
+// CHECK-NEXT:  scf.yield
+
+module {
+  tt.func public @optimize_select(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32 {tt.divisibility = 16 : i32}) {
+    %cst = arith.constant 0.000000e+00 : f32
+    %c0 = arith.constant 0 : index
+    %cst_0 = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> : vector<16xi32>
+    %cst_1 = arith.constant dense<1.000000e+00> : vector<16xf32>
+    %c16_i32 = arith.constant 16 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %cst_2 = arith.constant dense<0.000000e+00> : vector<16xf32>
+    %0 = vector.splat %arg2 : vector<16xi32>
+    %1 = scf.for %arg3 = %c0_i32 to %arg2 step %c16_i32 iter_args(%arg4 = %cst_2) -> (vector<16xf32>)  : i32 {
+      %3 = vector.splat %arg3 : vector<16xi32>
+      %4 = arith.addi %3, %cst_0 : vector<16xi32>
+      %5 = arith.cmpi slt, %4, %0 : vector<16xi32>
+      %6 = tt.addptr %arg0, %arg3 : !tt.ptr<f32>, i32
+      %7 = triton_cpu.ptr_to_memref %6 : <f32> -> memref<16xf32>
+      %8 = vector.maskedload %7[%c0], %5, %cst_2 : memref<16xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
+      %9 = arith.addf %8, %cst_1 : vector<16xf32>
+      %10 = arith.select %5, %9, %cst_2 : vector<16xi1>, vector<16xf32>
+      %11 = arith.addf %arg4, %10 : vector<16xf32>
+      scf.yield %11 : vector<16xf32>
+    }
+    %2 = vector.multi_reduction <add>, %1, %cst [0] : vector<16xf32> to f32
+    tt.store %arg1, %2 : !tt.ptr<f32>
     tt.return
   }
 }

--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -119,6 +119,7 @@ class CPUBackend(BaseBackend):
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
         cpu.passes.ttcpuir.add_optimize_masks(pm)
+        passes.common.add_canonicalizer(pm)
         convert_bf16_dot_product = self.cpu_arch == "aarch64" and 'fp-armv8' in self.cpu_features and 'neon' in self.cpu_features
         if convert_bf16_dot_product:
             use_horizontal_sum = os.getenv("TRITON_CPU_DOT_PROD_HORIZ_SUM", "1") == "1"


### PR DESCRIPTION
This is a minor refactoring of the masks optimization. Instead of replacing masked load and stores having a mask proven to be all-ones, we replace such a mask with a constant and then let the canonicalizer do the rest. This allows additional benefits because such masks can be used in operations other than masked loads and stores. E.g. in the layer norm tutorial, this allows us to optimize out `arith.select` operation.