### PR TITLE
[cpu-v2] Super hacky LinearLayout for DotOperandEncoding

### DIFF
--- a/include/triton/Tools/LinearLayout.h
+++ b/include/triton/Tools/LinearLayout.h
@@ -689,6 +689,7 @@ public:
   llvm::MapVector<StringAttr, int32_t> getFreeVariableMasks() const;
 
   std::string toString() const;
+  void dump() const;
 
   friend bool operator==(LinearLayout lhs, LinearLayout rhs);
   friend bool operator!=(LinearLayout lhs, LinearLayout rhs) {

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMA.cpp
@@ -90,6 +90,8 @@ LogicalResult convertFMADot(triton::DotOp op, triton::DotOp::Adaptor adaptor,
             int z = isCRow
                         ? mIdx * N / nShapePerCTATile * mSizePerThread + nIdx
                         : nIdx * M / mShapePerCTATile * nSizePerThread + mIdx;
+            // TODO: It's a scalar fmad. But LLVM vectorizes it easily. Try to
+            // directly use vector types.
             ret[z] = rewriter.create<LLVM::FMulAddOp>(loc, has[{m + mm, k}],
                                                       hbs[{n + nn, k}], ret[z]);
           }

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -227,14 +227,32 @@ struct TritonDotPattern : public OpConversionPattern<triton::DotOp> {
     auto rank = origShape.size();
     SmallVector<unsigned> retSizePerThread(rank, 1);
     auto numElements = product<int64_t>(origShape);
-    if (numElements / (numWarps * threadsPerWarp) >= 4) {
-      retSizePerThread[rank - 1] = 2;
-      retSizePerThread[rank - 2] = 2;
-    }
-    if (numElements / (numWarps * threadsPerWarp) >= 16) {
-      retSizePerThread[rank - 1] = 4;
-      retSizePerThread[rank - 2] = 4;
-    }
+
+    // TODO: For CPU, where larger vectorization is possible, we can incrase it.
+    // But right now, the hacky linear layout conversion only correctly supports
+    // size=[1, 1]. So commented out for now.
+    //
+    // if (numElements / (numWarps * threadsPerWarp) >= 4) {
+    //   retSizePerThread[rank - 1] = 2;
+    //   retSizePerThread[rank - 2] = 2;
+    // }
+    // if (numElements / (numWarps * threadsPerWarp) >= 16) {
+    //   retSizePerThread[rank - 1] = 4;
+    //   retSizePerThread[rank - 2] = 4;
+    // }
+    // if (numElements / (numWarps * threadsPerWarp) >= 64) {
+    //   retSizePerThread[rank - 1] = 8;
+    //   retSizePerThread[rank - 2] = 8;
+    // }
+    // if (numElements / (numWarps * threadsPerWarp) >= 256) {
+    //   retSizePerThread[rank - 1] = 16;
+    //   retSizePerThread[rank - 2] = 16;
+    // }
+    // if (numElements / (numWarps * threadsPerWarp) >= 1024) {
+    //   retSizePerThread[rank - 1] = 32;
+    //   retSizePerThread[rank - 2] = 32;
+    // }
+
     SmallVector<unsigned> retOrder(rank);
     for (unsigned i = 0; i < rank; ++i)
       retOrder[i] = rank - 1 - i;

--- a/lib/Tools/LinearLayout.cpp
+++ b/lib/Tools/LinearLayout.cpp
@@ -1121,4 +1121,6 @@ std::string LinearLayout::toString() const {
   return ret;
 }
 
+void LinearLayout::dump() const { llvm::outs() << toString() << "\n"; }
+
 } // namespace mlir::triton

--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -148,7 +148,7 @@ def do_bench_cudagraph(fn, rep=20, grad_to_none=None, quantiles=None, return_mod
         return _summarize_statistics(torch.tensor(ret), quantiles, return_mode)
 
 
-def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, fast_flush=True, return_mode="mean",
+def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, fast_flush=True, return_mode="median",
              device_type="cuda", measure_time_with_hooks=False):
     """
     Benchmark the runtime of the provided function. By default, return the median runtime of :code:`fn` along with

--- a/python/tutorials/03-matrix-multiplication-cpu.py
+++ b/python/tutorials/03-matrix-multiplication-cpu.py
@@ -154,9 +154,10 @@ import torch
 import triton
 import triton.language as tl
 
-BLOCK_SIZE_M = 32
-BLOCK_SIZE_N = 32
-BLOCK_SIZE_K = 32
+# It depends on CPU cache sizes, but 16 looks better.
+BLOCK_SIZE_M = 16
+BLOCK_SIZE_N = 16
+BLOCK_SIZE_K = 16
 GROUP_SIZE_M = 8
 USE_GPU = False
 
@@ -284,10 +285,10 @@ def matmul(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor):
 
 torch.manual_seed(0)
 
-triton.runtime.driver.set_active_to_cpu()
+triton.runtime.driver.set_active_to_cpu(experimental=True)
 
-a = torch.randn((512, 512), device='cpu', dtype=torch.float32)
-b = torch.randn((512, 512), device='cpu', dtype=torch.float32)
+a = torch.randn((1024, 1024), device='cpu', dtype=torch.float32)
+b = torch.randn((1024, 1024), device='cpu', dtype=torch.float32)
 triton_output = matmul(a, b, None)
 torch_output = torch.matmul(a, b)
 print(f"triton_cpu_output_with_{a.dtype}_inputs={triton_output}")
@@ -309,9 +310,11 @@ else:
 # We can now compare the performance of our kernel against that of Pytorch. Here we focus on square matrices,
 # but feel free to arrange this script as you wish to benchmark any other matrix shape.
 
-LINE_VALS = ['triton-cpu-single', 'triton-cpu', 'torch-cpu-native', 'torch-cpu-compile']
-LINE_NAMES = ['TritonCPU 1', 'TritonCPU', 'TorchCPU (native)', 'TorchCPU (compile)']
-LINE_STYLES = [('blue', '--'), ('blue', '-'), ('green', '--'), ('green', '-')]
+LINE_VALS = [
+    'triton-cpu-single', 'triton-cpu', 'triton-cpu-single-v2', 'triton-cpu-v2', 'torch-cpu-native', 'torch-cpu-compile'
+]
+LINE_NAMES = ['TritonCPU 1', 'TritonCPU', 'TritonCPU 1-v2', 'TritonCPU-v2', 'TorchCPU (native)', 'TorchCPU (compile)']
+LINE_STYLES = [('blue', '--'), ('blue', '-'), ('red', '--'), ('red', '-'), ('green', '--'), ('green', '-')]
 
 if USE_GPU and triton.runtime.driver.get_active_gpus():
     triton.runtime.driver.set_active_to_gpu()
@@ -367,11 +370,11 @@ def benchmark(M, N, K, provider):
 
     if device == 'cpu':
         c = torch.empty((M, N), device=a.device, dtype=a.dtype)
-        triton.runtime.driver.set_active_to_cpu()
         if 'single' in provider:
             os.environ['TRITON_CPU_SINGLE_CORE'] = '1'
         else:
             os.unsetenv('TRITON_CPU_SINGLE_CORE')
+        triton.runtime.driver.set_active_to_cpu(experimental='v2' in provider)
     else:
         c = None
         triton.runtime.driver.set_active_to_gpu()
@@ -390,9 +393,9 @@ def benchmark(M, N, K, provider):
         compiled = torch.compile(torch.matmul)
         ms, min_ms, max_ms = triton.testing.do_bench(lambda: compiled(a, b, out=c), quantiles=quantiles,
                                                      device_type=device)
-    elif provider == 'triton-cpu-single':
+    elif provider == 'triton-cpu-single' or provider == 'triton-cpu-single-v2':
         ms, min_ms, max_ms = triton.testing.do_bench(lambda: matmul(a, b, c), quantiles=quantiles, device_type=device)
-    elif provider == 'triton-cpu':
+    elif provider == 'triton-cpu' or provider == 'triton-cpu-v2':
         ms, min_ms, max_ms = triton.testing.do_bench(lambda: matmul(a, b, c), quantiles=quantiles, device_type=device)
     perf = lambda ms: 2 * M * N * K * 1e-9 / (ms * 1e-3)
     return perf(ms), perf(max_ms), perf(min_ms)


### PR DESCRIPTION
A super dirty hacky implementation for `DotOperandEncodingAttr::toLinearLayout` to support dot operations, except for dot 3d.

The default Triton dot operator is implemented in [lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMA.cpp](https://github.com/triton-lang/triton-cpu/blob/ed82c339e5c9b9329d1ef3b3edea0d64e515f6ce/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMA.cpp#L93), which is very straightforward: a typical tiled matmul using fmad. Super interestingly, this baseline implementation gives a 2-3x speedup over `vector::contract` on an old Skylake machine. A similar speedup was also found on a newer Zen CPU. It's just one data point.

Anyhow, I just want to make this PoC to be more complete for any future reference. A few more diffs will be coming. 

![image](https://github.com/user-attachments/assets/d508ef34-4179-4ee0-875a-700fb453f251)

```
matmul-performance-fp32 (BLOCK_SIZE_M=16, BLOCK_SIZE_N=16, BLOCK_SIZE_K=16, GROUP_SIZE_M=8):
         M       N       K  TritonCPU 1   TritonCPU  TritonCPU 1-v2  TritonCPU-v2  TorchCPU (native)  TorchCPU (compile)
0    256.0   256.0   256.0     7.036959   77.954712       16.428116    113.784017         103.533996           55.422010
1    384.0   384.0   384.0     7.230106  150.841788       17.204728    235.383417         490.327067          225.532065
2    512.0   512.0   512.0     7.225359  169.606151       15.678304    340.981592         302.056098          238.439254
3    640.0   640.0   640.0     8.446829  152.775801       18.351114    348.153957         884.579578          630.762605
4    768.0   768.0   768.0     7.755974  174.997340       18.437344    322.425636         979.202088          724.205525
5    896.0   896.0   896.0     8.655725  198.077089       21.896762    364.840157        1306.871087         1066.739422
6   1024.0  1024.0  1024.0     7.742679  138.717416       13.581063    292.883598        1266.702432         1041.146183
7   1152.0  1152.0  1152.0     7.898757  144.209921       17.972409    373.602146        1531.475764         1298.970273
8   1280.0  1280.0  1280.0     7.519190  140.955475       15.280781    277.869713        1523.763737         1536.006856
9   1408.0  1408.0  1408.0     7.753607  200.386900       18.532695    358.697687        1966.566358         1723.504763
10  1536.0  1536.0  1536.0     7.234100  133.445015       14.938264    263.123460        2076.778321         1550.281877
11  1664.0  1664.0  1664.0     6.843227  185.578426       15.800448    297.677816        1902.277679         1956.235468
12  1792.0  1792.0  1792.0     6.861423  107.019089       14.774886    278.501985        1614.930886         1720.022893
13  1920.0  1920.0  1920.0     5.950670  129.171256       14.176932    263.127435        2405.761380         1871.888075
14  2048.0  2048.0  2048.0     6.582817  132.821055       13.027225    251.888866        2298.148734         2269.880690
15  2176.0  2176.0  2176.0     6.333814  154.877825       14.378767    387.185947        2618.869065         1985.559814
16  2304.0  2304.0  2304.0     6.532545  130.434220       12.991961    284.836640        1886.539027         1866.574822
17  2432.0  2432.0  2432.0     6.237915  149.736527       14.073907    279.264443        1967.746614         1924.814993
18  2560.0  2560.0  2560.0     6.223824  139.880248       12.502659    244.735870        1912.993018         1920.422939
```