### PR TITLE
Fix trailing null char in ulpSuffix

### DIFF
--- a/third_party/cpu/lib/TritonCPUToLLVM/MathToVecLib.cpp
+++ b/third_party/cpu/lib/TritonCPUToLLVM/MathToVecLib.cpp
@@ -231,12 +231,14 @@ private:
 class SleefNameGenerator {
 public:
   SleefNameGenerator(StringRef baseName, unsigned ulp = 10)
-      : baseName(baseName), ulpSuffix(5, '\0') {
-    if (ulp == 0)
+      : baseName(baseName), ulpSuffix(4, '\0') {
+    if (ulp == 0) {
       ulpSuffix = "";
-    else
-      // snprintf inserts '\0' at the end
-      snprintf(ulpSuffix.data(), ulpSuffix.size(), "_u%02u", ulp);
+    } else {
+      char buf[5]; // 4 char suffix + '\0' added by snprintf
+      snprintf(buf, 5, "_u%02u", ulp);
+      ulpSuffix = buf;
+    }
   }
 
   std::string operator()(unsigned bitwidth, unsigned numel,


### PR DESCRIPTION
Popping the null char inserted by the `snprintf` function. Leaving it causes CI issues.