### PR TITLE
Add num_threads option to control threading per kernel invocation.

### DIFF
--- a/python/tutorials/01-vector-add.py
+++ b/python/tutorials/01-vector-add.py
@@ -195,7 +195,6 @@ if USE_GPU and triton.runtime.driver.get_active_gpus():
         args={},  # Values for function arguments not in `x_names` and `y_name`.
     ))
 def benchmark(size, provider):
-    import os
 
     device = 'cpu' if 'cpu' in provider else 'cuda'
     x = torch.rand(size, device=device, dtype=torch.float32)
@@ -203,10 +202,6 @@ def benchmark(size, provider):
 
     if device == 'cpu':
         triton.runtime.driver.set_active_to_cpu()
-        if 'single' in provider:
-            os.environ['TRITON_CPU_SINGLE_CORE'] = '1'
-        else:
-            os.unsetenv('TRITON_CPU_SINGLE_CORE')
     else:
         triton.runtime.driver.set_active_to_gpu()
     output = torch.empty_like(x)

--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -27,9 +27,14 @@ class CPUOptions:
     # GPU-specific options are used in several places.
     # For now, we just provide dummy values.
     backend_name: str = "cpu"
+    # These options provide compatibility with GPU kernel calls.
+    # All of them are ignored.
     num_warps: int = 0
     num_stages: int = 0
     num_ctas: int = 0
+    # Max number of threads to be used for a kernel call.
+    # Zero value is used to utilize all available CPU cores.
+    num_threads: int = 0
     cluster_dims: tuple = (1, 1, 1)
     extern_libs: dict = None
     debug: bool = False


### PR DESCRIPTION
I propose to use a new kernel option instead of environment variables. `OMP_NUM_THREADS` variable still can be used though. This provides more explicit interface and matches GPU way to control parallelism. I'm also counting on autotuning it in the future.