### PR TITLE
Make CPU runtime lib lookup work for Python 3.8

### DIFF
--- a/third_party/cpu/backend/driver.py
+++ b/third_party/cpu/backend/driver.py
@@ -14,7 +14,11 @@ from triton._C.libtriton import llvm
 
 _dirname = os.getenv("TRITON_SYS_PATH", default="/usr/local")
 # for locating libTritonCPURuntime
-_triton_C_dir = importlib.resources.files(triton).joinpath("_C")
+try:
+    _triton_C_dir = importlib.resources.files(triton).joinpath("_C")
+except AttributeError:
+    # resources.files() doesn't exist for Python < 3.9
+    _triton_C_dir = importlib.resources.path(triton, "_C").__enter__()
 
 include_dirs = [os.path.join(_dirname, "include")]
 library_dirs = [os.path.join(_dirname, "lib"), _triton_C_dir]


### PR DESCRIPTION
The version compatibility pain continues...

PyTorch still supports 3.8 so we need this