### PR TITLE
Refactor MathToLibmvec pass

### DIFF
--- a/third_party/cpu/include/TritonCPUToLLVM/Passes.h
+++ b/third_party/cpu/include/TritonCPUToLLVM/Passes.h
@@ -17,6 +17,11 @@ template <typename T> class OperationPass;
 namespace triton {
 namespace cpu {
 
+enum class VecLib {
+  Mvec,
+  Sleef,
+};
+
 #define GEN_PASS_DECL
 #include "cpu/include/TritonCPUToLLVM/Passes.h.inc"
 
@@ -26,9 +31,8 @@ std::unique_ptr<OperationPass<ModuleOp>> createGetProgramIdOpToLLVMPass();
 std::unique_ptr<OperationPass<triton::FuncOp>> createLowerMultiReductionPass();
 std::unique_ptr<OperationPass<ModuleOp>> createAtomicOpsToLLVMPass();
 std::unique_ptr<OperationPass<ModuleOp>> createDebugOpsToLLVMPass();
-std::unique_ptr<OperationPass<ModuleOp>> createMathToLibmvecPass();
 std::unique_ptr<OperationPass<ModuleOp>>
-createMathToLibmvecPass(bool use_sleef);
+createMathToVecLibPass(VecLib lib = VecLib::Sleef);
 
 #define GEN_PASS_REGISTRATION
 #include "cpu/include/TritonCPUToLLVM/Passes.h.inc"

--- a/third_party/cpu/include/TritonCPUToLLVM/Passes.td
+++ b/third_party/cpu/include/TritonCPUToLLVM/Passes.td
@@ -66,16 +66,16 @@ def DebugOpsToLLVM : Pass<"triton-cpu-debug-ops-to-llvm", "mlir::ModuleOp"> {
                              "mlir::triton::TritonDialect"];
 }
 
-def MathToLibmvec : Pass<"triton-cpu-math-to-libmvec", "mlir::ModuleOp"> {
+def MathToVecLib : Pass<"triton-cpu-math-to-vec-lib", "mlir::ModuleOp"> {
     let summary = "Convert vector math operations to vector libm or sleef calls.";
     let description = [{
     }];
-    let constructor = "mlir::triton::cpu::createMathToLibmvecPass()";
+    let constructor = "mlir::triton::cpu::createMathToVecLibPass()";
 
     let options = [
-        Option<"use_sleef", "use-sleef",
-               "bool", /*default*/"false",
-               "Use sleef library for vector math instead of libmvec.">,
+        Option<"lib", "lib",
+               "mlir::triton::cpu::VecLib", /*default*/"mlir::triton::cpu::VecLib::Sleef",
+               "Library to use for vector math (libsleef or libmvec).">,
     ];
 
     let dependentDialects = ["mlir::vector::VectorDialect",

--- a/third_party/cpu/lib/TritonCPUToLLVM/CMakeLists.txt
+++ b/third_party/cpu/lib/TritonCPUToLLVM/CMakeLists.txt
@@ -4,7 +4,7 @@ add_triton_library(TritonCPUToLLVM
     FuncOpToLLVM.cpp
     GetProgramIdOpToLLVM.cpp
     LowerMultiReduction.cpp
-    MathToLibmvec.cpp
+    MathToVecLib.cpp
     MemoryOpToLLVM.cpp
     TypeConverter.cpp
     Utility.cpp

--- a/third_party/cpu/triton_cpu.cc
+++ b/third_party/cpu/triton_cpu.cc
@@ -18,12 +18,15 @@
 #include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
 
-#include <iostream>
-
 namespace py = pybind11;
 
 void init_triton_cpu_passes_ttcpuir(py::module &&m) {
   using namespace mlir::triton;
+
+  py::enum_<cpu::VecLib>(m, "VecLib")
+      .value("libsleef", cpu::VecLib::Sleef)
+      .value("libmvec", cpu::VecLib::Mvec);
+
   m.def("add_convert_memory_ops",
         [](mlir::PassManager &pm, bool useScalarLoops) {
           pm.addPass(mlir::triton::cpu::createConvertMemoryOps(useScalarLoops));
@@ -122,8 +125,8 @@ void init_triton_cpu_passes_ttcpuir(py::module &&m) {
   m.def("add_memref_to_llvmir", [](mlir::PassManager &pm) {
     pm.addPass(mlir::createFinalizeMemRefToLLVMConversionPass());
   });
-  m.def("add_math_to_libmvec", [](mlir::PassManager &pm, bool use_sleef) {
-    pm.addPass(mlir::triton::cpu::createMathToLibmvecPass(use_sleef));
+  m.def("add_math_to_vec_lib", [](mlir::PassManager &pm, cpu::VecLib lib) {
+    pm.addPass(mlir::triton::cpu::createMathToVecLibPass(lib));
   });
   m.def("add_math_to_libm", [](mlir::PassManager &pm) {
     pm.addPass(mlir::createConvertMathToLibmPass());


### PR DESCRIPTION
Since the pass can generate libsleef calls too, having "libmvec" in the pass name is a bit of a misnomer, so I've renamed it accordingly.

I've also switched from using a bool to using an enum to select between vector math libraries. This makes for cleaner code and makes it easy to extend to support additional libraries (e.g. MKL).

Finally (and most significantly), I've changed how library function names are generated. Instead of having all the logic in the MathToLibmvecPass, I'm giving each library its own naming functor. This makes it easier to extend to accomodate each library's quirks, as following PRs will demonstrate.