### PR TITLE
Introduce DotOp lowering to AMX

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -26,6 +26,7 @@
 #include "triton/Conversion/TritonToTritonGPU/Passes.h"
 #include "triton/Target/LLVMIR/Passes.h"
 
+#include "mlir/Dialect/AMX/AMXDialect.h"
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/InitAllPasses.h"
@@ -82,9 +83,9 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
                   mlir::triton::gpu::TritonGPUDialect, mlir::math::MathDialect,
                   mlir::arith::ArithDialect, mlir::scf::SCFDialect,
                   mlir::memref::MemRefDialect, mlir::vector::VectorDialect,
-                  mlir::tensor::TensorDialect, mlir::gpu::GPUDialect,
-                  mlir::LLVM::LLVMDialect, mlir::NVVM::NVVMDialect,
-                  mlir::triton::nvgpu::NVGPUDialect,
+                  mlir::amx::AMXDialect, mlir::tensor::TensorDialect,
+                  mlir::gpu::GPUDialect, mlir::LLVM::LLVMDialect,
+                  mlir::NVVM::NVVMDialect, mlir::triton::nvgpu::NVGPUDialect,
                   mlir::triton::amdgpu::TritonAMDGPUDialect,
                   mlir::ROCDL::ROCDLDialect>();
 }

