### PR TITLE
Implement more libdevice functions using extern_elementwise

### DIFF
--- a/include/triton/Dialect/TritonCPU/IR/TritonCPUOps.td
+++ b/include/triton/Dialect/TritonCPU/IR/TritonCPUOps.td
@@ -19,6 +19,27 @@ class TTC_Op<string mnemonic, list<Trait> traits = []> :
        !listconcat(traits, [])> {
 }
 
+//
+// External Elementwise op
+//
+def TTC_ExternElementwiseOp : TTC_Op<"extern_elementwise", [Elementwise,
+                                                            SameOperandsAndResultEncoding,
+                                                            SameVariadicOperandSize,
+                                                            DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+
+    let description = [{
+        Similar to TT_ExternElementwiseOp, but only supports calls to libsleef at the moment.
+        The string "%s(numel)" in $symbol will be interpolated with the number of elements of
+        the vector argument(s).
+    }];
+
+    let arguments = (ins Variadic<TTC_Type>:$srcs, StrAttr:$symbol, BoolAttr:$pure);
+
+    let results = (outs TTC_Type:$result);
+
+    let assemblyFormat = "operands attr-dict `:` functional-type(operands, $result)";
+}
+
 def TTC_ExtractMemRefOp : TTC_Op<"extract_memref", [NoMemoryEffect]> {
   let summary = "Extract base memref from a block pointer";
 

--- a/include/triton/Dialect/TritonCPU/IR/TritonCPUTypes.td
+++ b/include/triton/Dialect/TritonCPU/IR/TritonCPUTypes.td
@@ -26,4 +26,6 @@ def TTC_TokenType : TTC_TypeDef<"Token", "token"> {
 
 def TTC_Vector : VectorOf<[TT_Float, TT_Int]>;
 
+def TTC_Type : AnyTypeOf<[TT_Float, TT_Int, TTC_Vector]>;
+
 #endif

--- a/lib/Dialect/TritonCPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonCPU/IR/Ops.cpp
@@ -15,4 +15,15 @@ LogicalResult PrintOp::verify() {
   return success();
 }
 
+void ExternElementwiseOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  if (getPure())
+    return;
+  effects.emplace_back(MemoryEffects::Write::get(),
+                       SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(),
+                       SideEffects::DefaultResource::get());
+}
+
 } // namespace mlir::triton::cpu

--- a/python/triton/language/extra/cpu/libdevice.py
+++ b/python/triton/language/extra/cpu/libdevice.py
@@ -129,6 +129,33 @@ def trunc(arg0, _builder=None):
     return core.tensor(_builder.create_trunc(arg0.handle), arg0.type)
 
 
+@core.extern
+def ceil(arg0, _builder=None):
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("Sleef_ceilf%(numel)", core.dtype("fp32")),
+            (core.dtype("fp64"), ): ("Sleef_ceild%(numel)", core.dtype("fp64")),
+        }, is_pure=True, _builder=_builder)
+
+
+@core.extern
+def pow(arg0, arg1, _builder=None):
+    return core.extern_elementwise(
+        "", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("Sleef_powf%(numel)_u10", core.dtype("fp32")),
+            (core.dtype("fp64"), core.dtype("fp64")): ("Sleef_powd%(numel)_u10", core.dtype("fp64")),
+        }, is_pure=True, _builder=_builder)
+
+
+@core.extern
+def fmod(arg0, arg1, _builder=None):
+    return core.extern_elementwise(
+        "", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("Sleef_fmodf%(numel)", core.dtype("fp32")),
+            (core.dtype("fp64"), core.dtype("fp64")): ("Sleef_fmodd%(numel)", core.dtype("fp64")),
+        }, is_pure=True, _builder=_builder)
+
+
 @jit
 def _const(v, dtype):
     """

--- a/third_party/cpu/lib/TritonToTritonCPU/ConvertElementwiseOps.cpp
+++ b/third_party/cpu/lib/TritonToTritonCPU/ConvertElementwiseOps.cpp
@@ -59,6 +59,7 @@ public:
     addIllegalOp<triton::MulhiUIOp>();
     addIllegalOp<triton::ClampFOp>();
     addIllegalOp<triton::FpToFpOp>();
+    addIllegalOp<triton::ExternElementwiseOp>();
   }
 };
 
@@ -248,6 +249,9 @@ struct ConvertElementwiseOps
     patterns.add<OpTypeConversion<triton::PreciseDivFOp, arith::DivFOp>>(
         typeConverter, context);
     patterns.add<OpTypeConversion<triton::PreciseSqrtOp, math::SqrtOp>>(
+        typeConverter, context);
+    patterns.add<OpTypeConversion<triton::ExternElementwiseOp,
+                                  triton::cpu::ExternElementwiseOp>>(
         typeConverter, context);
     patterns.add<MulhiUIOpConversion>(typeConverter, context);
     patterns.add<ClampFOpConversion>(typeConverter, context);


### PR DESCRIPTION
This PR adds support for libdevice functions that don't map cleanly to a MathOp. We implement them using tt.extern_elementwise instead, indicating which Sleef function to use.

While tt.extern_elementwise contains fields for the library path and name, the CUDA backend ignores those fields as it always uses the NVIDIA's libdevice library. We take a similar approach here and assume all extern calls go to the Sleef library.

One difference though is that we need to select our Sleef function based on the number of elements of the vector, which is done by interpolating this number into the symbol name. To indicate where this interpolation should occur, I have made `%(numel)` into a special string value. This allows us to reuse tt.extern_elementwise without adding any extra attributes.