### PR TITLE
[FP8 support] Enable Float8 tests failed after rebase

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1,4 +1,4 @@
-#include <pybind11/functional.h>
+﻿#include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 

--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -25,6 +25,10 @@ def is_on_mi300():
     return is_hip() and triton.runtime.driver.active.get_current_target().arch in ('gfx940', 'gfx941', 'gfx942')
 
 
+def is_cpu():
+    return not is_interpreter() and triton.runtime.driver.active.get_current_target().backend == "cpu"
+
+
 def test_err_undefined_variable():
 
     @triton.jit
@@ -370,6 +374,8 @@ def test_fp8_support(dtype):
             supported_dtypes += [tl.float8e4b8, tl.float8e5b16]
     elif is_interpreter():
         supported_dtypes = [tl.float8e5, tl.float8e5b16, tl.float8e4nv, tl.float8e4b8, tl.float8e4b15]
+    elif is_cpu():
+        supported_dtypes = [tl.float8e5, tl.float8e5b16, tl.float8e4nv]
 
     @triton.jit
     def dtype_kernel(dtype: tl.constexpr):

--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -334,6 +334,7 @@ def test_typeconvert_upcast(src_dtype, dst_dtype, device):
 ])
 def test_typeconvert_downcast(src_dtype, dst_dtype, rounding, max_repr, device):
     if is_cpu() and dst_dtype not in ['float8e5', 'float8e4nv', 'float8e5b16']:
+        # TODO check if 'float8e4b15' downcast is fine for cpu if it will enable in this test
         pytest.skip(f"Conversion from {src_dtype} to {dst_dtype} is not supported on CPU")
 
     if src_dtype != 'float32' and is_cuda() and torch.cuda.get_device_capability(0) < (9, 0):

--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -284,12 +284,10 @@ def upcast_test(src_dtype, dst_dtype, exponent_bits, mantissa_bits, exponent_bia
     ('float8e5b16', 'float16'),
 ])
 def test_typeconvert_upcast(src_dtype, dst_dtype, device):
-    if src_dtype in ('float8e4b8', 'float8e4b15') and is_cpu():
-        pytest.skip(f"Conversion from {src_dtype} to {dst_dtype} is not supported on CPU")
-
     if ((src_dtype == 'float8e4nv' and is_cuda() and torch.cuda.get_device_capability(0) < (8, 9))
        or (src_dtype in ('float8e4nv', 'float8e4b15') and is_hip())
-       or (src_dtype in ('float8e4b8', 'float8e5b16') and (is_cuda() or not is_on_mi300()))):
+       or (src_dtype in ('float8e4b8', 'float8e5b16') and (is_cuda() or (is_hip() and not is_on_mi300())))
+       or (src_dtype in ('float8e4b8', 'float8e4b15') and is_cpu())):
         # If the dtype should error out in the given device, we assert that and return
         with pytest.raises(triton.CompilationError, match="not supported in this architecture"):
             launch_exhaustive_populate(getattr(tl, src_dtype), 0, 65536, False, 8, 0x7f, device=device)

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1101,6 +1101,8 @@ def test_abs_fp8(in_dtype, device):
             pytest.skip("float8e4b15 not supported on CUDA >= 9.0")
         if in_dtype == tl.float8e4nv and cc < (8, 9):
             pytest.skip("float8e4nv not supported on CUDA < 8.9")
+    elif is_cpu():
+        pytest.skip('CPU not supports "fp8e4b15"')
 
     @triton.jit
     def abs_kernel(X, Z, SIZE: tl.constexpr):

--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -33,7 +33,7 @@ class CPUOptions:
     cluster_dims: tuple = (1, 1, 1)
     extern_libs: dict = None
     debug: bool = False
-    supported_fp8_dtypes: Tuple[str] = ("fp8e5", "fp8e4b15", "fp8e4nv")
+    supported_fp8_dtypes: Tuple[str] = ("fp8e5", "fp8e5b16", "fp8e4nv")
     deprecated_fp8_dtypes: Tuple[str] = ()
     allowed_dot_input_precisions: Tuple[str] = ("ieee", "tf32", "tf32x3")
     allow_fp8e4nv: bool = True

