### PR TITLE
Lower memory ops with vector gather and scatter

### DIFF
--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -122,8 +122,8 @@ class CPUBackend(BaseBackend):
         # TTIR -> TTCIR
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
-        cpu.passes.ttcpuir.add_scalarize(pm)
-        cpu.passes.ttcpuir.add_convert_memory_ops(pm)
+        cpu.passes.ttcpuir.add_scalarize(pm, True)
+        cpu.passes.ttcpuir.add_convert_memory_ops(pm, True)
         cpu.passes.ttcpuir.add_convert_ptr_ops(pm)
         cpu.passes.ttcpuir.add_convert_elementwise_ops(pm)
         cpu.passes.ttcpuir.add_convert_elem_manip_ops(pm)

--- a/third_party/cpu/include/TritonToTritonCPU/Passes.td
+++ b/third_party/cpu/include/TritonToTritonCPU/Passes.td
@@ -8,6 +8,13 @@ def ConvertMemoryOps : Pass<"triton-cpu-convert-memory-ops", "mlir::ModuleOp"> {
     let description = [{
 
     }];
+
+    let options = [
+        Option<"useGatherScatter", "use-gather-scatter",
+               "bool", /*default*/"false",
+               "Use Gather or Scatter to lower memory ops.">,
+    ];
+
     let constructor = "mlir::triton::cpu::createConvertMemoryOps()";
 
     let dependentDialects = ["mlir::arith::ArithDialect",
@@ -172,6 +179,12 @@ def ScalarizeUsingForOp : Pass<"triton-cpu-scalarize", "mlir::ModuleOp"> {
         operations that cannot be handled as vectors, and simply increases
         the amount of IR without any further optimization.
     }];
+
+    let options = [
+        Option<"skipGatherScatter", "skip-gather-scatter",
+               "bool", /*default*/"false",
+               "Skip scalarizing gather/scatter ops.">,
+    ];
 
     let constructor = "mlir::triton::cpu::createScalarizeUsingForOpPass()";
 

--- a/third_party/cpu/lib/TritonToTritonCPU/ConvertMemoryOps.cpp
+++ b/third_party/cpu/lib/TritonToTritonCPU/ConvertMemoryOps.cpp
@@ -45,9 +45,12 @@ struct MemoryOpConversion : public OpConversionPattern<OpT> {
 
   MemoryOpConversion(ModuleAxisInfoAnalysis &axisInfoAnalysis,
                      ModuleTensorPtrShapeInfoAnalysis &shapeInfoAnalysis,
-                     TypeConverter &typeConverter, MLIRContext *context)
+                     TypeConverter &typeConverter, MLIRContext *context,
+                     bool useGatherScatter)
       : OpConversionPattern<OpT>(typeConverter, context),
-        axisAnalysis(axisInfoAnalysis), shapeAnalysis(shapeInfoAnalysis) {}
+        axisAnalysis(axisInfoAnalysis), shapeAnalysis(shapeInfoAnalysis) {
+    this->useGatherScatter = useGatherScatter;
+  }
 
   Value extractScalarPointer(Location loc, Value ptrs,
                              ArrayRef<int64_t> indices,
@@ -137,6 +140,7 @@ struct MemoryOpConversion : public OpConversionPattern<OpT> {
 protected:
   ModuleAxisInfoAnalysis &axisAnalysis;
   ModuleTensorPtrShapeInfoAnalysis &shapeAnalysis;
+  bool useGatherScatter;
 };
 
 struct LoadOpConversion : public MemoryOpConversion<triton::LoadOp> {
@@ -176,6 +180,9 @@ struct LoadOpConversion : public MemoryOpConversion<triton::LoadOp> {
       auto axisInfo = axisAnalysis.getAxisInfo(ptr);
       if (isContiguousRowMajorAccess(axisInfo, loadOp)) {
         return lowerToContiguousRowMajor(loadOp, rewriter);
+      }
+      if (useGatherScatter && succeeded(lowerToGather(loadOp, rewriter))) {
+        return success();
       }
       return lowerToScalarLoads(loadOp, rewriter);
     }
@@ -257,6 +264,44 @@ struct LoadOpConversion : public MemoryOpConversion<triton::LoadOp> {
     return success();
   }
 
+  LogicalResult lowerToGather(triton::LoadOp loadOp,
+                              ConversionPatternRewriter &rewriter) const {
+    auto loc = loadOp.getLoc();
+    auto vecTy = dyn_cast<VectorType>(
+        getTypeConverter()->convertType(loadOp.getResult().getType()));
+    auto shape = vecTy.getShape();
+
+    auto [basePtr, offset] = getMemoryBaseOffset(loadOp);
+
+    if (!basePtr || !offset)
+      return failure();
+
+    auto pointeeType =
+        dyn_cast<PointerType>(basePtr.getType()).getPointeeType();
+
+    auto gatherBase = rewriter.create<triton::cpu::PtrToMemRefOp>(
+        loc, MemRefType::get({}, pointeeType), basePtr);
+    auto gatherIndices = SmallVector<Value>();
+    auto gatherIndexVec = rewriter.getRemappedValue(offset);
+
+    Value gatherMask;
+    if (auto loadMask = loadOp.getMask()) {
+      gatherMask = rewriter.getRemappedValue(loadMask);
+    } else {
+      auto maskType = VectorType::get(shape, rewriter.getI1Type());
+      gatherMask = rewriter.create<arith::ConstantOp>(
+          loc, maskType, DenseElementsAttr::get(maskType, true));
+    }
+
+    auto passThru = convertOtherVal(loadOp, rewriter);
+
+    auto gatherOp =
+        rewriter.create<vector::GatherOp>(loc, vecTy, gatherBase, gatherIndices,
+                                          gatherIndexVec, gatherMask, passThru);
+    rewriter.replaceOp(loadOp, gatherOp);
+    return success();
+  }
+
   LogicalResult lowerToScalarLoads(triton::LoadOp loadOp,
                                    ConversionPatternRewriter &rewriter) const {
     // Scalar loads and boundary checks are not expected.
@@ -329,6 +374,9 @@ struct StoreOpConversion : public MemoryOpConversion<triton::StoreOp> {
       if (isContiguousRowMajorAccess(axisInfo, storeOp)) {
         return lowerToContiguousRowMajor(storeOp, rewriter);
       }
+      if (useGatherScatter && succeeded(lowerToScatter(storeOp, rewriter))) {
+        return success();
+      }
       return lowerToScalarStores(storeOp, rewriter);
     }
 
@@ -394,6 +442,41 @@ struct StoreOpConversion : public MemoryOpConversion<triton::StoreOp> {
     }
 
     rewriter.eraseOp(storeOp);
+    return success();
+  }
+
+  LogicalResult lowerToScatter(triton::StoreOp storeOp,
+                               ConversionPatternRewriter &rewriter) const {
+    auto loc = storeOp.getLoc();
+    auto vals = rewriter.getRemappedValue(storeOp.getValue());
+    auto vecTy = dyn_cast<VectorType>(vals.getType());
+    auto shape = vecTy.getShape();
+
+    auto [basePtr, offset] = getMemoryBaseOffset(storeOp);
+
+    if (!basePtr || !offset)
+      return failure();
+
+    auto pointeeType =
+        dyn_cast<PointerType>(basePtr.getType()).getPointeeType();
+
+    auto scatterBase = rewriter.create<triton::cpu::PtrToMemRefOp>(
+        loc, MemRefType::get({}, pointeeType), basePtr);
+    auto scatterIndices = SmallVector<Value>();
+    auto scatterIndexVec = rewriter.getRemappedValue(offset);
+
+    Value scatterMask;
+    if (auto storeMask = storeOp.getMask()) {
+      scatterMask = rewriter.getRemappedValue(storeMask);
+    } else {
+      auto maskType = VectorType::get(shape, rewriter.getI1Type());
+      scatterMask = rewriter.create<arith::ConstantOp>(
+          loc, maskType, DenseElementsAttr::get(maskType, true));
+    }
+
+    auto scatterOp = rewriter.create<vector::ScatterOp>(
+        loc, scatterBase, scatterIndices, scatterIndexVec, scatterMask, vals);
+    rewriter.replaceOp(storeOp, scatterOp);
     return success();
   }
 
@@ -511,6 +594,10 @@ struct ConvertMemoryOps
     : public triton::cpu::impl::ConvertMemoryOpsBase<ConvertMemoryOps> {
   ConvertMemoryOps() = default;
 
+  ConvertMemoryOps(bool useGatherScatter) {
+    this->useGatherScatter = useGatherScatter;
+  }
+
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     ModuleOp mod = getOperation();
@@ -522,7 +609,8 @@ struct ConvertMemoryOps
     RewritePatternSet patterns(context);
     patterns.add<LoadOpConversion, StoreOpConversion, CpuStoreOpConversion,
                  CpuLoadOpConversion>(axisInfoAnalysis, shapeInfoAnalysis,
-                                      pointerConverter, context);
+                                      pointerConverter, context,
+                                      useGatherScatter);
 
     if (failed(applyPartialConversion(mod, convTarget, std::move(patterns))))
       return signalPassFailure();
@@ -537,6 +625,11 @@ namespace cpu {
 
 std::unique_ptr<OperationPass<ModuleOp>> createConvertMemoryOps() {
   return std::make_unique<ConvertMemoryOps>();
+}
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createConvertMemoryOps(bool useGatherScatter) {
+  return std::make_unique<ConvertMemoryOps>(useGatherScatter);
 }
 
 } // namespace cpu

--- a/third_party/cpu/triton_cpu.cc
+++ b/third_party/cpu/triton_cpu.cc
@@ -28,11 +28,13 @@ void init_triton_cpu_passes_ttcpuir(py::module &&m) {
       .value("libsleef", cpu::VecLib::Sleef)
       .value("libmvec", cpu::VecLib::Mvec);
 
-  m.def("add_scalarize", [](mlir::PassManager &pm) {
-    pm.addPass(mlir::triton::cpu::createScalarizeUsingForOpPass());
+  m.def("add_scalarize", [](mlir::PassManager &pm, bool skip_gather_scatter) {
+    pm.addPass(
+        mlir::triton::cpu::createScalarizeUsingForOpPass(skip_gather_scatter));
   });
-  m.def("add_convert_memory_ops", [](mlir::PassManager &pm) {
-    pm.addPass(mlir::triton::cpu::createConvertMemoryOps());
+  m.def("add_convert_memory_ops", [](mlir::PassManager &pm,
+                                     bool use_gather_scatter) {
+    pm.addPass(mlir::triton::cpu::createConvertMemoryOps(use_gather_scatter));
   });
   m.def("add_convert_ptr_ops", [](mlir::PassManager &pm) {
     pm.addPass(mlir::triton::cpu::createConvertPtrOps());


### PR DESCRIPTION
This PR add `lowerToGather` and `lowerToScatter` for load and store conversion. Memory ops with the pointer computed from splat and addptr can be lowered with `vector.gather` or `vector.scatter`.

For architectures with scatter and gather support (like SVE and RVV), the code generated with this approach might be more efficient.

Two options are added to scalarization and memory op conversion to enable lowering with gather and scatter operations.
