### PR TITLE
Implement isnan, isinf, signbit

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -378,7 +378,7 @@ class dtype:
                 self.primitive_bitwidth = 32
                 self.exponent_bias = 127
             elif name == 'fp64':
-                self.fp_mantissa_width = 53
+                self.fp_mantissa_width = 52
                 self.primitive_bitwidth = 64
                 self.exponent_bias = 1023
             else:

--- a/python/triton/language/extra/cpu/__init__.py
+++ b/python/triton/language/extra/cpu/__init__.py
@@ -1,3 +1,0 @@
-from . import libdevice
-
-__all__ = ["libdevice"]


### PR DESCRIPTION
Since these aren't natively available in sleef / libmvec, let's implement them natively in Triton.

They were implemented via a `@builtin` wrapping a `@jit` function because operations like `get_int_dtype` don't work under `@jit`. The `@builtin` annotation was necessary so that we would get a handle to the `_generator`, which we can then use to call a JitFunction from a non-JIT one without specifying the grid.