### PR TITLE
Small fixes for autotuner on CPU

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -249,11 +249,12 @@ class Config:
                     function are args.
     """
 
-    def __init__(self, kwargs, num_warps=4, num_stages=2, num_ctas=1, maxnreg=None, pre_hook=None):
+    def __init__(self, kwargs, num_warps=4, num_stages=2, num_ctas=1, num_threads=0, maxnreg=None, pre_hook=None):
         self.kwargs = kwargs
         self.num_warps = num_warps
         self.num_ctas = num_ctas
         self.num_stages = num_stages
+        self.num_threads = num_threads
         self.maxnreg = maxnreg
         self.pre_hook = pre_hook
 
@@ -265,6 +266,7 @@ class Config:
                     ("num_warps", self.num_warps),
                     ("num_ctas", self.num_ctas),
                     ("num_stages", self.num_stages),
+                    ("num_threads", self.num_threads),
                     ("maxnreg", self.maxnreg),
                 ) if v is not None
             }
@@ -277,6 +279,7 @@ class Config:
         res.append(f"num_warps: {self.num_warps}")
         res.append(f"num_ctas: {self.num_ctas}")
         res.append(f"num_stages: {self.num_stages}")
+        res.append(f"num_threads: {self.num_threads}")
         res.append(f"maxnreg: {self.maxnreg}")
         return ", ".join(res)
 

--- a/third_party/cpu/backend/driver.py
+++ b/third_party/cpu/backend/driver.py
@@ -435,7 +435,13 @@ class CPUDriver(DriverBase):
 
     def get_benchmarker(self):
         from triton.testing import do_bench
-        return do_bench
+
+        def do_bench_cpu(*args, **kwargs):
+            if not 'measure_time_with_hooks' in kwargs:
+                kwargs['measure_time_with_hooks'] = True
+            return do_bench(*args, **kwargs)
+
+        return do_bench_cpu
 
     def get_empty_cache_for_benchmark(self):
         import torch


### PR DESCRIPTION
This patch adds `num_threads` tuning to autotuner and enables hooks timing by default for autotuner on CPU. It also adds an example of an autotuned vector-add kernel to the tutorial. Autotuned kernel can select proper configs for small vectors and be as efficient as manually tuned `add_tiled_with_st_threshold`. 