### PR TITLE
Fix linux-aarch64 build

### DIFF
--- a/third_party/cpu/triton_cpu.cc
+++ b/third_party/cpu/triton_cpu.cc
@@ -20,9 +20,9 @@
 #include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
 
-#ifdef __linux__
+#if defined(__x86_64__) || defined(__i386__)
 #include <asm/prctl.h>
-#endif // __linux__
+#endif
 #include <sys/syscall.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Summary: Follow the https://github.com/triton-lang/triton-cpu/pull/165 example, and update one macro for building on linux-aarch64.
