### PR TITLE
Add TritonCPU canonicalizer.

### DIFF
--- a/test/TritonCPU/canonicalize.mlir
+++ b/test/TritonCPU/canonicalize.mlir
@@ -1,0 +1,30 @@
+// RUN: triton-opt %s -split-input-file -triton-cpu-canonicalize | FileCheck %s
+
+// Fold transfer read and shape cast.
+
+// CHECK-LABEL: @fold_transfer_read_shape_cast
+// CHECK:       %[[VAL:.+]] = vector.transfer_read
+// CHECK:       vector.transfer_write %[[VAL]]
+
+module {
+  tt.func public @fold_transfer_read_shape_cast(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<bf16> {tt.divisibility = 16 : i32}) {
+    %cst = arith.constant 0.000000e+00 : bf16
+    %c0 = arith.constant 0 : index
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c2_i64 = arith.constant 2 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %c256_i64 = arith.constant 256 : i64
+    %c512_i64 = arith.constant 512 : i64
+    %in_p = tt.make_tensor_ptr %arg0, [%c2_i64, %c2_i64, %c16_i64, %c16_i64], [%c512_i64, %c256_i64, %c16_i64, %c1_i64], [%c0_i32, %c0_i32, %c0_i32, %c0_i32] {order = array<i32: 3, 2, 1, 0>} : <tensor<1x1x16x16xbf16>>
+    %out_p = tt.make_tensor_ptr %arg1, [%c16_i64, %c16_i64], [%c16_i64, %c1_i64], [%c0_i32, %c0_i32] {order = array<i32: 1, 0>} : <tensor<16x16xbf16>>
+    %memref1 = triton_cpu.extract_memref %in_p : <tensor<1x1x16x16xbf16>> -> memref<2x2x16x16xbf16, strided<[512, 256, 16, 1]>>
+    %indices1:4 = triton_cpu.extract_indices %in_p : <tensor<1x1x16x16xbf16>> -> index, index, index, index
+    %val1 = vector.transfer_read %memref1[%indices1#0, %indices1#1, %indices1#2, %indices1#3], %cst {in_bounds = [true, true, true, true]} : memref<2x2x16x16xbf16, strided<[512, 256, 16, 1]>>, vector<1x1x16x16xbf16>
+    %val2 = vector.shape_cast %val1 : vector<1x1x16x16xbf16> to vector<16x16xbf16>
+    %memref2 = triton_cpu.extract_memref %out_p : <tensor<16x16xbf16>> -> memref<16x16xbf16, strided<[16, 1]>>
+    %indices2:2 = triton_cpu.extract_indices %out_p : <tensor<16x16xbf16>> -> index, index
+    vector.transfer_write %val2, %memref2[%indices2#0, %indices2#1] {in_bounds = [true, true]} : vector<16x16xbf16>, memref<16x16xbf16, strided<[16, 1]>>
+    tt.return
+  }
+}

--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -160,6 +160,7 @@ class CPUBackend(BaseBackend):
         # TTCIR -> Target TTCIR
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
+        cpu.passes.ttcpuir.add_triton_cpu_canonicalizer(pm)
         cpu.passes.ttcpuir.add_optimize_masks(pm)
         passes.common.add_canonicalizer(pm)
         convert_bf16_dot_product = ((self.cpu_arch == "aarch64" or self.cpu_arch == "armv8")

--- a/third_party/cpu/include/TritonCPUTransforms/Passes.h
+++ b/third_party/cpu/include/TritonCPUTransforms/Passes.h
@@ -37,6 +37,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createConvertDotToAMX();
 std::unique_ptr<OperationPass<ModuleOp>>
 createConvertDotToAMX(bool convertInt8, bool convertFp16, bool convertBf16);
 std::unique_ptr<OperationPass<ModuleOp>> createConvertDotGeneric();
+std::unique_ptr<OperationPass<ModuleOp>> createCanonicalize();
 
 #define GEN_PASS_REGISTRATION
 #include "cpu/include/TritonCPUTransforms/Passes.h.inc"

--- a/third_party/cpu/include/TritonCPUTransforms/Passes.td
+++ b/third_party/cpu/include/TritonCPUTransforms/Passes.td
@@ -137,4 +137,17 @@ def ConvertDotGeneric : Pass<"triton-cpu-convert-dot-generic", "mlir::ModuleOp">
                              "mlir::triton::cpu::TritonCPUDialect"];
 }
 
+def Canonicalize : Pass<"triton-cpu-canonicalize", "mlir::ModuleOp"> {
+    let summary = "Canonicalization pass.";
+    let description = [{
+        This pass applies various foldings to simplify analysis and transformations
+        in optimization passes.
+    }];
+
+    let constructor = "mlir::triton::cpu::createCanonicalize()";
+
+    let dependentDialects = ["mlir::vector::VectorDialect",
+                             "mlir::triton::cpu::TritonCPUDialect"];
+}
+
 #endif

--- a/third_party/cpu/lib/TritonCPUTransforms/CMakeLists.txt
+++ b/third_party/cpu/lib/TritonCPUTransforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_triton_library(TritonCPUTransforms
     ConvertDotOp/ConvertDotGeneric.cpp
     ConvertDotOp/ConvertDotToAMX.cpp
+    Canonicalize.cpp
     ConvertDotProduct.cpp
     ConvertUnsupportedOps.cpp
     DecomposeFpConversions.cpp

--- a/third_party/cpu/lib/TritonCPUTransforms/Canonicalize.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/Canonicalize.cpp
@@ -1,0 +1,110 @@
+#include "cpu/include/TritonCPUTransforms/OptCommon.h"
+#include "cpu/include/TritonCPUTransforms/Passes.h"
+
+#include "mlir/Dialect/Utils/IndexingUtils.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonCPU/IR/Dialect.h"
+
+namespace mlir {
+namespace triton {
+namespace cpu {
+#define GEN_PASS_DEF_CANONICALIZE
+#include "cpu/include/TritonCPUTransforms/Passes.h.inc"
+} // namespace cpu
+} // namespace triton
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::triton;
+using namespace mlir::triton::cpu;
+
+namespace {
+
+// Fold transfer read and the following shape cast that removes heading
+// dimensions with size 1.
+struct FoldReadShapeCast : public OpRewritePattern<vector::TransferReadOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::TransferReadOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    if (!op->hasOneUse())
+      return failure();
+
+    auto permMap = op.getPermutationMap();
+    if (!permMap.isMinorIdentity())
+      return failure();
+
+    auto reshape = dyn_cast<vector::ShapeCastOp>(*op->user_begin());
+    if (!reshape)
+      return failure();
+
+    VectorType ty = cast<VectorType>(op.getType());
+    VectorType dstTy = cast<VectorType>(reshape.getType());
+    if (ty.getRank() <= dstTy.getRank())
+      return failure();
+
+    // Check all removed dimensions have size 1.
+    if (!all_of(drop_end(ty.getShape(), dstTy.getRank()),
+                [](int64_t val) { return val == 1; }))
+      return failure();
+
+    // Check shape prefix matches the resulting type.
+    if (!equal(drop_begin(ty.getShape(), ty.getRank() - dstTy.getRank()),
+               dstTy.getShape()))
+      return failure();
+
+    auto inBounds = op.getInBounds();
+    if (std::any_of(inBounds.begin(), inBounds.end() - dstTy.getRank(),
+                    [](Attribute attr) {
+                      return !cast<mlir::BoolAttr>(attr).getValue();
+                    }))
+      return failure();
+
+    // Fold read and shape cast into a single read.
+    auto newPermMap = permMap.getMinorIdentityMap(
+        permMap.getNumDims(), dstTy.getRank(), getContext());
+    auto newInBounds = rewriter.getArrayAttr(SmallVector<Attribute>(drop_begin(
+        op.getInBounds().getValue(), ty.getRank() - dstTy.getRank())));
+    auto newRead = rewriter.create<vector::TransferReadOp>(
+        loc, dstTy, op.getSource(), op.getIndices(), newPermMap,
+        op.getPadding(), op.getMask(), newInBounds);
+    rewriter.replaceOp(reshape, newRead);
+    rewriter.eraseOp(op);
+
+    return success();
+  }
+};
+
+struct Canonicalize : public triton::cpu::impl::CanonicalizeBase<Canonicalize> {
+  Canonicalize() = default;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ModuleOp mod = getOperation();
+
+    RewritePatternSet patterns(context);
+    patterns.add<FoldReadShapeCast>(context);
+
+    if (failed(mlir::applyPatternsAndFoldGreedily(mod, std::move(patterns))))
+      return signalPassFailure();
+  }
+};
+
+} // namespace
+
+namespace mlir {
+namespace triton {
+namespace cpu {
+
+std::unique_ptr<OperationPass<ModuleOp>> createCanonicalize() {
+  return std::make_unique<Canonicalize>();
+}
+
+} // namespace cpu
+} // namespace triton
+} // namespace mlir

--- a/third_party/cpu/triton_cpu.cc
+++ b/third_party/cpu/triton_cpu.cc
@@ -76,6 +76,9 @@ void init_triton_cpu_passes_ttcpuir(py::module &&m) {
   m.def("add_convert_debug_ops", [](mlir::PassManager &pm) {
     pm.addPass(mlir::triton::cpu::createConvertDebugOps());
   });
+  m.def("add_triton_cpu_canonicalizer", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::triton::cpu::createCanonicalize());
+  });
   m.def("add_optimize_masks", [](mlir::PassManager &pm) {
     pm.addPass(mlir::triton::cpu::createOptimizeMasks());
   });


### PR DESCRIPTION
This patch adds a canonicalizer pass to be used on TTCIR. Its goal is to simplify pattern matching in transformation passes. So far, it has a single pattern only to fold shape cast into transfer read. This simplifies code analysis for multidimensional block pointers (e.g. for blocked layout matmul where I use 4D block pointers to load 2D blocks).