--- a/third_party/cpu/lib/TritonCPUTransforms/DecomposeFpConversions.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/DecomposeFpConversions.cpp
@@ -222,15 +222,13 @@ Value convertToFp8(Location loc, Value src, Type dstFpTy, int dstExpBits,
 
 Value convertFp16ToFp8E4M3Rtz(Location loc, Value src,
                               PatternRewriter &rewriter) {
-  // TODO: Fix type to Float8E4M3FN.
-  return convertToFp8(loc, src, rewriter.getFloat8E4M3FNUZType(), 4, 7, false,
+  return convertToFp8(loc, src, rewriter.getFloat8E4M3FNType(), 4, 7, false,
                       false, rewriter);
 }
 
 Value convertFp16ToFp8E4M3Rtne(Location loc, Value src,
                                PatternRewriter &rewriter) {
-  // TODO: Fix type to Float8E4M3FN.
-  return convertToFp8(loc, src, rewriter.getFloat8E4M3FNUZType(), 4, 7, true,
+  return convertToFp8(loc, src, rewriter.getFloat8E4M3FNType(), 4, 7, true,
                       false, rewriter);
 }
 
@@ -287,19 +285,17 @@ Value convertFp16ToFp8E5M2B16Rtne(Location loc, Value src,
 
 Value convertBf16ToFp8E4M3Rtz(Location loc, Value src,
                               PatternRewriter &rewriter) {
-  // TODO: Fix type to Float8E4M3FN.
   Value f32Src =
       rewriter.create<arith::ExtFOp>(loc, toFp32(src.getType()), src);
-  return convertToFp8(loc, f32Src, rewriter.getFloat8E4M3FNUZType(), 4, 7,
-                      false, false, rewriter);
+  return convertToFp8(loc, f32Src, rewriter.getFloat8E4M3FNType(), 4, 7, false,
+                      false, rewriter);
 }
 
 Value convertBf16ToFp8E4M3Rtne(Location loc, Value src,
                                PatternRewriter &rewriter) {
-  // TODO: Fix type to Float8E4M3FN.
   Value f32Src =
       rewriter.create<arith::ExtFOp>(loc, toFp32(src.getType()), src);
-  return convertToFp8(loc, f32Src, rewriter.getFloat8E4M3FNUZType(), 4, 7, true,
+  return convertToFp8(loc, f32Src, rewriter.getFloat8E4M3FNType(), 4, 7, true,
                       false, rewriter);
 }
 
@@ -337,15 +333,13 @@ Value convertBf16ToFp8E5M2B16Rtne(Location loc, Value src,
 
 Value convertFp32ToFp8E4M3Rtz(Location loc, Value src,
                               PatternRewriter &rewriter) {
-  // TODO: Fix type to Float8E4M3FN.
-  return convertToFp8(loc, src, rewriter.getFloat8E4M3FNUZType(), 4, 7, false,
+  return convertToFp8(loc, src, rewriter.getFloat8E4M3FNType(), 4, 7, false,
                       false, rewriter);
 }
 
 Value convertFp32ToFp8E4M3Rtne(Location loc, Value src,
                                PatternRewriter &rewriter) {
-  // TODO: Fix type to Float8E4M3FN.
-  return convertToFp8(loc, src, rewriter.getFloat8E4M3FNUZType(), 4, 7, true,
+  return convertToFp8(loc, src, rewriter.getFloat8E4M3FNType(), 4, 7, true,
                       false, rewriter);
 }
 


### PR DESCRIPTION
This commit adds list of supported dtypes on CPU for test_fp8_support
from test_compile_errors.py suit. Also in upstream in ir.cc updated
get_fp8e4nv_ty and currently returns "Float8E4M3FNType" instead of "Float8E4M3FNUZType".
So I am updating corresponding conversions to use similar type.