### PR TITLE
Fix compilation when ARCH_REQ_XCOMP_PERM isn't defined

### DIFF
--- a/third_party/cpu/triton_cpu.cc
+++ b/third_party/cpu/triton_cpu.cc
@@ -159,6 +159,7 @@ void init_triton_cpu(py::module &&m) {
   init_triton_cpu_passes_ttcpuir(passes.def_submodule("ttcpuir"));
 
   m.def("enable_amx", []() -> bool {
+#ifdef ARCH_REQ_XCOMP_PERM
     // AMX usage requires extended XSTATE which is disabled by default. We
     // need to request access to AMX so that XSTATE was dynamically extended
     // on the first AMX usage instead of issuing SIGILL.
@@ -168,6 +169,9 @@ void init_triton_cpu(py::module &&m) {
     if (syscall(SYS_arch_prctl, ARCH_REQ_XCOMP_PERM, XFEATURE_XTILEDATA))
       return false;
     return true;
+#else
+    return false;
+#endif
   });
 
   m.def("load_dialects", [](mlir::MLIRContext &context) {


### PR DESCRIPTION
Allows compilation to succeed even when the latest kernel headers aren't present