### PR TITLE
[NFC][CPU] Drop MLIR prefix in ScalarizeInterface

### DIFF
--- a/third_party/cpu/include/ScalarizePass/CMakeLists.txt
+++ b/third_party/cpu/include/ScalarizePass/CMakeLists.txt
@@ -1,1 +1,4 @@
-add_mlir_interface(ScalarizeInterface)
+set(LLVM_TARGET_DEFINITIONS ScalarizeInterface.td)
+mlir_tablegen(ScalarizeInterface.h.inc -gen-op-interface-decls)
+mlir_tablegen(ScalarizeInterface.cpp.inc -gen-op-interface-defs)
+add_public_tablegen_target(ScalarizeInterfaceIncGen)

--- a/third_party/cpu/lib/TritonToTritonCPU/CMakeLists.txt
+++ b/third_party/cpu/lib/TritonToTritonCPU/CMakeLists.txt
@@ -16,7 +16,7 @@ add_triton_library(TritonToTritonCPU
 
     DEPENDS
     TritonToTritonCPUPassIncGen
-    MLIRScalarizeInterfaceIncGen
+    ScalarizeInterfaceIncGen
     MLIRDialectUtils
 
     LINK_LIBS PUBLIC


### PR DESCRIPTION
Found this issue while working for intenal build. `ScalarizeInterfaceIncGen` shouldn't have the MLIR prefix.

`add_mlir_interface` is defined in [mlir/cmake/modules/AddMLIR.cmake](https://github.com/llvm/llvm-project/blob/0de8de1b8432f01adb0a7c6d2f1e3d4fd8c0c30c/mlir/cmake/modules/AddMLIR.cmake#L191-L197). Drop the `MLIR` prefix, and no need to add dependency to `mlir-generic-headers`.