### PR TITLE
Fix isSigned and add float16 in PrintOp

### DIFF
--- a/third_party/cpu/lib/TritonCPUToLLVM/DebugOpsToLLVM.cpp
+++ b/third_party/cpu/lib/TritonCPUToLLVM/DebugOpsToLLVM.cpp
@@ -190,7 +190,7 @@ void createRuntimePrintScalarCall(ConversionPatternRewriter &rewriter,
 
 void createRuntimePrintCall(ConversionPatternRewriter &rewriter,
                             std::array<Value, 3> pid, StringRef prefix,
-                            Value ptr, Type dtype, bool hex) {
+                            Value ptr, Type dtype, bool isSigned, bool hex) {
   assert(!prefix.empty());
   auto loc = UnknownLoc::get(rewriter.getContext());
   Value prefixValue = LLVM::addStringToModule(
@@ -205,7 +205,7 @@ void createRuntimePrintCall(ConversionPatternRewriter &rewriter,
 
   allArgs.push_back(i32_val(dtype.getIntOrFloatBitWidth()));
   allArgs.push_back(i32_val(dtype.isInteger()));
-  allArgs.push_back(i32_val(dtype.isSignedInteger()));
+  allArgs.push_back(i32_val(isSigned));
   allArgs.push_back(i32_val(hex));
 
   call(getOrAddPrintMemrefFuncDecl(rewriter), allArgs);
@@ -254,7 +254,7 @@ struct PrintOpConversion : public ConvertOpToLLVMPattern<triton::cpu::PrintOp> {
     createRuntimePrintCall(
         rewriter, pid, op.getPrefix(), adaptor.getOperands()[0],
         cast<UnrankedMemRefType>(op.getVal()[0].getType()).getElementType(),
-        op.getHex());
+        op.getIsSigned()[0], op.getHex());
 
     rewriter.eraseOp(op);
     return success();

--- a/third_party/cpu/lib/TritonToTritonCPU/ConvertDebugOps.cpp
+++ b/third_party/cpu/lib/TritonToTritonCPU/ConvertDebugOps.cpp
@@ -61,11 +61,13 @@ struct PrintOpConversion : public OpConversionPattern<triton::PrintOp> {
       return success();
     }
 
-    for (auto operand : op.getOperands()) {
+    for (size_t i = 0; i < op.getNumOperands(); i++) {
+      Value operand = op.getOperands()[i];
+      auto isSigned = {op.getIsSigned()[i]};
       if (!isa<RankedTensorType>(operand.getType())) {
         rewriter.create<triton::cpu::PrintOp>(
             loc, op.getPrefix(), op.getHex(),
-            rewriter.getRemappedValue(operand), false);
+            rewriter.getRemappedValue(operand), isSigned);
         continue;
       }
 
@@ -92,7 +94,7 @@ struct PrintOpConversion : public OpConversionPattern<triton::PrintOp> {
           allocVal);
 
       rewriter.create<triton::cpu::PrintOp>(loc, op.getPrefix(), op.getHex(),
-                                            allocUnrankedVal, false);
+                                            allocUnrankedVal, isSigned);
 
       rewriter.create<memref::DeallocOp>(loc, allocVal);
     }

--- a/third_party/cpu/runtime/cpu_runtime.cpp
+++ b/third_party/cpu/runtime/cpu_runtime.cpp
@@ -91,6 +91,12 @@ std::pair<int /* numDigits */, bool /* isNegative */> computeDigitInfo(T val) {
   return {digits, val < 0};
 }
 
+template <>
+std::pair<int /* numDigits */, bool /* isNegative */>
+computeDigitInfo<_Float16>(_Float16 val) {
+  return computeDigitInfo<float>(static_cast<float>(val));
+}
+
 template <typename T>
 std::tuple<int, int, bool> computeDigitStats(const MemRefDescriptor<T> &desc) {
   int maxIntDigits = 0;
@@ -177,6 +183,12 @@ void printFormattedElement<uint8_t>(std::stringstream &ss, uint8_t val,
   printFormattedElement<uint16_t>(ss, val, formatInfo);
 }
 
+template <>
+void printFormattedElement<_Float16>(std::stringstream &ss, _Float16 val,
+                                     const FormatInfo &formatInfo) {
+  printFormattedElement<float>(ss, static_cast<float>(val), formatInfo);
+}
+
 template <typename T>
 void printToStreamRecursive(const MemRefDescriptor<T> &desc,
                             std::stringstream &ss, const FormatInfo &formatInfo,
@@ -245,6 +257,10 @@ void printMemRef(std::stringstream &ss, int32_t rank, void *descriptor,
       return;
     case 32:
       printToStream(MemRefDescriptor<float>(rank, descriptor), ss,
+                    partialFormat, linePrefix);
+      return;
+    case 16:
+      printToStream(MemRefDescriptor<_Float16>(rank, descriptor), ss,
                     partialFormat, linePrefix);
       return;
     default:

--- a/third_party/cpu/runtime/cpu_runtime.cpp
+++ b/third_party/cpu/runtime/cpu_runtime.cpp
@@ -325,14 +325,13 @@ EXPORT void triton_assert(int32_t pid0, int32_t pid1, int32_t pid2, bool cond,
 EXPORT void triton_print_unranked_memref(int32_t pid0, int32_t pid1,
                                          int32_t pid2, const char *prefix,
                                          UnrankedMemRefType memref, int32_t btw,
-                                         bool isInteger, bool isSignedInteger,
+                                         bool isInteger, bool isSigned,
                                          bool asHex) {
   std::stringstream ss;
   ss << "(" << pid0 << ", " << pid1 << ", " << pid2 << ")" << prefix;
   std::string linePrefix(ss.str().size(), ' ');
-
-  printMemRef(ss, memref.rank, memref.descriptor, btw, isInteger,
-              isSignedInteger, asHex, linePrefix);
+  printMemRef(ss, memref.rank, memref.descriptor, btw, isInteger, isSigned,
+              asHex, linePrefix);
   ss << "\n";
   std::cout << ss.str() << std::flush;
 }

--- a/third_party/cpu/runtime/cpu_runtime.cpp
+++ b/third_party/cpu/runtime/cpu_runtime.cpp
@@ -9,6 +9,9 @@
 #include <string>
 #include <vector>
 
+#define __STDC_WANT_IEC_60559_TYPES_EXT__
+#include <float.h>
+
 #if defined(_MSC_VER)
 #define EXPORT __declspec(dllexport)
 #elif defined(__GNUC__)
@@ -23,6 +26,42 @@ namespace {
 const int MAX_FLOAT_WIDTH = 8;
 const int FLOAT_PREC = 4;
 const int ELEMS_PER_LINE = 8;
+
+using FLOAT16 = struct _FLOAT16 {
+#ifdef FLT16_MAX
+  _Float16 x;
+#else
+  uint16_t x;
+#endif
+
+  float toFloat32() const {
+#ifdef FLT16_MAX
+    return static_cast<float>(x);
+#else
+    // Based on https://gist.github.com/zhuker/b4bd1fb306c7b04975b712c37c4c4075
+    uint32_t t1;
+    uint32_t t2;
+    uint32_t t3;
+
+    t1 = x & 0x7fffu; // Non-sign bits
+    t2 = x & 0x8000u; // Sign bit
+    t3 = x & 0x7c00u; // Exponent
+
+    t1 <<= 13u; // Align mantissa on MSB
+    t2 <<= 16u; // Shift sign bit into position
+
+    t1 += 0x38000000; // Adjust bias
+
+    t1 = (t3 == 0 ? 0 : t1); // Denormals-as-zero
+
+    t1 |= t2; // Re-insert sign bit
+
+    float out;
+    *((uint32_t *)&out) = t1;
+    return out;
+#endif
+  }
+};
 
 struct FormatInfo {
   bool isInt;
@@ -93,8 +132,8 @@ std::pair<int /* numDigits */, bool /* isNegative */> computeDigitInfo(T val) {
 
 template <>
 std::pair<int /* numDigits */, bool /* isNegative */>
-computeDigitInfo<_Float16>(_Float16 val) {
-  return computeDigitInfo<float>(static_cast<float>(val));
+computeDigitInfo<FLOAT16>(FLOAT16 val) {
+  return computeDigitInfo<float>(val.toFloat32());
 }
 
 template <typename T>
@@ -184,9 +223,9 @@ void printFormattedElement<uint8_t>(std::stringstream &ss, uint8_t val,
 }
 
 template <>
-void printFormattedElement<_Float16>(std::stringstream &ss, _Float16 val,
-                                     const FormatInfo &formatInfo) {
-  printFormattedElement<float>(ss, static_cast<float>(val), formatInfo);
+void printFormattedElement<FLOAT16>(std::stringstream &ss, FLOAT16 val,
+                                    const FormatInfo &formatInfo) {
+  printFormattedElement<float>(ss, val.toFloat32(), formatInfo);
 }
 
 template <typename T>
@@ -260,7 +299,7 @@ void printMemRef(std::stringstream &ss, int32_t rank, void *descriptor,
                     partialFormat, linePrefix);
       return;
     case 16:
-      printToStream(MemRefDescriptor<_Float16>(rank, descriptor), ss,
+      printToStream(MemRefDescriptor<FLOAT16>(rank, descriptor), ss,
                     partialFormat, linePrefix);
       return;
     default:


### PR DESCRIPTION
Easy fix and update.

Added float16 support for PrintOp.

Interestingly, negative numbers were incorrectly printed. The unittest, `test_print[device_print_negative-int32]`, was failing. Why did't CI catch it? Anyhow quickly fixed it.

---
Testing

- Now all print unit tests are passed.
- float16 testing:

```
# Before this patch:
> % TRITON_CPU_BACKEND=1 python3 python/test/unit/language/print_helper.py test_print device_print_negative float16 cpu
Unsupported bitWidth
UNREACHABLE executed at /data/users/minjang/triton-oss/triton-cpu-minjang/third_party/cpu/runtime/cpu_runtime.cpp:251!

# After this patch:
> % TRITON_CPU_BACKEND=1 python3 python/test/unit/language/print_helper.py test_print device_print_negative float16 cpu
(0, 0, 0) x: [   -0.0000,   -1.0000,   -2.0000,   -3.0000,   -4.0000,   -5.0000,   -6.0000,   -7.0000,
                -8.0000,   -9.0000,  -10.0000,  -11.0000,  -12.0000,  -13.0000,  -14.0000,  -15.0000,
               -16.0000,  -17.0000,  -18.0000,  -19.0000,  -20.0000,  -21.0000,  -22.0000,  -23.0000,
               -24.0000,  -25.0000,  -26.0000,  -27.0000,  -28.0000,  -29.0000,  -30.0000,  -31.0000,
               -32.0000,  -33.0000,  -34.0000,  -35.0000,  -36.0000,  -37.0000,  -38.0000,  -39.0000,
               -40.0000,  -41.0000,  -42.0000,  -43.0000,  -44.0000,  -45.0000,  -46.0000,  -47.0000,
               -48.0000,  -49.0000,  -50.0000,  -51.0000,  -52.0000,  -53.0000,  -54.0000,  -55.0000,
               -56.0000,  -57.0000,  -58.0000,  -59.0000,  -60.0000,  -61.0000,  -62.0000,  -63.0000,
               -64.0000,  -65.0000,  -66.0000,  -67.0000,  -68.0000,  -69.0000,  -70.0000,  -71.0000,
               -72.0000,  -73.0000,  -74.0000,  -75.0000,  -76.0000,  -77.0000,  -78.0000,  -79.0000,
               -80.0000,  -81.0000,  -82.0000,  -83.0000,  -84.0000,  -85.0000,  -86.0000,  -87.0000,
               -88.0000,  -89.0000,  -90.0000,  -91.0000,  -92.0000,  -93.0000,  -94.0000,  -95.0000,
               -96.0000,  -97.0000,  -98.0000,  -99.0000, -100.0000, -101.0000, -102.0000, -103.0000,
              -104.0000, -105.0000, -106.0000, -107.0000, -108.0000, -109.0000, -110.0000, -111.0000,
              -112.0000, -113.0000, -114.0000, -115.0000, -116.0000, -117.0000, -118.0000, -119.0000,
              -120.0000, -121.0000, -122.0000, -123.0000, -124.0000, -125.0000, -126.0000, -127.0000]
```