### PR TITLE
Use 1-D vector reduction op to convert reduce op

### DIFF
--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -128,7 +128,7 @@ class CPUBackend(BaseBackend):
         cpu.passes.ttcpuir.add_convert_elem_manip_ops(pm)
         cpu.passes.ttcpuir.add_convert_dot_op(pm)
         cpu.passes.ttcpuir.add_convert_histogram_op(pm)
-        cpu.passes.ttcpuir.add_convert_reduction_op(pm, False)
+        cpu.passes.ttcpuir.add_convert_reduction_op(pm, True, False)
         cpu.passes.ttcpuir.add_convert_scan_op(pm)
         cpu.passes.ttcpuir.add_convert_cf_ops(pm)
         cpu.passes.ttcpuir.add_convert_atomic_ops(pm)

--- a/third_party/cpu/include/TritonToTritonCPU/Passes.h
+++ b/third_party/cpu/include/TritonToTritonCPU/Passes.h
@@ -29,7 +29,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createConvertControlFlowOps();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertHistogramOp();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertReductionOp();
 std::unique_ptr<OperationPass<ModuleOp>>
-createConvertReductionOp(bool useMultiDimReductionOp);
+createConvertReductionOp(bool useReductionOp, bool useMultiDimReductionOp);
 std::unique_ptr<OperationPass<ModuleOp>> createConvertScanOp();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertAtomicOps();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertDebugOps();

--- a/third_party/cpu/include/TritonToTritonCPU/Passes.td
+++ b/third_party/cpu/include/TritonToTritonCPU/Passes.td
@@ -117,6 +117,10 @@ def ConvertReductionOp : Pass<"triton-cpu-convert-reduction", "mlir::ModuleOp"> 
         Option<"useMultiDimReductionOp", "use-multidim-reduction-op",
                "bool", /*default*/"false",
                "Use vector::MultiDimReductionOp and its default lowering when possible.">,
+
+        Option<"useReductionOp", "use-reduction-op",
+               "bool", /*default*/"false",
+                "Use vector::ReductionOp and its default lowering when possible.">,
     ];
 
     let dependentDialects = ["mlir::arith::ArithDialect",

--- a/third_party/cpu/triton_cpu.cc
+++ b/third_party/cpu/triton_cpu.cc
@@ -47,9 +47,10 @@ void init_triton_cpu_passes_ttcpuir(py::module &&m) {
     pm.addPass(mlir::triton::cpu::createConvertHistogramOp());
   });
   m.def("add_convert_reduction_op",
-        [](mlir::PassManager &pm, bool use_multidim_reduction_op) {
+        [](mlir::PassManager &pm, bool use_reduction_op,
+           bool use_multidim_reduction_op) {
           pm.addPass(mlir::triton::cpu::createConvertReductionOp(
-              use_multidim_reduction_op));
+              use_reduction_op, use_multidim_reduction_op));
         });
   m.def("add_convert_scan_op", [](mlir::PassManager &pm) {
     pm.addPass(mlir::triton::cpu::createConvertScanOp());


### PR DESCRIPTION
This is a PR to use `vector.reduction` for 1-D vectors when lowering `tt.reduce`.

Currently, `triton::ReduceOp` is lowered in a generic way with half shuffled and accumulated. However, some architecture support dedicated reduction instructions (e.g. `vredsum` in RVV), which cannot be inst-selected from current shuffle & accumulate pattern, and sub-optimal code might be generated. The 1-D reduction can be lowered later for specific target in the Target TTCIR stage, or just converted to intrinsics and let LLVM do the code generation.

An alternate approach is keeping the `mapToMultiDimReductionOp` enabled by default, and let the multi-reduction be converted to `llvm.vector.reduce.*` intrinsics for 1-D vectors. But according to [the previous PR](https://github.com/triton-lang/triton-cpu/pull/98#issuecomment-2362386215), current code generation can lead to better results for 2-D reductions.

An `useReductionOp` option is added to the `ConvertReductionOp` pass, and is enabled in the `compiler.py` file of CPU backend.