--- a/test/TritonCPU/dot-to-amx.mlir
+++ b/test/TritonCPU/dot-to-amx.mlir
@@ -1,0 +1,250 @@
+// RUN: triton-opt %s -split-input-file -triton-cpu-convert-dot-to-amx="convert-bf16=true convert-fp16=true convert-i8=true" -canonicalize | FileCheck %s
+
+// Replacement of a contraction operation with a single tile_mulf operation.
+
+// CHECK-LABEL: @test_single_mulf
+// CHECK:       %[[RHS_BUF:.+]] = memref.alloca() {alignment = 64 : i64} : memref<16x32xbf16>
+// CHECK:       %[[OUT_MEMREF:.+]] = triton_cpu.extract_memref %2 : <tensor<16x16xf32>> -> memref<16x16xf32, strided<[16, 1]>>
+// CHECK-NEXT:  %[[OUT_INDICES:.+]]:2 = triton_cpu.extract_indices %2 : <tensor<16x16xf32>> -> index, index
+// CHECK:       %[[ACC:.+]] = amx.tile_zero : vector<16x16xf32>
+// CHECK-NEXT:  %[[LHS:.+]] = amx.tile_load %3[%4#0, %4#1]
+// CHECK-NEXT:  %[[RHS:.+]] = amx.tile_load %[[RHS_BUF]][%c0{{.*}}, %c0{{.*}}]
+// CHECK-NEXT:  %[[RES:.+]] = amx.tile_mulf %[[LHS]], %[[RHS]], %[[ACC]] : vector<16x32xbf16>, vector<16x32xbf16>, vector<16x16xf32>
+// CHECK-NEXT:  amx.tile_store %[[OUT_MEMREF]][%[[OUT_INDICES]]#0, %[[OUT_INDICES]]#1], %[[RES]] : memref<16x16xf32, strided<[16, 1]>>, vector<16x16xf32>
+
+#loc = loc(unknown)
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+module {
+  tt.func public @test_single_mulf(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32} loc(unknown), %arg1: !tt.ptr<bf16> {tt.divisibility = 16 : i32} loc(unknown), %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc(unknown)) attributes {noinline = false} {
+    %cst = arith.constant 0.000000e+00 : bf16 loc(#loc)
+    %cst_0 = arith.constant dense<0.000000e+00> : vector<16x16xf32> loc(#loc)
+    %c16_i64 = arith.constant 16 : i64 loc(#loc)
+    %c32_i64 = arith.constant 32 : i64 loc(#loc)
+    %c1_i64 = arith.constant 1 : i64 loc(#loc)
+    %c0_i32 = arith.constant 0 : i32 loc(#loc)
+    %0 = tt.make_tensor_ptr %arg0, [%c16_i64, %c32_i64], [%c32_i64, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<16x32xbf16>> loc(#loc)
+    %1 = tt.make_tensor_ptr %arg1, [%c32_i64, %c16_i64], [%c16_i64, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<32x16xbf16>> loc(#loc)
+    %2 = tt.make_tensor_ptr %arg2, [%c16_i64, %c16_i64], [%c16_i64, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<16x16xf32>> loc(#loc)
+    %3 = triton_cpu.extract_memref %0 : <tensor<16x32xbf16>> -> memref<16x32xbf16, strided<[32, 1]>> loc(#loc)
+    %4:2 = triton_cpu.extract_indices %0 : <tensor<16x32xbf16>> -> index, index loc(#loc)
+    %5 = vector.transfer_read %3[%4#0, %4#1], %cst {in_bounds = [true, true]} : memref<16x32xbf16, strided<[32, 1]>>, vector<16x32xbf16> loc(#loc)
+    %6 = triton_cpu.extract_memref %1 : <tensor<32x16xbf16>> -> memref<32x16xbf16, strided<[16, 1]>> loc(#loc)
+    %7:2 = triton_cpu.extract_indices %1 : <tensor<32x16xbf16>> -> index, index loc(#loc)
+    %8 = vector.transfer_read %6[%7#0, %7#1], %cst {in_bounds = [true, true]} : memref<32x16xbf16, strided<[16, 1]>>, vector<32x16xbf16> loc(#loc)
+    %9 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %5, %8, %cst_0 : vector<16x32xbf16>, vector<32x16xbf16> into vector<16x16xf32> loc(#loc)
+    %10 = triton_cpu.extract_memref %2 : <tensor<16x16xf32>> -> memref<16x16xf32, strided<[16, 1]>> loc(#loc)
+    %11:2 = triton_cpu.extract_indices %2 : <tensor<16x16xf32>> -> index, index loc(#loc)
+    vector.transfer_write %9, %10[%11#0, %11#1] {in_bounds = [true, true]} : vector<16x16xf32>, memref<16x16xf32, strided<[16, 1]>> loc(#loc)
+    tt.return loc(#loc)
+  } loc(#loc)
+} loc(#loc)
+
+// -----
+
+// Replacement of a contraction operation with multiple tile_muli operations.
+
+// CHECK-LABEL: @test_single_tile_two_muli
+// CHECK:       %[[RHS_BUF:.+]] = memref.alloca() {alignment = 64 : i64} : memref<32x64xi8>
+// CHECK:       %[[OUT_MEMREF:.+]] = triton_cpu.extract_memref %2 : <tensor<16x16xi32>> -> memref<16x16xi32, strided<[16, 1]>>
+// CHECK-NEXT:  %[[OUT_INDICES:.+]]:2 = triton_cpu.extract_indices %2 : <tensor<16x16xi32>> -> index, index
+// CHECK:       %[[ACC:.+]] = amx.tile_zero : vector<16x16xi32>
+// CHECK-NEXT:  %[[LHS1:.+]] = amx.tile_load %3[%4#0, %4#1]
+// CHECK-NEXT:  %[[RHS1:.+]] = amx.tile_load %[[RHS_BUF]][%c0{{.*}}, %c0{{.*}}]
+// CHECK-NEXT:  %[[RES1:.+]] = amx.tile_muli %[[LHS1]], %[[RHS1]], %[[ACC]] : vector<16x64xi8>, vector<16x64xi8>, vector<16x16xi32>
+// CHECK-NEXT:  %[[IDX1:.+]] = arith.addi %4#1, %c64{{.*}} : index
+// CHECK-NEXT:  %[[LHS2:.+]] = amx.tile_load %3[%4#0, %[[IDX1]]] : memref<16x128xi8, strided<[128, 1]>> into vector<16x64xi8>
+// CHECK-NEXT:  %[[RHS2:.+]] = amx.tile_load %[[RHS_BUF]][%c16{{.*}}, %c0{{.*}}] : memref<32x64xi8> into vector<16x64xi8>
+// CHECK-NEXT:  %[[RES2:.+]] = amx.tile_muli %[[LHS2]], %[[RHS2]], %[[RES1]] : vector<16x64xi8>, vector<16x64xi8>, vector<16x16xi32>
+// CHECK-NEXT:  amx.tile_store %[[OUT_MEMREF]][%[[OUT_INDICES]]#0, %[[OUT_INDICES]]#1], %[[RES2]] : memref<16x16xi32, strided<[16, 1]>>, vector<16x16xi32>
+
+#loc = loc(unknown)
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+module {
+  tt.func public @test_single_tile_two_muli(%arg0: !tt.ptr<i8> {tt.divisibility = 16 : i32} loc(unknown), %arg1: !tt.ptr<i8> {tt.divisibility = 16 : i32} loc(unknown), %arg2: !tt.ptr<i32> {tt.divisibility = 16 : i32} loc(unknown)) attributes {noinline = false} {
+    %c0_i8 = arith.constant 0 : i8 loc(#loc)
+    %cst = arith.constant dense<0> : vector<16x16xi32> loc(#loc)
+    %c16_i64 = arith.constant 16 : i64 loc(#loc)
+    %c128_i64 = arith.constant 128 : i64 loc(#loc)
+    %c1_i64 = arith.constant 1 : i64 loc(#loc)
+    %c0_i32 = arith.constant 0 : i32 loc(#loc)
+    %0 = tt.make_tensor_ptr %arg0, [%c16_i64, %c128_i64], [%c128_i64, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<16x128xi8>> loc(#loc)
+    %1 = tt.make_tensor_ptr %arg1, [%c128_i64, %c16_i64], [%c16_i64, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<128x16xi8>> loc(#loc)
+    %2 = tt.make_tensor_ptr %arg2, [%c16_i64, %c16_i64], [%c16_i64, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<16x16xi32>> loc(#loc)
+    %3 = triton_cpu.extract_memref %0 : <tensor<16x128xi8>> -> memref<16x128xi8, strided<[128, 1]>> loc(#loc)
+    %4:2 = triton_cpu.extract_indices %0 : <tensor<16x128xi8>> -> index, index loc(#loc)
+    %5 = vector.transfer_read %3[%4#0, %4#1], %c0_i8 {in_bounds = [true, true]} : memref<16x128xi8, strided<[128, 1]>>, vector<16x128xi8> loc(#loc)
+    %6 = triton_cpu.extract_memref %1 : <tensor<128x16xi8>> -> memref<128x16xi8, strided<[16, 1]>> loc(#loc)
+    %7:2 = triton_cpu.extract_indices %1 : <tensor<128x16xi8>> -> index, index loc(#loc)
+    %8 = vector.transfer_read %6[%7#0, %7#1], %c0_i8 {in_bounds = [true, true]} : memref<128x16xi8, strided<[16, 1]>>, vector<128x16xi8> loc(#loc)
+    %9 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %5, %8, %cst : vector<16x128xi8>, vector<128x16xi8> into vector<16x16xi32> loc(#loc)
+    %10 = triton_cpu.extract_memref %2 : <tensor<16x16xi32>> -> memref<16x16xi32, strided<[16, 1]>> loc(#loc)
+    %11:2 = triton_cpu.extract_indices %2 : <tensor<16x16xi32>> -> index, index loc(#loc)
+    vector.transfer_write %9, %10[%11#0, %11#1] {in_bounds = [true, true]} : vector<16x16xi32>, memref<16x16xi32, strided<[16, 1]>> loc(#loc)
+    tt.return loc(#loc)
+  } loc(#loc)
+} loc(#loc)
+
+// -----
+
+// Replacement of a contraction operation with multiple tile_mulf operations
+// and multiple output tiles.
+
+// CHECK-LABEL: @test_two_tiles_four_mulf
+// CHECK:       %[[RHS_BUF:.+]] = memref.alloca() {alignment = 64 : i64} : memref<32x64xbf16>
+// CHECK:       %[[OUT_MEMREF:.+]] = triton_cpu.extract_memref %2 : <tensor<16x32xf32>> -> memref<16x32xf32, strided<[32, 1]>>
+// CHECK-NEXT:  %[[OUT_INDICES:.+]]:2 = triton_cpu.extract_indices %2 : <tensor<16x32xf32>> -> index, index
+// CHECK:       %[[ACC1:.+]] = amx.tile_zero : vector<16x16xf32>
+// CHECK-NEXT:  %[[ACC2:.+]] = amx.tile_zero : vector<16x16xf32>
+// CHECK-NEXT:  %[[LHS1:.+]] = amx.tile_load %3[%4#0, %4#1] : memref<16x64xbf16, strided<[64, 1]>> into vector<16x32xbf16>
+// CHECK-NEXT:  %[[RHS1:.+]] = amx.tile_load %[[RHS_BUF]][%c0{{.*}}, %c0{{.*}}] : memref<32x64xbf16> into vector<16x32xbf16>
+// CHECK-NEXT:  %[[RES1:.+]] = amx.tile_mulf %[[LHS1]], %[[RHS1]], %[[ACC1]] : vector<16x32xbf16>, vector<16x32xbf16>, vector<16x16xf32>
+// CHECK:       %[[RHS2:.+]] = amx.tile_load %[[RHS_BUF]][%c0{{.*}}, %c32{{.*}}] : memref<32x64xbf16> into vector<16x32xbf16>
+// CHECK-NEXT:  %[[RES2:.+]] = amx.tile_mulf %[[LHS1]], %[[RHS2]], %[[ACC2]] : vector<16x32xbf16>, vector<16x32xbf16>, vector<16x16xf32>
+// CHECK:       %[[IDX1:.+]] = arith.addi %4#1, %c32{{.*}} : index
+// CHECK-NEXT:  %[[LHS2:.+]] = amx.tile_load %3[%4#0, %[[IDX1]]] : memref<16x64xbf16, strided<[64, 1]>> into vector<16x32xbf16>
+// CHECK:       %[[RHS3:.+]] = amx.tile_load %[[RHS_BUF]][%c16{{.*}}, %c0{{.*}}] : memref<32x64xbf16> into vector<16x32xbf16>
+// CHECK-NEXT:  %[[RES3:.+]] = amx.tile_mulf %[[LHS2]], %[[RHS3]], %[[RES1]] : vector<16x32xbf16>, vector<16x32xbf16>, vector<16x16xf32>
+// CHECK-NEXT:  amx.tile_store %[[OUT_MEMREF]][%[[OUT_INDICES]]#0, %[[OUT_INDICES]]#1], %[[RES3]] : memref<16x32xf32, strided<[32, 1]>>, vector<16x16xf32>
+// CHECK:       %[[RHS4:.+]] = amx.tile_load %[[RHS_BUF]][%c16{{.*}}, %c32{{.*}}] : memref<32x64xbf16> into vector<16x32xbf16>
+// CHECK-NEXT:  %[[RES4:.+]] = amx.tile_mulf %[[LHS2]], %[[RHS4]], %[[RES2]] : vector<16x32xbf16>, vector<16x32xbf16>, vector<16x16xf32>
+// CHECK:       %[[IDX2:.+]] = arith.addi %[[OUT_INDICES]]#1, %c16{{.*}} : index
+// CHECK-NEXT:  amx.tile_store %[[OUT_MEMREF]][%[[OUT_INDICES]]#0, %[[IDX2]]], %[[RES4]] : memref<16x32xf32, strided<[32, 1]>>, vector<16x16xf32>
+
+#loc = loc(unknown)
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+module {
+  tt.func public @test_two_tiles_four_mulf(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32} loc(unknown), %arg1: !tt.ptr<bf16> {tt.divisibility = 16 : i32} loc(unknown), %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc(unknown)) attributes {noinline = false} {
+    %cst = arith.constant 0.000000e+00 : bf16 loc(#loc)
+    %cst_0 = arith.constant dense<0.000000e+00> : vector<16x32xf32> loc(#loc)
+    %c32_i64 = arith.constant 32 : i64 loc(#loc)
+    %c16_i64 = arith.constant 16 : i64 loc(#loc)
+    %c64_i64 = arith.constant 64 : i64 loc(#loc)
+    %c1_i64 = arith.constant 1 : i64 loc(#loc)
+    %c0_i32 = arith.constant 0 : i32 loc(#loc)
+    %0 = tt.make_tensor_ptr %arg0, [%c16_i64, %c64_i64], [%c64_i64, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<16x64xbf16>> loc(#loc)
+    %1 = tt.make_tensor_ptr %arg1, [%c64_i64, %c32_i64], [%c32_i64, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<64x32xbf16>> loc(#loc)
+    %2 = tt.make_tensor_ptr %arg2, [%c16_i64, %c32_i64], [%c32_i64, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<16x32xf32>> loc(#loc)
+    %3 = triton_cpu.extract_memref %0 : <tensor<16x64xbf16>> -> memref<16x64xbf16, strided<[64, 1]>> loc(#loc)
+    %4:2 = triton_cpu.extract_indices %0 : <tensor<16x64xbf16>> -> index, index loc(#loc)
+    %5 = vector.transfer_read %3[%4#0, %4#1], %cst {in_bounds = [true, true]} : memref<16x64xbf16, strided<[64, 1]>>, vector<16x64xbf16> loc(#loc)
+    %6 = triton_cpu.extract_memref %1 : <tensor<64x32xbf16>> -> memref<64x32xbf16, strided<[32, 1]>> loc(#loc)
+    %7:2 = triton_cpu.extract_indices %1 : <tensor<64x32xbf16>> -> index, index loc(#loc)
+    %8 = vector.transfer_read %6[%7#0, %7#1], %cst {in_bounds = [true, true]} : memref<64x32xbf16, strided<[32, 1]>>, vector<64x32xbf16> loc(#loc)
+    %9 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %5, %8, %cst_0 : vector<16x64xbf16>, vector<64x32xbf16> into vector<16x32xf32> loc(#loc)
+    %10 = triton_cpu.extract_memref %2 : <tensor<16x32xf32>> -> memref<16x32xf32, strided<[32, 1]>> loc(#loc)
+    %11:2 = triton_cpu.extract_indices %2 : <tensor<16x32xf32>> -> index, index loc(#loc)
+    vector.transfer_write %9, %10[%11#0, %11#1] {in_bounds = [true, true]} : vector<16x32xf32>, memref<16x32xf32, strided<[32, 1]>> loc(#loc)
+    tt.return loc(#loc)
+  } loc(#loc)
+} loc(#loc)
+
+// -----
+
+// More complicated case with a loop, input casts, and accumulator that
+// cannot fit tile register file.
+
+// CHECK-LABEL: @test_loop_acc_two_blocks
+// CHECK:       %[[LHS_BUF:.+]] = memref.alloca() {alignment = 64 : i64} : memref<64x64xbf16>
+// CHECK:       %[[RHS_BUF:.+]] = memref.alloca() {alignment = 64 : i64} : memref<32x64xbf16>
+// CHECK:       %[[ACC_BUF:.+]] = memref.alloca() {alignment = 64 : i64} : memref<64x32xf32>
+// CHECK:       vector.transfer_write %cst{{.+}}, %[[ACC_BUF]][%c0{{.*}}, %c0{{.*}}] {in_bounds = [true, true]}  : vector<64x32xf32>, memref<64x32xf32>
+// CHECK:       %3:2 = scf.for %arg3 = %c0_i32 to %c2_i32 step %c1_i32 iter_args(%arg4 = %0, %arg5 = %1) -> (!tt.ptr<tensor<64x64xf8E5M2>>, !tt.ptr<tensor<64x32xf8E5M2>>) : i32
+// CHECK:         %[[LHS:.+]] = vector.transfer_read %{{.+}}[%{{.+}}#0, %{{.+}}#1], %{{.+}} {in_bounds = [true, true]} : memref<64x128xf8E5M2, strided<[128, 1]>>, vector<64x64xf8E5M2>
+// CHECK:         %[[RHS:.+]] = vector.transfer_read %{{.+}}[%{{.+}}#0, %{{.+}}#1], %{{.+}} {in_bounds = [true, true]} : memref<128x32xf8E5M2, strided<[32, 1]>>, vector<64x32xf8E5M2>
+// CHECK-NEXT:    %[[LHS1:.+]] = arith.extf %[[LHS]] : vector<64x64xf8E5M2> to vector<64x64xbf16>
+// CHECK-NEXT:    vector.transfer_write %[[LHS1]], %[[LHS_BUF]][%c0{{.*}}, %c0{{.*}}] {in_bounds = [true, true]} : vector<64x64xbf16>, memref<64x64xbf16>
+// CHECK-NEXT:    %[[RHS1:.+]] = arith.extf %[[RHS]] : vector<64x32xf8E5M2> to vector<64x32xbf16>
+// CHECK-COUNT-32: vector.store %{{.+}}, %[[RHS_BUF]][%{{.+}}, %{{.+}}] : memref<32x64xbf16>, vector<64xbf16>
+// CHECK-NEXT:    %[[ACC_0_0:.+]] = amx.tile_load %[[ACC_BUF]][%c0{{.*}}, %c0{{.*}}] : memref<64x32xf32> into vector<16x16xf32>
+// CHECK-NEXT:    %[[ACC_0_1:.+]] = amx.tile_load %[[ACC_BUF]][%c0{{.*}}, %c16{{.*}}] : memref<64x32xf32> into vector<16x16xf32>
+// CHECK-NEXT:    %[[ACC_1_0:.+]] = amx.tile_load %[[ACC_BUF]][%c16{{.*}}, %c0{{.*}}] : memref<64x32xf32> into vector<16x16xf32>
+// CHECK-NEXT:    %[[ACC_1_1:.+]] = amx.tile_load %[[ACC_BUF]][%c16{{.*}}, %c16{{.*}}] : memref<64x32xf32> into vector<16x16xf32>
+// CHECK-NEXT:    %[[LHS_0_0:.+]] = amx.tile_load %[[LHS_BUF]][%c0{{.*}}, %c0{{.*}}] : memref<64x64xbf16> into vector<16x32xbf16>
+// CHECK-NEXT:    %[[LHS_1_0:.+]] = amx.tile_load %[[LHS_BUF]][%c16{{.*}}, %c0{{.*}}] : memref<64x64xbf16> into vector<16x32xbf16>
+// CHECK-NEXT:    %[[RHS_0_0:.+]] = amx.tile_load %[[RHS_BUF]][%c0{{.*}}, %c0{{.*}}] : memref<32x64xbf16> into vector<16x32xbf16>
+// CHECK-NEXT:    %[[TMP_0_0:.+]] = amx.tile_mulf %[[LHS_0_0]], %[[RHS_0_0]], %[[ACC_0_0]] : vector<16x32xbf16>, vector<16x32xbf16>, vector<16x16xf32>
+// CHECK-NEXT:    %[[TMP_1_0:.+]] = amx.tile_mulf %[[LHS_1_0]], %[[RHS_0_0]], %[[ACC_1_0]] : vector<16x32xbf16>, vector<16x32xbf16>, vector<16x16xf32>
+// CHECK-NEXT:    %[[RHS_0_1:.+]] = amx.tile_load %[[RHS_BUF]][%c0{{.*}}, %c32{{.*}}] : memref<32x64xbf16> into vector<16x32xbf16>
+// CHECK-NEXT:    %[[TMP_0_1:.+]] = amx.tile_mulf %[[LHS_0_0]], %[[RHS_0_1]], %[[ACC_0_1]] : vector<16x32xbf16>, vector<16x32xbf16>, vector<16x16xf32>
+// CHECK-NEXT:    %[[TMP_1_1:.+]] = amx.tile_mulf %[[LHS_1_0]], %[[RHS_0_1]], %[[ACC_1_1]] : vector<16x32xbf16>, vector<16x32xbf16>, vector<16x16xf32>
+// CHECK-NEXT:    %[[LHS_0_1:.+]] = amx.tile_load %[[LHS_BUF]][%c0{{.*}}, %c32{{.*}}] : memref<64x64xbf16> into vector<16x32xbf16>
+// CHECK-NEXT:    %[[LHS_1_1:.+]] = amx.tile_load %[[LHS_BUF]][%c16{{.*}}, %c32{{.*}}] : memref<64x64xbf16> into vector<16x32xbf16>
+// CHECK-NEXT:    %[[RHS_1_0:.+]] = amx.tile_load %[[RHS_BUF]][%c16{{.*}}, %c0{{.*}}] : memref<32x64xbf16> into vector<16x32xbf16>
+// CHECK-NEXT:    %[[RES_0_0:.+]] = amx.tile_mulf %[[LHS_0_1]], %[[RHS_1_0]], %[[TMP_0_0]] : vector<16x32xbf16>, vector<16x32xbf16>, vector<16x16xf32>
+// CHECK-NEXT:    amx.tile_store %[[ACC_BUF]][%c0{{.*}}, %c0{{.*}}], %[[RES_0_0]] : memref<64x32xf32>, vector<16x16xf32>
+// CHECK-NEXT:    %[[RES_1_0:.+]] = amx.tile_mulf %[[LHS_1_1]], %[[RHS_1_0]], %[[TMP_1_0]] : vector<16x32xbf16>, vector<16x32xbf16>, vector<16x16xf32>
+// CHECK-NEXT:    amx.tile_store %[[ACC_BUF]][%c16{{.*}}, %c0{{.*}}], %[[RES_1_0]] : memref<64x32xf32>, vector<16x16xf32>
+// CHECK-NEXT:    %[[RHS_1_1:.+]] = amx.tile_load %[[RHS_BUF]][%c16{{.*}}, %c32{{.*}}] : memref<32x64xbf16> into vector<16x32xbf16>
+// CHECK-NEXT:    %[[RES_0_1:.+]] = amx.tile_mulf %[[LHS_0_1]], %[[RHS_1_1]], %[[TMP_0_1]] : vector<16x32xbf16>, vector<16x32xbf16>, vector<16x16xf32>
+// CHECK-NEXT:    amx.tile_store %[[ACC_BUF]][%c0{{.*}}, %c16{{.*}}], %[[RES_0_1]] : memref<64x32xf32>, vector<16x16xf32>
+// CHECK-NEXT:    %[[RES_1_1:.+]] = amx.tile_mulf %[[LHS_1_1]], %[[RHS_1_1]], %[[TMP_1_1]] : vector<16x32xbf16>, vector<16x32xbf16>, vector<16x16xf32>
+// CHECK-NEXT:    amx.tile_store %[[ACC_BUF]][%c16{{.*}}, %c16{{.*}}], %[[RES_1_1]] : memref<64x32xf32>, vector<16x16xf32>
+// CHECK-NEXT:    %[[ACC_2_0:.+]] = amx.tile_load %[[ACC_BUF]][%c32{{.*}}, %c0{{.*}}] : memref<64x32xf32> into vector<16x16xf32>
+// CHECK-NEXT:    %[[ACC_2_1:.+]] = amx.tile_load %[[ACC_BUF]][%c32{{.*}}, %c16{{.*}}] : memref<64x32xf32> into vector<16x16xf32>
+// CHECK-NEXT:    %[[ACC_3_0:.+]] = amx.tile_load %[[ACC_BUF]][%c48{{.*}}, %c0{{.*}}] : memref<64x32xf32> into vector<16x16xf32>
+// CHECK-NEXT:    %[[ACC_3_1:.+]] = amx.tile_load %[[ACC_BUF]][%c48{{.*}}, %c16{{.*}}] : memref<64x32xf32> into vector<16x16xf32>
+// CHECK-NEXT:    %[[LHS_2_0:.+]] = amx.tile_load %[[LHS_BUF]][%c32{{.*}}, %c0{{.*}}] : memref<64x64xbf16> into vector<16x32xbf16>
+// CHECK-NEXT:    %[[LHS_3_0:.+]] = amx.tile_load %[[LHS_BUF]][%c48{{.*}}, %c0{{.*}}] : memref<64x64xbf16> into vector<16x32xbf16>
+// CHECK-NEXT:    %[[RHS_0_0:.+]] = amx.tile_load %[[RHS_BUF]][%c0{{.*}}, %c0{{.*}}] : memref<32x64xbf16> into vector<16x32xbf16>
+// CHECK-NEXT:    %[[TMP_2_0:.+]] = amx.tile_mulf %[[LHS_2_0]], %[[RHS_0_0]], %[[ACC_2_0]] : vector<16x32xbf16>, vector<16x32xbf16>, vector<16x16xf32>
+// CHECK-NEXT:    %[[TMP_3_0:.+]] = amx.tile_mulf %[[LHS_3_0]], %[[RHS_0_0]], %[[ACC_3_0]] : vector<16x32xbf16>, vector<16x32xbf16>, vector<16x16xf32>
+// CHECK-NEXT:    %[[RHS_0_1:.+]] = amx.tile_load %[[RHS_BUF]][%c0{{.*}}, %c32{{.*}}] : memref<32x64xbf16> into vector<16x32xbf16>
+// CHECK-NEXT:    %[[TMP_2_1:.+]] = amx.tile_mulf %[[LHS_2_0]], %[[RHS_0_1]], %[[ACC_2_1]] : vector<16x32xbf16>, vector<16x32xbf16>, vector<16x16xf32>
+// CHECK-NEXT:    %[[TMP_3_1:.+]] = amx.tile_mulf %[[LHS_3_0]], %[[RHS_0_1]], %[[ACC_3_1]] : vector<16x32xbf16>, vector<16x32xbf16>, vector<16x16xf32>
+// CHECK-NEXT:    %[[LHS_2_1:.+]] = amx.tile_load %[[LHS_BUF]][%c32{{.*}}, %c32{{.*}}] : memref<64x64xbf16> into vector<16x32xbf16>
+// CHECK-NEXT:    %[[LHS_3_1:.+]] = amx.tile_load %[[LHS_BUF]][%c48{{.*}}, %c32{{.*}}] : memref<64x64xbf16> into vector<16x32xbf16>
+// CHECK-NEXT:    %[[RHS_1_0:.+]] = amx.tile_load %[[RHS_BUF]][%c16{{.*}}, %c0{{.*}}] : memref<32x64xbf16> into vector<16x32xbf16>
+// CHECK-NEXT:    %[[RES_2_0:.+]] = amx.tile_mulf %[[LHS_2_1]], %[[RHS_1_0]], %[[TMP_2_0]] : vector<16x32xbf16>, vector<16x32xbf16>, vector<16x16xf32>
+// CHECK-NEXT:    amx.tile_store %[[ACC_BUF]][%c32{{.*}}, %c0{{.*}}], %[[RES_2_0]] : memref<64x32xf32>, vector<16x16xf32>
+// CHECK-NEXT:    %[[RES_3_0:.+]] = amx.tile_mulf %[[LHS_3_1]], %[[RHS_1_0]], %[[TMP_3_0]] : vector<16x32xbf16>, vector<16x32xbf16>, vector<16x16xf32>
+// CHECK-NEXT:    amx.tile_store %[[ACC_BUF]][%c48{{.*}}, %c0{{.*}}], %[[RES_3_0]] : memref<64x32xf32>, vector<16x16xf32>
+// CHECK-NEXT:    %[[RHS_1_1:.+]] = amx.tile_load %[[RHS_BUF]][%c16{{.*}}, %c32{{.*}}] : memref<32x64xbf16> into vector<16x32xbf16>
+// CHECK-NEXT:    %[[RES_2_1:.+]] = amx.tile_mulf %[[LHS_2_1]], %[[RHS_1_1]], %[[TMP_2_1]] : vector<16x32xbf16>, vector<16x32xbf16>, vector<16x16xf32>
+// CHECK-NEXT:    amx.tile_store %[[ACC_BUF]][%c32{{.*}}, %c16{{.*}}], %[[RES_2_1]] : memref<64x32xf32>, vector<16x16xf32>
+// CHECK-NEXT:    %[[RES_3_1:.+]] = amx.tile_mulf %[[LHS_3_1]], %[[RHS_1_1]], %[[TMP_3_1]] : vector<16x32xbf16>, vector<16x32xbf16>, vector<16x16xf32>
+// CHECK-NEXT:    amx.tile_store %[[ACC_BUF]][%c48{{.*}}, %c16{{.*}}], %[[RES_3_1]] : memref<64x32xf32>, vector<16x16xf32>
+// CHECK:       %[[RES:.+]] = vector.transfer_read %[[ACC_BUF]][%c0{{.*}}, %c0{{.*}}], %{{.*}} {in_bounds = [true, true]} : memref<64x32xf32>, vector<64x32xf32>
+
+#loc = loc(unknown)
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+module {
+  tt.func public @test_loop_acc_two_blocks(%arg0: !tt.ptr<f8E5M2> {tt.divisibility = 16 : i32} loc(unknown), %arg1: !tt.ptr<f8E5M2> {tt.divisibility = 16 : i32} loc(unknown), %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc(unknown)) attributes {noinline = false} {
+    %cst = arith.constant 0.000000e+00 : f8E5M2 loc(#loc)
+    %c2_i32 = arith.constant 2 : i32 loc(#loc)
+    %c1_i32 = arith.constant 1 : i32 loc(#loc)
+    %c64_i32 = arith.constant 64 : i32 loc(#loc)
+    %cst_0 = arith.constant dense<0.000000e+00> : vector<64x32xf32> loc(#loc)
+    %c32_i64 = arith.constant 32 : i64 loc(#loc)
+    %c64_i64 = arith.constant 64 : i64 loc(#loc)
+    %c128_i64 = arith.constant 128 : i64 loc(#loc)
+    %c1_i64 = arith.constant 1 : i64 loc(#loc)
+    %c0_i32 = arith.constant 0 : i32 loc(#loc)
+    %0 = tt.make_tensor_ptr %arg0, [%c64_i64, %c128_i64], [%c128_i64, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<64x64xf8E5M2>> loc(#loc)
+    %1 = tt.make_tensor_ptr %arg1, [%c128_i64, %c32_i64], [%c32_i64, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<64x32xf8E5M2>> loc(#loc)
+    %2 = tt.make_tensor_ptr %arg2, [%c64_i64, %c32_i64], [%c32_i64, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<64x32xf32>> loc(#loc)
+    %3:3 = scf.for %arg3 = %c0_i32 to %c2_i32 step %c1_i32 iter_args(%arg4 = %cst_0, %arg5 = %0, %arg6 = %1) -> (vector<64x32xf32>, !tt.ptr<tensor<64x64xf8E5M2>>, !tt.ptr<tensor<64x32xf8E5M2>>)  : i32 {
+      %6 = triton_cpu.extract_memref %arg5 : <tensor<64x64xf8E5M2>> -> memref<64x128xf8E5M2, strided<[128, 1]>> loc(#loc)
+      %7:2 = triton_cpu.extract_indices %arg5 : <tensor<64x64xf8E5M2>> -> index, index loc(#loc)
+      %8 = vector.transfer_read %6[%7#0, %7#1], %cst {in_bounds = [true, true]} : memref<64x128xf8E5M2, strided<[128, 1]>>, vector<64x64xf8E5M2> loc(#loc)
+      %9 = triton_cpu.extract_memref %arg6 : <tensor<64x32xf8E5M2>> -> memref<128x32xf8E5M2, strided<[32, 1]>> loc(#loc)
+      %10:2 = triton_cpu.extract_indices %arg6 : <tensor<64x32xf8E5M2>> -> index, index loc(#loc)
+      %11 = vector.transfer_read %9[%10#0, %10#1], %cst {in_bounds = [true, true]} : memref<128x32xf8E5M2, strided<[32, 1]>>, vector<64x32xf8E5M2> loc(#loc)
+      %12 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %8, %11, %arg4 : vector<64x64xf8E5M2>, vector<64x32xf8E5M2> into vector<64x32xf32> loc(#loc)
+      %13 = tt.advance %arg5, [%c0_i32, %c64_i32] : <tensor<64x64xf8E5M2>> loc(#loc)
+      %14 = tt.advance %arg6, [%c64_i32, %c0_i32] : <tensor<64x32xf8E5M2>> loc(#loc)
+      scf.yield %12, %13, %14 : vector<64x32xf32>, !tt.ptr<tensor<64x64xf8E5M2>>, !tt.ptr<tensor<64x32xf8E5M2>> loc(#loc)
+    } loc(#loc)
+    %4 = triton_cpu.extract_memref %2 : <tensor<64x32xf32>> -> memref<64x32xf32, strided<[32, 1]>> loc(#loc)
+    %5:2 = triton_cpu.extract_indices %2 : <tensor<64x32xf32>> -> index, index loc(#loc)
+    vector.transfer_write %3#0, %4[%5#0, %5#1] {in_bounds = [true, true]} : vector<64x32xf32>, memref<64x32xf32, strided<[32, 1]>> loc(#loc)
+    tt.return loc(#loc)
+  } loc(#loc)
+} loc(#loc)

--- a/third_party/cpu/CMakeLists.txt
+++ b/third_party/cpu/CMakeLists.txt
@@ -4,7 +4,7 @@ add_subdirectory(include)
 add_subdirectory(lib)
 if(TRITON_BUILD_PYTHON_MODULE)
   add_triton_plugin(TritonCPU ${CMAKE_CURRENT_SOURCE_DIR}/triton_cpu.cc LINK_LIBS TritonCPUToLLVM TritonCPUTransforms)
-  target_link_libraries(TritonCPU PUBLIC MLIRVectorToSCF MLIRAffineToStandard MLIRMathToLibm)
+  target_link_libraries(TritonCPU PUBLIC MLIRVectorToSCF MLIRAffineToStandard MLIRMathToLibm MLIRAMXToLLVMIRTranslation)
 endif()
 
 add_library(TritonCPURuntime SHARED ${CMAKE_CURRENT_SOURCE_DIR}/runtime/cpu_runtime.cpp)

--- a/third_party/cpu/include/TritonCPUTransforms/Passes.h
+++ b/third_party/cpu/include/TritonCPUTransforms/Passes.h
@@ -33,6 +33,10 @@ std::unique_ptr<OperationPass<ModuleOp>> createConvertDotProduct();
 std::unique_ptr<OperationPass<ModuleOp>>
 createConvertDotProduct(bool useHorizontalSum);
 
+std::unique_ptr<OperationPass<ModuleOp>> createConvertDotToAMX();
+std::unique_ptr<OperationPass<ModuleOp>>
+createConvertDotToAMX(bool convertInt8, bool convertFp16, bool convertBf16);
+
 #define GEN_PASS_REGISTRATION
 #include "cpu/include/TritonCPUTransforms/Passes.h.inc"
 

--- a/third_party/cpu/include/TritonCPUTransforms/Passes.td
+++ b/third_party/cpu/include/TritonCPUTransforms/Passes.td
@@ -98,4 +98,31 @@ def ConvertDotProduct : Pass<"triton-cpu-convert-dot-product", "mlir::ModuleOp">
                              "mlir::triton::cpu::TritonCPUDialect"];
 }
 
+def ConvertDotToAMX : Pass<"triton-cpu-convert-dot-to-amx", "mlir::ModuleOp"> {
+    let summary = "Convert dot product op to AMX dialect.";
+    let description = [{
+        This pass is used to lower matmul operations to amx dialect.
+    }];
+
+    let options = [
+        Option<"convertInt8", "convert-i8",
+               "bool", /*default*/"false",
+               "Use AMX extensions for int8 type.">,
+        Option<"convertFp16", "convert-fp16",
+               "bool", /*default*/"false",
+               "Use AMX extensions for ifp16 type.">,
+        Option<"convertBf16", "convert-bf16",
+               "bool", /*default*/"false",
+               "Use AMX extensions for bf16 type.">,
+    ];
+
+    let constructor = "mlir::triton::cpu::createConvertDotToAMX()";
+
+    let dependentDialects = ["mlir::arith::ArithDialect",
+                             "mlir::vector::VectorDialect",
+                             "mlir::amx::AMXDialect",
+                             "mlir::triton::TritonDialect",
+                             "mlir::triton::cpu::TritonCPUDialect"];
+}
+
 #endif

--- a/third_party/cpu/lib/TritonCPUTransforms/CMakeLists.txt
+++ b/third_party/cpu/lib/TritonCPUTransforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_triton_library(TritonCPUTransforms
     ConvertDotProduct.cpp
+    ConvertDotToAMX.cpp
     ConvertUnsupportedOps.cpp
     DecomposeFpConversions.cpp
     OptimizeMasks.cpp

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertDotToAMX.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertDotToAMX.cpp
@@ -1,0 +1,852 @@
+#include "cpu/include/TritonCPUTransforms/OptCommon.h"
+
+#include "cpu/include/TritonCPUTransforms/Passes.h"
+
+#include "mlir/Dialect/AMX/AMXDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "include/triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonCPU/IR/Dialect.h"
+#include <iostream>
+#include <utility>
+
+namespace mlir {
+namespace triton {
+namespace cpu {
+#define GEN_PASS_DEF_CONVERTDOTTOAMX
+#include "cpu/include/TritonCPUTransforms/Passes.h.inc"
+} // namespace cpu
+} // namespace triton
+} // namespace mlir
+
+#define DEBUG_TYPE "triton-cpu-dot-to-amx"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using namespace mlir;
+using namespace mlir::triton;
+using namespace mlir::triton::cpu;
+
+namespace {
+
+// This struct describes buffers used to load/store AMX tiles.
+struct AmxBuffer {
+  Value memRef;
+  SmallVector<Value, 2> indices;
+};
+
+// This structure is used to hold candidates for conversion to AMX
+// Mul[F|I]Op operations.
+struct AmxDotOpCandidate {
+  // Operation to convert.
+  vector::ContractionOp op;
+  // Available LHS, RHS, and accumulator types are limited in AMX and we might
+  // require additional casts. Here we keep actual element types used by LHS,
+  // RHS, and accumulator in AMX tiles.
+  Type lhsTileElemTy;
+  Type rhsTileElemTy;
+  Type accTileElemTy;
+  // AMX tile row size is limited by 64 bytes, so M and N dimensions are limited
+  // by 16 because accumulator always has 4-byte elements. K dimension for tiles
+  // is limited by 64 / <size of input element>. Here we keep actual tile sizes.
+  int64_t tileM;
+  int64_t tileN;
+  int64_t tileK;
+  // We have a limited number of available tiles, so if input/output is too
+  // big to fit available tiles, we need to split them into blocks. Here we
+  // keep a number of tiles in accumulator block. K dimension for input blocks
+  // is always 1 tile now.
+  int64_t tilesInBlockM;
+  int64_t tilesInBlockN;
+  // If accumulator is updated in a loop, then this flag indicates if we
+  // should keep it in tiles the whole loop and move back to vectors only
+  // after the loop.
+  bool keepAccOnTiles = false;
+  // If we want to keep accumulator in tiles but it's too big, then we might
+  // keep it bufferized instead.
+  bool keepAccInBuf = false;
+};
+
+bool checkIdxMap(Attribute attr, unsigned int v1, unsigned int v2) {
+  auto map = cast<AffineMapAttr>(attr).getAffineMap();
+  return map ==
+         AffineMap::getMultiDimMapWithTargets(3, {v1, v2}, attr.getContext());
+}
+
+// Return true if specified contraction op is actually a converted DotOp.
+bool isDotOp(vector::ContractionOp op) {
+  // First, check ranks of inputs.
+  if (cast<VectorType>(op.getLhs().getType()).getRank() != 2 ||
+      cast<VectorType>(op.getRhs().getType()).getRank() != 2 ||
+      cast<VectorType>(op.getAcc().getType()).getRank() != 2) {
+    LDBG("Drop candidate with rank != 2");
+    return false;
+  }
+
+  // Matmul uses add as a combining function.
+  if (op.getKind() != vector::CombiningKind::ADD) {
+    LDBG("Drop candidate with combining function " << op.getKind());
+    return false;
+  }
+
+  // Expect two parallel and one reduction iterators.
+  auto iterTypes = op.getIteratorTypes();
+  if (iterTypes.size() != 3 ||
+      cast<vector::IteratorTypeAttr>(iterTypes[0]).getValue() !=
+          vector::IteratorType::parallel ||
+      cast<vector::IteratorTypeAttr>(iterTypes[1]).getValue() !=
+          vector::IteratorType::parallel ||
+      cast<vector::IteratorTypeAttr>(iterTypes[2]).getValue() !=
+          vector::IteratorType::reduction) {
+    LDBG("Drop candidate with mismatched iterator types.");
+    return false;
+  }
+
+  // Check affine maps.
+  // TODO: be less restrictive on maps to allow transposed inputs?
+  auto idxMaps = op.getIndexingMaps();
+  if (!checkIdxMap(idxMaps[0], 0, 2) || !checkIdxMap(idxMaps[1], 2, 1) ||
+      !checkIdxMap(idxMaps[2], 0, 1)) {
+    LDBG("Drop candidate with mismatched affine maps.");
+    return false;
+  }
+
+  return true;
+}
+
+// Check if input and output types can be handled by AMX (possibly, using
+// additional casts for input/output). Returns tru if AMX usage is possible.
+// In this case, tile element type fields of the candidate structure are
+// filled with actual types to be used in lowering.
+bool checkElemTypes(Type lhsElemTy, Type rhsElemTy, Type accElemTy,
+                    Type resElemTy, bool supportInt8, bool supportFp16,
+                    bool supportBf16, AmxDotOpCandidate &candidate) {
+  MLIRContext *ctx = lhsElemTy.getContext();
+  if (lhsElemTy.isInteger()) {
+    if (!supportInt8) {
+      LDBG("Drop candidate because AMX_INT8 is not available.");
+      return false;
+    }
+
+    // For integer case only i8 is allowed for LHS and RHS.
+    if (!lhsElemTy.isInteger(8) || !rhsElemTy.isInteger(8)) {
+      LDBG("Drop candidate with unsupported input integer type.");
+      return false;
+    }
+
+    // Accumulator should be i32. If it's smaller, we will use casts.
+    if (!accElemTy.isInteger() || accElemTy.getIntOrFloatBitWidth() > 32 ||
+        !resElemTy.isInteger() || resElemTy.getIntOrFloatBitWidth() > 32) {
+      LDBG("Drop candidate with unsupported output integer type.");
+      return false;
+    }
+
+    candidate.lhsTileElemTy = IntegerType::get(ctx, 8);
+    candidate.rhsTileElemTy = IntegerType::get(ctx, 8);
+    candidate.accTileElemTy = IntegerType::get(ctx, 32);
+
+    return true;
+  }
+
+  // FP case. Expect no integer args or result.
+  if (rhsElemTy.isInteger() || accElemTy.isInteger() || resElemTy.isInteger()) {
+    LDBG("Drop candidate with mixed int/fp types.");
+    return false;
+  }
+
+  // For fp case LHS and RHS types should match and can be either FP16 or
+  // BF16.
+  if (lhsElemTy.getIntOrFloatBitWidth() > 16 ||
+      rhsElemTy.getIntOrFloatBitWidth() > 16) {
+    LDBG("Drop candidate with unsupported input fp type.");
+    return false;
+  }
+
+  // Try to find common input type.
+  Type commonInputElemTy;
+  if (lhsElemTy.getIntOrFloatBitWidth() == 16) {
+    commonInputElemTy = lhsElemTy;
+    if (rhsElemTy.getIntOrFloatBitWidth() == 16 &&
+        rhsElemTy != commonInputElemTy) {
+      LDBG("Drop candidate with mismatched input types.");
+      return false;
+    }
+  } else if (rhsElemTy.getIntOrFloatBitWidth() == 16)
+    commonInputElemTy = rhsElemTy;
+  // Both inputs are FP8, choose 16-bit FP type to use.
+  else if (supportBf16)
+    commonInputElemTy = BFloat16Type::get(ctx);
+  else
+    commonInputElemTy = Float16Type::get(ctx);
+
+  if (commonInputElemTy.isF16() && !supportFp16) {
+    LDBG("Drop candidate because AMX_FP16 is not available.");
+    return false;
+  }
+
+  if (commonInputElemTy.isBF16() && !supportBf16) {
+    LDBG("Drop candidate because AMX_BF16 is not available.");
+    return false;
+  }
+
+  // Accumulator type should be FP32, we can use casts if it is smaller.
+  if (accElemTy.getIntOrFloatBitWidth() > 32) {
+    LDBG("Drop candidate with unsupported accumulator type.");
+    return false;
+  }
+
+  candidate.lhsTileElemTy = commonInputElemTy;
+  candidate.rhsTileElemTy = commonInputElemTy;
+  candidate.accTileElemTy = Float32Type::get(ctx);
+
+  return true;
+}
+
+// Check if accumulator value is updated in a loop and has no other
+// usages than a dot op, that updates it. Tile loads/stores and casts
+// for such accumulators can be done outside of the loop.
+bool isLoopCarriedAcc(Value acc) {
+  LDBG("Check if accumulator can be held in tiles: " << acc);
+  if (!acc.hasOneUse()) {
+    LDBG("  No. Has multiple uses.");
+    for (auto op : acc.getUsers())
+      LDBG("    " << *op);
+    return false;
+  }
+
+  auto blockArg = dyn_cast<BlockArgument>(acc);
+  if (!blockArg) {
+    LDBG("  No. Not a block argument.");
+    return false;
+  }
+
+  auto forOp = dyn_cast<scf::ForOp>(blockArg.getOwner()->getParentOp());
+  if (!forOp) {
+    LDBG("  No. Not in a for-loop.");
+    return false;
+  }
+
+  blockArg.getArgNumber();
+
+  Value updAcc = acc.getUsers().begin()->getResult(0);
+  if (!updAcc.hasOneUse()) {
+    LDBG("  No. Has multiple uses.");
+    return false;
+  }
+
+  auto &updAccUse = *updAcc.getUses().begin();
+  if (!isa<scf::YieldOp>(updAccUse.getOwner()) ||
+      updAccUse.getOperandNumber() !=
+          (blockArg.getArgNumber() - forOp.getNumInductionVars())) {
+    LDBG("  No. Loop carried dependency not detected.");
+    return false;
+  }
+
+  LDBG("  Yes.");
+  return true;
+}
+
+// Choose tile and block sizes for the candidate. Tile sizes are determined
+// by input shapes and types. Block sizes are chosen to minimize number of
+// tile loads/stores including tile register spills.
+void setupBlockAndTileSizes(ArrayRef<int64_t> lhsShape,
+                            ArrayRef<int64_t> rhsShape,
+                            AmxDotOpCandidate &candidate) {
+  int64_t m = lhsShape[0];
+  int64_t n = rhsShape[1];
+  int64_t k = rhsShape[0];
+  int64_t tileM = std::min(m, (int64_t)16);
+  int64_t tileN = std::min(n, (int64_t)16);
+  int64_t tileK = std::min(
+      k, (int64_t)512 / candidate.lhsTileElemTy.getIntOrFloatBitWidth());
+
+  int64_t accBlocksM = m / tileM;
+  int64_t accBlocksN = n / tileN;
+
+  // All these sizes are power of 2. We have 8 tile registers and
+  // cannot use them all for accumulator. So, we will use up to 4
+  // tiles for accumulator in a single block.
+  while (accBlocksM * accBlocksN > 4) {
+    if (accBlocksM > accBlocksN)
+      accBlocksM /= 2;
+    else
+      accBlocksN /= 2;
+  }
+
+  candidate.tileM = tileM;
+  candidate.tileN = tileN;
+  candidate.tileK = tileK;
+  candidate.tilesInBlockM = accBlocksM;
+  candidate.tilesInBlockN = accBlocksN;
+}
+
+// Check if specified ContractionOp can be lowered to AMX operations.
+// If conversion is possible, then true is returned and candidate
+// structure is filled with detailed transformation info.
+bool isAmxCandidate(vector::ContractionOp op, bool supportInt8,
+                    bool supportFp16, bool supportBf16,
+                    AmxDotOpCandidate &candidate) {
+  MLIRContext *ctx = op.getContext();
+  VectorType lhsTy = cast<VectorType>(op.getLhs().getType());
+  VectorType rhsTy = cast<VectorType>(op.getRhs().getType());
+  VectorType accTy = cast<VectorType>(op.getAcc().getType());
+  VectorType resTy = cast<VectorType>(op.getType());
+
+  LDBG("Considering candidate op: " << op);
+
+  // Contraction op is very generic. For now, we generate it only as a
+  // result of DotOp conversion. But still check it's what we expect.
+  if (!isDotOp(op))
+    return false;
+
+  // Check if input and output types match available hardware capabilities.
+  // If check is successful then tile element types are filled with types
+  // to use in AMX operations.
+  if (!checkElemTypes(lhsTy.getElementType(), rhsTy.getElementType(),
+                      accTy.getElementType(), resTy.getElementType(),
+                      supportInt8, supportFp16, supportBf16, candidate))
+    return false;
+
+  candidate.op = op;
+  setupBlockAndTileSizes(lhsTy.getShape(), rhsTy.getShape(), candidate);
+  candidate.keepAccOnTiles = isLoopCarriedAcc(op.getAcc());
+
+  // Can't keep acc in a tile the whole loop right now:
+  // https://github.com/llvm/llvm-project/issues/109481
+  if (candidate.keepAccOnTiles) {
+    // We might not have enough tiles to hold accumulator. In this case
+    // keep it in a bufffer.
+    if (candidate.tilesInBlockM * candidate.tilesInBlockN > 1) {
+      LDBG("Accumulator is too big to keep on tiles. Keep it bufferized "
+           "insterad.");
+      candidate.keepAccOnTiles = false;
+      candidate.keepAccInBuf = true;
+    }
+
+    // TODO: fix LLVM bug and remove this code.
+    LDBG("Avoid accumulator on tiles due to LLVM bug: "
+         "https://github.com/llvm/llvm-project/issues/109481.");
+    LDBG("Keep accumulator bufferized instead.");
+    candidate.keepAccOnTiles = false;
+    candidate.keepAccInBuf = true;
+  }
+
+  return true;
+}
+
+// Cast vector to a specified element type using ext or trunc
+// operations. Return the originl value if it already matches
+// required element type.
+Value maybeCast(Location loc, Value val, Type dstElemTy,
+                PatternRewriter &rewriter) {
+  VectorType srcTy = cast<VectorType>(val.getType());
+  if (srcTy.getElementType() == dstElemTy)
+    return val;
+
+  VectorType dstTy = srcTy.cloneWith(std::nullopt, dstElemTy);
+  if (srcTy.getElementType().isInteger()) {
+    if (srcTy.getElementTypeBitWidth() < dstTy.getElementTypeBitWidth())
+      return rewriter.create<arith::ExtSIOp>(loc, dstTy, val);
+    return rewriter.create<arith::TruncIOp>(loc, dstTy, val);
+  }
+
+  if (srcTy.getElementTypeBitWidth() < dstTy.getElementTypeBitWidth())
+    return rewriter.create<arith::ExtFOp>(loc, dstTy, val);
+  return rewriter.create<arith::TruncFOp>(loc, dstTy, val);
+}
+
+// Get initial value for a loop-carried accumulator.
+Value getInitAccValue(Value val) {
+  auto blockArg = cast<BlockArgument>(val);
+  auto forOp = cast<scf::ForOp>(blockArg.getOwner()->getParentOp());
+  int initValIdx = blockArg.getArgNumber() - forOp.getNumInductionVars();
+  return forOp.getInitArgs()[initValIdx];
+}
+
+VectorType getSwizzledRhsTileType(VectorType origTileType) {
+  int64_t rowsPerGroup = 32 / origTileType.getElementTypeBitWidth();
+  SmallVector<int64_t> shape({origTileType.getDimSize(0) / rowsPerGroup,
+                              origTileType.getDimSize(1) * rowsPerGroup});
+  return origTileType.cloneWith(shape, origTileType.getElementType());
+}
+
+Value allocateTmpBuffer(Location loc, VectorType vecTy, Operation *allocaPoint,
+                        PatternRewriter &rewriter) {
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(allocaPoint);
+  auto memRefTy = MemRefType::get(vecTy.getShape(), vecTy.getElementType());
+  return rewriter.create<memref::AllocaOp>(
+      loc, memRefTy, rewriter.getIntegerAttr(rewriter.getI64Type(), 64));
+}
+
+// Check if vector transfer read/write operation uses a mask
+// or involves a bounds check.
+template <typename T> bool hasMaskOrBoundsCheck(T op) {
+  auto inBounds = op.getInBounds();
+  Value mask = op.getMask();
+  bool hasBoundsCheck =
+      std::any_of(inBounds.begin(), inBounds.end(), [](Attribute attr) {
+        return !cast<mlir::BoolAttr>(attr).getValue();
+      });
+  return hasBoundsCheck || mask;
+}
+
+// In AMX, element values shoud be packed to 32-bit groups that would be
+// multiplied elementwise with following accumulation. It means that RHS
+// needs to be pre-packed. E.g. for the following input
+//   B(0,0) B(0,1) B(0,2) ... B(0,15)
+//   B(1,0) B(1,1) B(1,2) ... B(1,15)
+//   B(2,0) B(2,1) B(2,2) ... B(2,15)
+//   B(3,0) B(3,1) B(3,2) ... B(3,15)
+// and BF16/FP16 type we need to transform it to
+//   B(0,0) B(1,0) B(0,1), B(1,1) ... B(0,15) B(1,15)
+//   B(2,0) B(3,0) B(2,1), B(3,1) ... B(2,15) B(3,15)
+// so that original columns are 32-bits now. In case of int8 type, the
+// result would be:
+//   B(0,0) B(1,0) B(2,0), B(3,0) ... B(0,15) B(1,15), B(2,15) B(3,15)
+void interleaveAndStore(Location loc, Value val, Value buf,
+                        PatternRewriter &rewriter) {
+  LDBG("Repacking operand before storing to a buffer.");
+  VectorType valTy = cast<VectorType>(val.getType());
+  int64_t rowsPerGroup = 32 / valTy.getElementTypeBitWidth();
+  assert(rowsPerGroup == 2 || rowsPerGroup == 4);
+  assert(valTy.getDimSize(0) % rowsPerGroup == 0);
+  Value zeroIdx = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  for (int64_t i = 0; i < valTy.getDimSize(0); i += rowsPerGroup) {
+    Value row1, row2;
+    if (rowsPerGroup == 2) {
+      row1 = rewriter.create<vector::ExtractOp>(loc, val, i);
+      row2 = rewriter.create<vector::ExtractOp>(loc, val, i + 1);
+    } else {
+      row1 = rewriter.create<vector::InterleaveOp>(
+          loc, rewriter.create<vector::ExtractOp>(loc, val, i),
+          rewriter.create<vector::ExtractOp>(loc, val, i + 2));
+      row2 = rewriter.create<vector::InterleaveOp>(
+          loc, rewriter.create<vector::ExtractOp>(loc, val, i + 1),
+          rewriter.create<vector::ExtractOp>(loc, val, i + 3));
+    }
+    Value shuffled = rewriter.create<vector::InterleaveOp>(loc, row1, row2);
+    Value idx = rewriter.create<arith::ConstantIndexOp>(loc, i / rowsPerGroup);
+    rewriter.create<vector::StoreOp>(loc, shuffled, buf,
+                                     SmallVector<Value>({idx, zeroIdx}));
+  }
+}
+
+// Prepare temporary buffers to be used for tile loads. If the original
+// value can be directly loaded to tiles from its original memory, then
+// use it instead. Return empty buffer if source value is all zeros and
+// skipForZeros is set.
+//
+// If interleave flag is set, then pre-pack RHS before sotring. See
+// interleaveAndStore for more details.
+AmxBuffer prepareTensorBuffer(Location loc, Value val, bool interleave,
+                              bool skipForZeros, bool readOnly,
+                              Operation *allocaPoint,
+                              PatternRewriter &rewriter) {
+  LDBG("Preparing buffer (interleave=" << interleave
+                                       << ") for a vector: " << val);
+  auto valLoad = val.getDefiningOp<vector::TransferReadOp>();
+  if (valLoad && !interleave && readOnly && !hasMaskOrBoundsCheck(valLoad)) {
+    Value memRef = valLoad.getSource();
+    ValueRange indices = valLoad.getIndices();
+    LDBG("  Reusing the original memref for a buffer: " << memRef);
+    return {memRef, indices};
+  }
+
+  if (skipForZeros && isZeroConst(val)) {
+    LDBG("Skip buffer for zero vector.");
+    return {};
+  }
+
+  auto vecTy = cast<VectorType>(val.getType());
+  if (interleave)
+    vecTy = getSwizzledRhsTileType(vecTy);
+  Value buf = allocateTmpBuffer(loc, vecTy, allocaPoint, rewriter);
+  Value zeroIdx;
+  {
+    // Create zero index at the same place as a buffer allocation to
+    // dominate all buffer usages.
+    OpBuilder::InsertionGuard g(rewriter);
+    rewriter.setInsertionPoint(allocaPoint);
+    zeroIdx = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  }
+  SmallVector<Value, 2> indices(vecTy.getRank(), zeroIdx);
+
+  if (interleave) {
+    interleaveAndStore(loc, val, buf, rewriter);
+  } else {
+    rewriter.create<vector::TransferWriteOp>(loc, val, buf, indices);
+  }
+
+  return {buf, indices};
+}
+
+Value shiftIndex(Location loc, Value index, int64_t offs,
+                 PatternRewriter &rewriter) {
+  if (!offs)
+    return index;
+
+  // Do constant folding right away here for better code readability
+  // after the pass.
+  auto cstOp = dyn_cast<arith::ConstantOp>(index.getDefiningOp());
+  if (cstOp) {
+    int64_t oldVal = cast<IntegerAttr>(cstOp.getValue()).getInt();
+    return rewriter.create<arith::ConstantIndexOp>(loc, oldVal + offs);
+  }
+
+  Value offsVal = rewriter.create<arith::ConstantIndexOp>(loc, offs);
+  return rewriter.create<arith::AddIOp>(loc, index.getType(), index, offsVal);
+}
+
+SmallVector<Value, 2> shiftIndices(Location loc, ArrayRef<Value> indices,
+                                   VectorType tileTy, int64_t tilesInBlockM,
+                                   int64_t tilesInBlockN, int64_t blockM,
+                                   int64_t blockN, int64_t tileM, int64_t tileN,
+                                   PatternRewriter &rewriter) {
+  int64_t blockOffsM = blockM * tilesInBlockM * tileTy.getDimSize(0);
+  int64_t blockOffsN = blockN * tilesInBlockN * tileTy.getDimSize(1);
+  int64_t tileOffsM = blockOffsM + tileM * tileTy.getDimSize(0);
+  int64_t tileOffsN = blockOffsN + tileN * tileTy.getDimSize(1);
+  return {shiftIndex(loc, indices[0], tileOffsM, rewriter),
+          shiftIndex(loc, indices[1], tileOffsN, rewriter)};
+}
+
+Value loadTile(Location loc, VectorType tileTy, const AmxBuffer &buf,
+               int64_t tilesInBlockM, int64_t tilesInBlockN, int64_t blockM,
+               int64_t blockN, int64_t tileM, int64_t tileN,
+               PatternRewriter &rewriter) {
+  auto indices =
+      shiftIndices(loc, buf.indices, tileTy, tilesInBlockM, tilesInBlockN,
+                   blockM, blockN, tileM, tileN, rewriter);
+  return rewriter.create<amx::TileLoadOp>(loc, tileTy, buf.memRef, indices);
+}
+
+void storeTile(Location loc, VectorType tileTy, Value val, const AmxBuffer &buf,
+               int64_t tilesInBlockM, int64_t tilesInBlockN, int64_t blockM,
+               int64_t blockN, int64_t tileM, int64_t tileN,
+               PatternRewriter &rewriter) {
+  auto indices =
+      shiftIndices(loc, buf.indices, tileTy, tilesInBlockM, tilesInBlockN,
+                   blockM, blockN, tileM, tileN, rewriter);
+  rewriter.create<amx::TileStoreOp>(loc, buf.memRef, indices, val);
+}
+
+SmallVector<SmallVector<Value>>
+loadBlockTiles(Location loc, VectorType tileTy, const AmxBuffer &buf,
+               int64_t tilesInBlockM, int64_t tilesInBlockN, int64_t blockM,
+               int64_t blockN, PatternRewriter &rewriter) {
+  SmallVector<SmallVector<Value>> res(tilesInBlockM);
+  for (int64_t m = 0; m < tilesInBlockM; ++m) {
+    for (int64_t n = 0; n < tilesInBlockN; ++n) {
+      res[m].push_back(loadTile(loc, tileTy, buf, tilesInBlockM, tilesInBlockN,
+                                blockM, blockN, m, n, rewriter));
+    }
+  }
+  return res;
+}
+
+// Move acc to a tile for the whole loop. It might be loads from memory or
+// zero tiles.
+SmallVector<SmallVector<Value>>
+moveLoopAccToTiles(Location loc, VectorType tileTy, const AmxBuffer &buf,
+                   int64_t tilesInBlockM, int64_t tilesInBlockN,
+                   PatternRewriter &rewriter) {
+  LDBG("Loading accumulator to tiles before the loop.");
+  if (buf.memRef)
+    return loadBlockTiles(loc, tileTy, buf, tilesInBlockM, tilesInBlockN, 0, 0,
+                          rewriter);
+
+  // No buffer for accumulator means tiles are zero-initialized.
+  LDBG("  Using zero tiles for accumulator tiles initialization.");
+  SmallVector<SmallVector<Value>> res(tilesInBlockM);
+  for (int64_t m = 0; m < tilesInBlockM; ++m) {
+    for (int64_t n = 0; n < tilesInBlockM; ++n) {
+      res[m].push_back(rewriter.create<amx::TileZeroOp>(loc, tileTy));
+    }
+  }
+
+  // TODO: add new block args into ForOp and return them instead.
+  // Yield directly uses them for now and will be patched after mul
+  // ops generation.
+  llvm_unreachable("Not yet supported.");
+
+  return res;
+}
+
+// Multiply two blocks. LHS block is preloaded to tiles with the following
+// iteration over RHS. Accumulator values are updated in accTiles.
+// Optionally, results can also be stored to accBuf.
+void multiplyBlocksPreloadLhs(Location loc, VectorType lhsTileTy,
+                              VectorType rhsTileTy, VectorType accTileTy,
+                              const AmxBuffer &lhsBuf, const AmxBuffer &rhsBuf,
+                              const AmxBuffer &accBuf, int64_t blockM,
+                              int64_t blockN, int64_t blockK,
+                              int64_t tilesInBlockM, int64_t tilesInBlockN,
+                              SmallVector<SmallVector<Value>> &accTiles,
+                              bool storeResult, PatternRewriter &rewriter) {
+  bool isInteger = accTileTy.getElementType().isInteger();
+  SmallVector<SmallVector<Value>> lhsTiles = loadBlockTiles(
+      loc, lhsTileTy, lhsBuf, tilesInBlockM, 1, blockM, blockK, rewriter);
+
+  for (int64_t tileN = 0; tileN < tilesInBlockN; ++tileN) {
+    Value rhsTile = loadTile(loc, rhsTileTy, rhsBuf, 1, tilesInBlockN, blockK,
+                             blockN, 0, tileN, rewriter);
+
+    for (int64_t tileM = 0; tileM < tilesInBlockM; ++tileM) {
+      if (isInteger)
+        accTiles[tileM][tileN] =
+            rewriter.create<amx::TileMulIOp>(loc, accTileTy, lhsTiles[tileM][0],
+                                             rhsTile, accTiles[tileM][tileN]);
+      else
+        accTiles[tileM][tileN] =
+            rewriter.create<amx::TileMulFOp>(loc, accTileTy, lhsTiles[tileM][0],
+                                             rhsTile, accTiles[tileM][tileN]);
+
+      // Insert store here to better mix stores with multiplications.
+      if (storeResult) {
+        storeTile(loc, accTileTy, accTiles[tileM][tileN], accBuf, tilesInBlockM,
+                  tilesInBlockN, blockM, blockN, tileM, tileN, rewriter);
+      }
+    }
+  }
+}
+
+// Similar to multiplyBlocksPreloadLhs but here RHS is preloaded to tiles.
+void multiplyBlocksPreloadRhs(Location loc, VectorType lhsTileTy,
+                              VectorType rhsTileTy, VectorType accTileTy,
+                              const AmxBuffer &lhsBuf, const AmxBuffer &rhsBuf,
+                              const AmxBuffer &accBuf, int64_t blockM,
+                              int64_t blockN, int64_t blockK,
+                              int64_t tilesInBlockM, int64_t tilesInBlockN,
+                              SmallVector<SmallVector<Value>> &accTiles,
+                              bool storeResult, PatternRewriter &rewriter) {
+  bool isInteger = accTileTy.getElementType().isInteger();
+  SmallVector<SmallVector<Value>> rhsTiles = loadBlockTiles(
+      loc, rhsTileTy, rhsBuf, 1, tilesInBlockN, blockK, blockN, rewriter);
+
+  for (int64_t tileM = 0; tileM < tilesInBlockM; ++tileM) {
+    Value lhsTile = loadTile(loc, lhsTileTy, lhsBuf, tilesInBlockM, 1, blockM,
+                             blockK, tileM, 0, rewriter);
+
+    for (int64_t tileN = 0; tileN < tilesInBlockN; ++tileN) {
+      if (isInteger)
+        accTiles[tileM][tileN] = rewriter.create<amx::TileMulIOp>(
+            loc, accTileTy, lhsTile, rhsTiles[0][tileN],
+            accTiles[tileM][tileN]);
+      else
+        accTiles[tileM][tileN] = rewriter.create<amx::TileMulFOp>(
+            loc, accTileTy, lhsTile, rhsTiles[0][tileN],
+            accTiles[tileM][tileN]);
+
+      // Insert store here to better mix stores with multiplications.
+      if (storeResult) {
+        storeTile(loc, accTileTy, accTiles[tileM][tileN], accBuf, tilesInBlockM,
+                  tilesInBlockN, blockM, blockN, tileM, tileN, rewriter);
+      }
+    }
+  }
+}
+
+LogicalResult convertCandidate(AmxDotOpCandidate &candidate,
+                               PatternRewriter &rewriter) {
+  vector::ContractionOp op = candidate.op;
+  Location loc = op.getLoc();
+  VectorType lhsTy = cast<VectorType>(op.getLhs().getType());
+  VectorType rhsTy = cast<VectorType>(op.getRhs().getType());
+  VectorType accTy = cast<VectorType>(op.getAcc().getType());
+  VectorType resTy = cast<VectorType>(op.getResultType());
+  VectorType lhsTileTy =
+      lhsTy.cloneWith(SmallVector<int64_t>({candidate.tileM, candidate.tileK}),
+                      candidate.lhsTileElemTy);
+  VectorType rhsTileTy = getSwizzledRhsTileType(
+      rhsTy.cloneWith(SmallVector<int64_t>({candidate.tileK, candidate.tileN}),
+                      candidate.rhsTileElemTy));
+  VectorType accTileTy =
+      accTy.cloneWith(SmallVector<int64_t>({candidate.tileM, candidate.tileN}),
+                      candidate.accTileElemTy);
+
+  // Cast input data if required.
+  Value lhs = maybeCast(loc, op.getLhs(), candidate.lhsTileElemTy, rewriter);
+  Value rhs = maybeCast(loc, op.getRhs(), candidate.rhsTileElemTy, rewriter);
+  Value acc = maybeCast(loc, op.getAcc(), candidate.accTileElemTy, rewriter);
+
+  Operation *allocaPoint = op;
+  while (!isa<triton::FuncOp>(allocaPoint->getParentOp()))
+    allocaPoint = allocaPoint->getParentOp();
+
+  Value accToStore = acc;
+  scf::ForOp forOp;
+  if (candidate.keepAccInBuf || candidate.keepAccOnTiles) {
+    forOp = cast<scf::ForOp>(op->getParentOp());
+    accToStore = getInitAccValue(acc);
+  }
+  // Prepare input buffers. It might be temporary buffers with stored
+  // vectors or the original tensor memory where vectors came from.
+  AmxBuffer lhsBuf =
+      prepareTensorBuffer(loc, lhs, false, false, true, allocaPoint, rewriter);
+  AmxBuffer rhsBuf =
+      prepareTensorBuffer(loc, rhs, true, false, true, allocaPoint, rewriter);
+  AmxBuffer accBuf;
+  {
+    // If accumulator is bufferized then we should move initial values before
+    // the loop.
+    OpBuilder::InsertionGuard g(rewriter);
+    if (candidate.keepAccInBuf)
+      rewriter.setInsertionPoint(forOp);
+    accBuf =
+        prepareTensorBuffer(loc, accToStore, false, candidate.keepAccOnTiles,
+                            false, allocaPoint, rewriter);
+  }
+
+  SmallVector<SmallVector<Value>> accTiles;
+  if (candidate.keepAccOnTiles)
+    accTiles =
+        moveLoopAccToTiles(loc, accTileTy, accBuf, candidate.tilesInBlockM,
+                           candidate.tilesInBlockN, rewriter);
+
+  int64_t blocksInAccM =
+      accTy.getDimSize(0) / candidate.tileM / candidate.tilesInBlockM;
+  int64_t blocksInAccN =
+      accTy.getDimSize(1) / candidate.tileN / candidate.tilesInBlockN;
+  int64_t tilesInVectorK = lhsTy.getDimSize(1) / candidate.tileK;
+  for (int64_t blockM = 0; blockM < blocksInAccM; ++blockM) {
+    for (int64_t blockN = 0; blockN < blocksInAccN; ++blockN) {
+      if (!candidate.keepAccOnTiles)
+        accTiles =
+            loadBlockTiles(loc, accTileTy, accBuf, candidate.tilesInBlockM,
+                           candidate.tilesInBlockN, blockM, blockN, rewriter);
+
+      for (int64_t blocK = 0; blocK < tilesInVectorK; ++blocK) {
+        // We can store accumulator if it is the last block over K dimension.
+        // TODO: enable forward store for acc kept in tiles.
+        bool storeAcc =
+            !candidate.keepAccOnTiles && (blocK == (tilesInVectorK - 1));
+        // We need to choose which block (LHS or RHS) to keep on tiles.
+        // E.g. for ACC block 4x1 tiles, LHS block is also 4 tiles, so
+        // we would use all tile registers trying to keep both ACC and
+        // LHS blocks on registers. To decrease register pressure, keep
+        // the smallest block on tiles.
+        if (candidate.tilesInBlockM <= candidate.tilesInBlockN)
+          multiplyBlocksPreloadLhs(
+              loc, lhsTileTy, rhsTileTy, accTileTy, lhsBuf, rhsBuf, accBuf,
+              blockM, blockN, blocK, candidate.tilesInBlockM,
+              candidate.tilesInBlockN, accTiles, storeAcc, rewriter);
+        else
+          multiplyBlocksPreloadRhs(
+              loc, lhsTileTy, rhsTileTy, accTileTy, lhsBuf, rhsBuf, accBuf,
+              blockM, blockN, blocK, candidate.tilesInBlockM,
+              candidate.tilesInBlockN, accTiles, storeAcc, rewriter);
+      }
+    }
+  }
+
+  // TODO: For keepAccOnTiles fix YieldOp to use mul results.
+  // TODO: For keepAccOnTiles move all new forOp results to vector through a
+  // buffer.
+  if (candidate.keepAccOnTiles)
+    llvm_unreachable("Not yet supported.");
+
+  if (candidate.keepAccInBuf) {
+    int resIdx = op.getResult().getUses().begin()->getOperandNumber();
+    Value loopRes = forOp.getResult(resIdx);
+    LDBG(
+        "Loading buffererized accumulator to a vector to replace loop result.");
+    OpBuilder::InsertionGuard g(rewriter);
+    rewriter.setInsertionPointAfter(forOp);
+    Value newVal = rewriter.create<vector::TransferReadOp>(
+        loc, cast<VectorType>(acc.getType()), accBuf.memRef, accBuf.indices);
+    // We might need to cast back to the original type.
+    newVal = maybeCast(loc, newVal, accTy.getElementType(), rewriter);
+    rewriter.replaceAllUsesWith(loopRes, newVal);
+    // For now, just use init value for unused ForOp result instead of
+    // its removal.
+    rewriter.replaceOp(op, op.getAcc());
+  } else {
+    LDBG("Loading the result to a vector to replace orig op result.");
+    Value newVal = rewriter.create<vector::TransferReadOp>(
+        loc, cast<VectorType>(acc.getType()), accBuf.memRef, accBuf.indices);
+    // We might need to cast back to the original type.
+    newVal = maybeCast(loc, newVal, accTy.getElementType(), rewriter);
+    rewriter.replaceOp(op, newVal);
+  }
+
+  return success();
+}
+
+struct ConvertDotToAMX
+    : public triton::cpu::impl::ConvertDotToAMXBase<ConvertDotToAMX> {
+  ConvertDotToAMX() = default;
+  ConvertDotToAMX(bool convertInt8, bool convertFp16, bool convertBf16) {
+    this->convertInt8 = convertInt8;
+    this->convertFp16 = convertFp16;
+    this->convertBf16 = convertBf16;
+  }
+
+  void runOnOperation() override {
+    if (!convertInt8 && !convertFp16 && !convertBf16)
+      return;
+
+    MLIRContext *context = &getContext();
+    ModuleOp mod = getOperation();
+
+    SmallVector<AmxDotOpCandidate> candidates;
+    mod->walk([this, &candidates](vector::ContractionOp op) {
+      AmxDotOpCandidate candidate;
+      if (isAmxCandidate(op, convertInt8, convertFp16, convertBf16,
+                         candidate)) {
+        LLVM_DEBUG({
+          LDBG("Found AMX candidate");
+          LDBG("  Op: " << candidate.op);
+          LDBG("  LhsTileElemTy: " << candidate.lhsTileElemTy);
+          LDBG("  RhsTileElemTy: " << candidate.rhsTileElemTy);
+          LDBG("  AccTileElemTy: " << candidate.accTileElemTy);
+          LDBG("  TileM: " << candidate.tileM);
+          LDBG("  TileN: " << candidate.tileN);
+          LDBG("  TileK: " << candidate.tileK);
+          LDBG("  TilesInBlockM: " << candidate.tilesInBlockM);
+          LDBG("  TilesInBlockN: " << candidate.tilesInBlockN);
+          LDBG("  KeepAccOnTiles: " << candidate.keepAccOnTiles);
+          LDBG("  KeepAccInBuf: " << candidate.keepAccInBuf);
+        });
+        candidates.push_back(candidate);
+      }
+      return WalkResult::advance();
+    });
+
+    for (auto &candidate : candidates) {
+      LDBG("Starting conversion of candidate: " << candidate.op);
+      PatternRewriter rewriter(context);
+      rewriter.setInsertionPoint(candidate.op);
+      if (succeeded(convertCandidate(candidate, rewriter))) {
+        LDBG("Conversion succeeded!");
+      } else {
+        LDBG("Conversion failed!");
+      }
+    }
+  }
+};
+
+} // namespace
+
+namespace mlir {
+namespace triton {
+namespace cpu {
+
+std::unique_ptr<OperationPass<ModuleOp>> createConvertDotToAMX() {
+  return std::make_unique<ConvertDotToAMX>();
+}
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createConvertDotToAMX(bool convertInt8, bool convertFp16, bool convertBf16) {
+  return std::make_unique<ConvertDotToAMX>(convertInt8, convertFp16,
+                                           convertBf16);
+}
+
+} // namespace cpu
+} // namespace triton
+} // namespace mlir


### PR DESCRIPTION
This patch introduces a new pass to lower matmul using AMX vector dialect ops. This implementation is not yet optimal, additional improvements will be added later to reduce number of memory operations.

I checked perf and it improves significantly, especially for single-threaded mode. We will need to find out why multi-threading doesn't provide us with perf scaling as for Torch.
Current perf for BF16:
```
         M       N       K  TritonCPU 1   TritonCPU
0    256.0   256.0   256.0    17.225417  163.044681
1    384.0   384.0   384.0    18.119113  359.164016
2    512.0   512.0   512.0    19.739487  489.369781
3    640.0   640.0   640.0    20.426998  580.103837
4    768.0   768.0   768.0    20.955009  616.985397
5    896.0   896.0   896.0    21.052365  633.909627
6   1024.0  1024.0  1024.0    20.997198  608.552439
7   1152.0  1152.0  1152.0    21.208961  655.427547
8   1280.0  1280.0  1280.0    21.237776  650.337788
9   1408.0  1408.0  1408.0    21.276936  672.059388
10  1536.0  1536.0  1536.0    21.296171  637.686103
11  1664.0  1664.0  1664.0    21.165996  674.407087
12  1792.0  1792.0  1792.0    21.381853  650.100089
13  1920.0  1920.0  1920.0    21.431392  703.496608
14  2048.0  2048.0  2048.0    20.669723  600.316184
15  2176.0  2176.0  2176.0    21.374836  643.259768
16  2304.0  2304.0  2304.0    21.399802  647.396061
17  2432.0  2432.0  2432.0    21.463065  702.588998
18  2560.0  2560.0  2560.0    20.878296  595.502825
```
With AMX:
```
         M       N       K  TritonCPU 1    TritonCPU
0    256.0   256.0   256.0    64.822820   194.724454
1    384.0   384.0   384.0    88.417377   626.866259
2    512.0   512.0   512.0   105.179260  1140.279400
3    640.0   640.0   640.0   133.565009  1827.825676
4    768.0   768.0   768.0   140.301577  2505.696469
5    896.0   896.0   896.0   152.133288  2957.834448
6   1024.0  1024.0  1024.0   115.204263  2657.543214
7   1152.0  1152.0  1152.0   166.852292  4030.719864
8   1280.0  1280.0  1280.0   159.584169  4463.438111
9   1408.0  1408.0  1408.0   177.282924  4599.660047
10  1536.0  1536.0  1536.0   158.283522  4380.471391
11  1664.0  1664.0  1664.0   182.896952  4419.704977
12  1792.0  1792.0  1792.0   186.820812  3817.801849
13  1920.0  1920.0  1920.0   191.386971  3629.086386
14  2048.0  2048.0  2048.0    77.897563  1379.265876
15  2176.0  2176.0  2176.0   190.299742  4031.410525
16  2304.0  2304.0  2304.0   153.199306  2668.240315
17  2432.0  2432.0  2432.0   158.476481  4019.517973
18  2560.0  2560.0  2560.0    89.321591  2866.503689
```
This is for the 03-matrix-multiplication-cpu.py tutorial run for BF16. Note, that AMX benefits from block pointers because it can use 2D loads when stride is known. If I use block pointers in the same tutorial, then I get:
```
         M       N       K  TritonCPU 1    TritonCPU  TorchCPU (native)  TorchCPU (compile)
0    256.0   256.0   256.0    86.280357   234.024517         241.240857          125.619328
1    384.0   384.0   384.0   114.959331   672.623211         581.447522          321.154685
2    512.0   512.0   512.0   147.614149  1385.301724        1394.571195          661.487146
3    640.0   640.0   640.0   150.886982  2200.412954        2204.011208         1052.427848
4    768.0   768.0   768.0   167.960086  3136.449270        3137.481257         1461.790720
5    896.0   896.0   896.0   184.792798  3944.749637        4480.898637         1957.238025
6   1024.0  1024.0  1024.0   146.125984  3218.418959        5939.625967         2606.210571
7   1152.0  1152.0  1152.0   207.224185  5292.455632        6819.854758         2998.726973
8   1280.0  1280.0  1280.0   220.505054  5860.676009        7065.554918         3279.685302
9   1408.0  1408.0  1408.0   228.203427  6270.276785        8517.867225         3801.132363
10  1536.0  1536.0  1536.0   240.228644  5621.776878       10424.850773         4533.975585
11  1664.0  1664.0  1664.0   246.793089  4740.716191        9883.547549         4806.887977
12  1792.0  1792.0  1792.0   247.044848  4232.104521       10125.483381         4932.504192
13  1920.0  1920.0  1920.0   257.051375  4013.117225       10436.133762         5233.231493
14  2048.0  2048.0  2048.0    92.250068  2243.360013       13147.498573         5995.428149
15  2176.0  2176.0  2176.0   239.639722  3523.783778       12639.474844         6286.489910
16  2304.0  2304.0  2304.0   198.155310  3573.135841       13317.473450         6341.796552
17  2432.0  2432.0  2432.0   178.347735  3636.560586       12501.528603         6932.240141
18  2560.0  2560.0  2560.0   114.181116  2580.811585       13146.794639         6671.098741
```
For small sizes, we can reach the same perf as Torch, but then we cannot scale as nicely as Torch does. Probably, the kernel needs to be adjusted for better data locality (e.g. 2048x2048 case is much worse compared to others), and we will need to try autotuner to find the best parameter combination.

I tested this patch on SPR machine (it has AMX_INT8 and AMX_BF16), and all core tests passed. Later, I'll try to add AMX-enabled worker for our CI to have it properly tested. Lit tests will also be added.