### PR TITLE
Introduce FMA lowering for DotOp.

### DIFF
--- a/python/tutorials/03-matrix-multiplication-cpu.py
+++ b/python/tutorials/03-matrix-multiplication-cpu.py
@@ -153,12 +153,33 @@ import torch
 
 import triton
 import triton.language as tl
+import os
 
-BLOCK_SIZE_M = 32
+DTYPE = getattr(torch, (os.getenv("DTYPE", "float32")))
+# Chosse block size depending on dtype. We have more register
+# capacity for bfloat16/float16 compared to float32.
+BLOCK_SIZE_M = 8 if DTYPE == torch.float32 else 32
 BLOCK_SIZE_N = 32
-BLOCK_SIZE_K = 32
+BLOCK_SIZE_K = 8 if DTYPE == torch.float32 else 32
+CACHE_PADDING = os.getenv("CACHE_PADDING", "0") != "0"
+PREPACKED = os.getenv("PREPACKED", "0") != "0"
+PAD_B_ONLY = True
 GROUP_SIZE_M = 8
 USE_GPU = False
+
+
+@triton.jit
+def pad_kernel(in_ptr, out_ptr, N, BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, PADDING: tl.constexpr):
+    in_offset = tl.program_id(axis=0) * N * BLOCK_SIZE_M
+    out_offset = tl.program_id(axis=0) * (N + PADDING) * BLOCK_SIZE_M
+    for row in tl.range(0, BLOCK_SIZE_M):
+        for block in tl.range(0, N // BLOCK_SIZE_N):
+            val = tl.load(in_ptr + in_offset + block * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N))
+            tl.store(out_ptr + out_offset + block * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N), val)
+        zero = tl.full((PADDING, ), 0, dtype=in_ptr.type.element_ty)
+        tl.store(out_ptr + out_offset + N + tl.arange(0, PADDING), zero)
+        in_offset += N
+        out_offset += N + PADDING
 
 
 @triton.jit
@@ -198,14 +219,12 @@ def matmul_kernel(
     # Create pointers for the first blocks of A and B.
     # We will advance this pointer as we move in the K direction
     # and accumulate
-    # `a_ptrs` is a block of [BLOCK_SIZE_M, BLOCK_SIZE_K] pointers
-    # `b_ptrs` is a block of [BLOCK_SIZE_K, BLOCK_SIZE_N] pointers
-    # See above `Pointer Arithmetic` section for details
-    offs_am = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
-    offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
-    offs_k = tl.arange(0, BLOCK_SIZE_K)
-    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
-    b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+    block_offset_m = pid_m * BLOCK_SIZE_M
+    block_offset_n = pid_n * BLOCK_SIZE_N
+    a_tile_ptr = tl.make_block_ptr(base=a_ptr, shape=(M, K), strides=(stride_am, stride_ak),
+                                   offsets=(block_offset_m, 0), block_shape=(BLOCK_SIZE_M, BLOCK_SIZE_K), order=(1, 0))
+    b_tile_ptr = tl.make_block_ptr(base=b_ptr, shape=(K, N), strides=(stride_bk, stride_bn),
+                                   offsets=(0, block_offset_n), block_shape=(BLOCK_SIZE_K, BLOCK_SIZE_N), order=(1, 0))
 
     # -----------------------------------------------------------
     # Iterate to compute a block of the C matrix.
@@ -217,43 +236,50 @@ def matmul_kernel(
         # Load the next block of A and B, generate a mask by checking the K dimension.
         # If it is out of bounds, set it to 0.
 
-        # TODO: Currently masked load is not supported yet.
-        # a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
-        # b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
-        a = tl.load(a_ptrs)
-        b = tl.load(b_ptrs)
+        a = tl.load(a_tile_ptr)
+        b = tl.load(b_tile_ptr)
         # We accumulate along the K dimension.
         accumulator = tl.dot(a, b, accumulator, out_dtype=tl.float32)
         # Advance the ptrs to the next K block.
-        a_ptrs += BLOCK_SIZE_K * stride_ak
-        b_ptrs += BLOCK_SIZE_K * stride_bk
+        a_tile_ptr = tl.advance(a_tile_ptr, [0, BLOCK_SIZE_K])
+        b_tile_ptr = tl.advance(b_tile_ptr, [BLOCK_SIZE_K, 0])
 
     # Convert the accumulator to the output matrix C's type if needed.
     c = accumulator
 
     # -----------------------------------------------------------
-    # Write back the block of the output matrix C with masks.
-    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
-
-    # TODO: Currently masked load is not supported yet.
-    # c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
-    # tl.store(c_ptrs, c, mask=c_mask)
-    tl.store(c_ptrs, c)
+    # Write back the block of the output matrix C.
+    c_block_ptr = tl.make_block_ptr(base=c_ptr, shape=(M, N), strides=(stride_cm, stride_cn),
+                                    offsets=(block_offset_m, block_offset_n), block_shape=(BLOCK_SIZE_M, BLOCK_SIZE_N),
+                                    order=(1, 0))
+    tl.store(c_block_ptr, c)
 
 
 # %%
 # We can now create a convenience wrapper function that only takes two input tensors,
 # and (1) checks any shape constraint; (2) allocates the output; (3) launches the above kernel.
 
+a_scratch = torch.empty((), dtype=DTYPE)
+b_scratch = torch.empty((), dtype=DTYPE)
 
-def matmul(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor, num_threads=0):
+
+def matmul_preprocess_input(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor, num_threads=0):
     # Check constraints.
     assert a.shape[1] == b.shape[0], "Incompatible dimensions"
     assert a.is_contiguous(), "Matrix A must be contiguous"
     M, K = a.shape
     K, N = b.shape
+
+    # TODO: Check if padding is needed at all.
+    if CACHE_PADDING:
+        a_scratch.resize_(M, K + 32)
+        b_scratch.resize_(K, N + 32)
+        if not PAD_B_ONLY:
+            pad_kernel[(M // BLOCK_SIZE_M, )](a, a_scratch, K, BLOCK_SIZE_M, BLOCK_SIZE_K, 32, num_threads=num_threads)
+            a = a_scratch
+        pad_kernel[(K // BLOCK_SIZE_K, )](b, b_scratch, N, BLOCK_SIZE_K, BLOCK_SIZE_N, 32, num_threads=num_threads)
+        b = b_scratch
+
     #TODO: Currently masked load is not supported yet.
     assert (M % BLOCK_SIZE_M == 0) and (N % BLOCK_SIZE_N == 0) and (
         K % BLOCK_SIZE_K == 0), "Masking currently not supported, Matrix dimensions must be multiples of block size"
@@ -262,6 +288,14 @@ def matmul(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor, num_threads=0):
         c = torch.empty((M, N), device=a.device, dtype=a.dtype)
     else:
         assert c.shape == (M, N), "Incompatible dimensions"
+
+    return a, b, c
+
+
+def matmul(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor, M: int, N: int, K: int, num_threads=0):
+    if not PREPACKED:
+        a, b, c = matmul_preprocess_input(a, b, c, num_threads=num_threads)
+
     # 1D launch kernel where each block gets its own program.
     grid = (triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N), )
     matmul_kernel[grid](
@@ -287,10 +321,13 @@ torch.manual_seed(0)
 
 triton.runtime.driver.set_active_to_cpu()
 
-a = torch.randn((512, 512), device='cpu', dtype=torch.float32)
-b = torch.randn((512, 512), device='cpu', dtype=torch.float32)
-triton_output = matmul(a, b, None)
-torch_output = torch.matmul(a, b)
+a = torch.randn((512, 512), device='cpu', dtype=DTYPE)
+b = torch.randn((512, 512), device='cpu', dtype=DTYPE)
+c = None
+torch_output = torch.matmul(a.to(torch.float32), b.to(torch.float32))
+if PREPACKED:
+    a, b, c = matmul_preprocess_input(a, b, c)
+triton_output = matmul(a, b, c, 512, 512, 512)
 print(f"triton_cpu_output_with_{a.dtype}_inputs={triton_output}")
 print(f"torch_cpu_output_with_{a.dtype}_inputs={torch_output}")
 rtol = 0
@@ -310,9 +347,9 @@ else:
 # We can now compare the performance of our kernel against that of Pytorch. Here we focus on square matrices,
 # but feel free to arrange this script as you wish to benchmark any other matrix shape.
 
-LINE_VALS = ['triton-cpu-single', 'triton-cpu', 'torch-cpu-native', 'torch-cpu-compile']
-LINE_NAMES = ['TritonCPU 1', 'TritonCPU', 'TorchCPU (native)', 'TorchCPU (compile)']
-LINE_STYLES = [('blue', '--'), ('blue', '-'), ('green', '--'), ('green', '-')]
+LINE_VALS = ['triton-cpu-single', 'triton-cpu', 'torch-cpu-native']
+LINE_NAMES = ['TritonCPU 1', 'TritonCPU', 'TorchCPU (native)']
+LINE_STYLES = [('blue', '--'), ('blue', '-'), ('green', '--')]
 
 if USE_GPU and triton.runtime.driver.get_active_gpus():
     triton.runtime.driver.set_active_to_gpu()
@@ -356,36 +393,47 @@ if USE_GPU and triton.runtime.driver.get_active_gpus():
         ylabel='GFLOPS',  # Label name for the y-axis.
         plot_name=
         # Name for the plot. Used also as a file name for saving the plot.
-        f'matmul-performance-fp32 (BLOCK_SIZE_M={BLOCK_SIZE_M}, BLOCK_SIZE_N={BLOCK_SIZE_N}, BLOCK_SIZE_K={BLOCK_SIZE_K}, GROUP_SIZE_M={GROUP_SIZE_M})',
+        f'matmul-performance-{DTYPE} (CACHE_PADDING={CACHE_PADDING} PREPACKED={PREPACKED} PAD_B_ONLY={PAD_B_ONLY} GROUP_SIZE_M={GROUP_SIZE_M})',
         args={},  # Values for function arguments not in `x_names` and `y_name`.
     ))
 def benchmark(M, N, K, provider):
 
     device = 'cpu' if 'cpu' in provider else 'cuda'
-    a = torch.randn((M, K), device=device, dtype=torch.float32)
-    b = torch.randn((K, N), device=device, dtype=torch.float32)
+    a = torch.randn((M, K), device=device, dtype=DTYPE)
+    b = torch.randn((K, N), device=device, dtype=DTYPE)
 
     if device == 'cpu':
-        c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+        if 'triton-cpu' in provider:
+            c = torch.zeros((M, N), device=a.device, dtype=torch.float32)
+        else:
+            c = torch.zeros((M, N), device=a.device, dtype=a.dtype)
         triton.runtime.driver.set_active_to_cpu()
     else:
         c = None
         triton.runtime.driver.set_active_to_gpu()
 
+    if PREPACKED:
+        triton_a, triton_b, triton_c = matmul_preprocess_input(a, b, c)
+    else:
+        triton_a, triton_b, triton_c = a, b, c
+
     quantiles = [0.5, 0.2, 0.8]
     if provider == 'torch-gpu':
         ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.matmul(a, b), quantiles=quantiles)
     elif provider == 'triton-gpu':
-        ms, min_ms, max_ms = triton.testing.do_bench(lambda: matmul(a, b, None), quantiles=quantiles)
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: matmul(triton_a, triton_b, None), quantiles=quantiles)
     elif provider == 'torch-cpu-native':
         ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.matmul(a, b, out=c), quantiles=quantiles)
     elif provider == 'torch-cpu-compile':
         compiled = torch.compile(torch.matmul)
         ms, min_ms, max_ms = triton.testing.do_bench(lambda: compiled(a, b, out=c), quantiles=quantiles)
     elif provider == 'triton-cpu-single':
-        ms, min_ms, max_ms = triton.testing.do_bench(lambda: matmul(a, b, c, num_threads=1), quantiles=quantiles)
+        ms, min_ms, max_ms = triton.testing.do_bench(
+            lambda: matmul(triton_a, triton_b, triton_c, M, N, K, num_threads=1), quantiles=quantiles,
+            measure_time_with_hooks=True)
     elif provider == 'triton-cpu':
-        ms, min_ms, max_ms = triton.testing.do_bench(lambda: matmul(a, b, c), quantiles=quantiles)
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: matmul(triton_a, triton_b, triton_c, M, N, K),
+                                                     quantiles=quantiles, measure_time_with_hooks=True)
     perf = lambda ms: 2 * M * N * K * 1e-9 / (ms * 1e-3)
     return perf(ms), perf(max_ms), perf(min_ms)
 

--- a/python/tutorials/cpu-blocked-matmul-fp32.py
+++ b/python/tutorials/cpu-blocked-matmul-fp32.py
@@ -1,0 +1,373 @@
+"""
+Matrix Multiplication
+=====================
+In this tutorial, matmul on CPU with different input layouts is tested.
+
+This tutorial is optimized for AMX-enabled CPUs.
+
+"""
+
+# %%
+# Kernels
+# -------
+
+import torch
+
+import triton
+import triton.language as tl
+
+BLOCK_SIZE_M = 8
+BLOCK_SIZE_N = 32
+BLOCK_SIZE_K = 8
+GROUP_SIZE_M = 8
+
+
+# This kernel is used for blocked encoding of input tensors for matmul.
+#
+# Blocked encoding is used to transform 2D tensor [M, N] into 4D tensor
+# [M / BLOCK_SIZE_M, N / BLOCK_SIZE_N, BLOCK_SIZE_M, BLOCK_SIZE_N].
+# This makes following access to blocks in matmul more efficient because
+# each block is placed into a contiguous memory fragment and is likely
+# to fit a single memory page.
+#
+# If TRANSPOSED_B is set to True then head dimensions of the RHS
+# tensor are transposed. It provides contiguos placement for a column
+# of blocks.
+#
+# If TRANSPOSED_BLOCK_A is set to True then tail dimensions of the LHS
+# tensor are transposed. Transposed LHS block better matches FMA lowering
+# used by Triton CPU backend which processes RHS block row-by-row and LHS
+# block column-by-column.
+@triton.jit
+def block_transpose_combined_kernel(in_a, out_a, in_b, out_b, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr,
+                                    BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
+                                    GROUP_SIZE_M: tl.constexpr, BLOCKED_A: tl.constexpr,
+                                    TRANSPOSED_BLOCK_A: tl.constexpr, BLOCKED_B: tl.constexpr,
+                                    TRANSPOSED_B: tl.constexpr):
+    tl.static_assert(M % BLOCK_SIZE_M == 0)
+    tl.static_assert(N % BLOCK_SIZE_N == 0)
+    tl.static_assert(BLOCKED_A or not TRANSPOSED_BLOCK_A)
+    tl.static_assert(BLOCKED_B or not TRANSPOSED_B)
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    in_block_m = first_pid_m + (pid % group_size_m)
+    in_block_n = (pid % num_pid_in_group) // group_size_m
+
+    if BLOCKED_A:
+        a_out_block_m = in_block_m
+        A_OUT_BLOCK_SIZE_M: tl.constexpr = BLOCK_SIZE_K if TRANSPOSED_BLOCK_A else BLOCK_SIZE_M
+        A_OUT_BLOCK_SIZE_K: tl.constexpr = BLOCK_SIZE_M if TRANSPOSED_BLOCK_A else BLOCK_SIZE_K
+        A_OUT_BLOCKS_M: tl.constexpr = M // BLOCK_SIZE_M
+        A_OUT_BLOCKS_K: tl.constexpr = K // BLOCK_SIZE_K
+        A_OUT_STRIDE_M: tl.constexpr = A_OUT_BLOCK_SIZE_K
+        A_OUT_STRIDE_BLOCK_M: tl.constexpr = BLOCK_SIZE_M * K
+        A_OUT_STRIDE_BLOCK_K: tl.constexpr = BLOCK_SIZE_M * BLOCK_SIZE_K
+        for in_block_k in tl.range(in_block_n, A_OUT_BLOCKS_K, N // BLOCK_SIZE_N):
+            a_out_block_k = in_block_k
+            a_in_ptr = tl.make_block_ptr(base=in_a, shape=(M, K), strides=(K, 1),
+                                         offsets=(in_block_m * BLOCK_SIZE_M, in_block_k * BLOCK_SIZE_K),
+                                         block_shape=(BLOCK_SIZE_M, BLOCK_SIZE_K), order=(1, 0))
+            a_out_ptr = tl.make_block_ptr(
+                base=out_a, shape=(A_OUT_BLOCKS_M, A_OUT_BLOCKS_K, A_OUT_BLOCK_SIZE_M, A_OUT_BLOCK_SIZE_K),
+                strides=(A_OUT_STRIDE_BLOCK_M, A_OUT_STRIDE_BLOCK_K, A_OUT_STRIDE_M, 1),
+                offsets=(a_out_block_m, a_out_block_k, 0, 0),
+                block_shape=(1, 1, A_OUT_BLOCK_SIZE_M, A_OUT_BLOCK_SIZE_K), order=(3, 2, 1, 0))
+            val = tl.load(a_in_ptr)
+            if TRANSPOSED_BLOCK_A:
+                val = val.T
+            val = tl.reshape(val, (1, 1, A_OUT_BLOCK_SIZE_M, A_OUT_BLOCK_SIZE_K))
+            tl.store(a_out_ptr, val)
+
+    if BLOCKED_B:
+        B_OUT_BLOCKS_K: tl.constexpr = N // BLOCK_SIZE_N if TRANSPOSED_B else K // BLOCK_SIZE_K
+        B_OUT_BLOCKS_N: tl.constexpr = K // BLOCK_SIZE_K if TRANSPOSED_B else N // BLOCK_SIZE_N
+        B_OUT_STRIDE_K: tl.constexpr = BLOCK_SIZE_N
+        B_OUT_STRIDE_BLOCK_K: tl.constexpr = (K * BLOCK_SIZE_N if TRANSPOSED_B else BLOCK_SIZE_K * N)
+        B_OUT_STRIDE_BLOCK_N: tl.constexpr = BLOCK_SIZE_K * BLOCK_SIZE_N
+        for in_block_k in tl.range(in_block_m, K // BLOCK_SIZE_K, M // BLOCK_SIZE_M):
+            b_out_block_k = in_block_n if TRANSPOSED_B else in_block_k
+            b_out_block_n = in_block_k if TRANSPOSED_B else in_block_n
+            b_in_ptr = tl.make_block_ptr(base=in_b, shape=(K, N), strides=(N, 1),
+                                         offsets=(in_block_k * BLOCK_SIZE_K, in_block_n * BLOCK_SIZE_N),
+                                         block_shape=(BLOCK_SIZE_K, BLOCK_SIZE_N), order=(1, 0))
+            b_out_ptr = tl.make_block_ptr(base=out_b,
+                                          shape=(B_OUT_BLOCKS_K, B_OUT_BLOCKS_N, BLOCK_SIZE_K, BLOCK_SIZE_N),
+                                          strides=(B_OUT_STRIDE_BLOCK_K, B_OUT_STRIDE_BLOCK_N, B_OUT_STRIDE_K, 1),
+                                          offsets=(b_out_block_k, b_out_block_n, 0, 0),
+                                          block_shape=(1, 1, BLOCK_SIZE_K, BLOCK_SIZE_N), order=(3, 2, 1, 0))
+            val = tl.load(b_in_ptr)
+            val = tl.reshape(val, (1, 1, BLOCK_SIZE_K, BLOCK_SIZE_N))
+            tl.store(b_out_ptr, val)
+
+
+# Matmul kernel that computes a single output block [BLOCK_SIZE_M, BLOCK_SIZE_N]. LHS can be in the
+# rowmajor, blocked, or blocked transposed encoding. RHS can be in rowmajor, blocked, or transposed
+# blocked encoding.
+#
+# To cover all input layouts, we use 4D block pointers that address a single input block
+# [1, 1, BLOCK_SIZE_M, BLOCK_SIZE_N], we choose strides for these block pointers
+# appropriately to keep navigation bentween blocks similar for all input encodings.
+#
+# E.g. for rowmajor LHS we use BLOCK_SIZE_K stride to move to the next block over K axis, but
+# for blocked encoding we use BLOCK_SIZE_M * BLOCK_SIZE_K stride. In both cases we then can
+# advance using the same (0, 1, 0, 0) offset in the loop.
+#
+# Reshape is used to remove the heading (1, 1) dimensions, but CPU backend folds it with the load
+# operation and it doesn't prevent direct vector loads from the input memory.
+@triton.jit
+def matmul_kernel_fma(a_ptr, b_ptr, c_ptr, M, N, K, BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr,
+                      BLOCK_SIZE_K: tl.constexpr,
+                      # number of blocks in a group
+                      GROUP_SIZE_M: tl.constexpr, BLOCKED_A: tl.constexpr, TRANSPOSED_BLOCK_A: tl.constexpr,
+                      BLOCKED_B: tl.constexpr, TRANSPOSED_B: tl.constexpr):
+    # TRANSPOSED_BLOCK_A means that each block in A is transposed.
+    # It is allowed only for blocked input.
+    assert (BLOCKED_A or not TRANSPOSED_BLOCK_A)
+    # TRANSPOSED_B means that blocks of B are reordered but blocks
+    # itself are not transpoed. It is allowed only for blocked input.
+    assert (BLOCKED_B or not TRANSPOSED_B)
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    block_m = first_pid_m + (pid % group_size_m)
+    block_n = (pid % num_pid_in_group) // group_size_m
+
+    A_BLOCK_SIZE_M: tl.constexpr = BLOCK_SIZE_K if TRANSPOSED_BLOCK_A else BLOCK_SIZE_M
+    A_BLOCK_SIZE_K: tl.constexpr = BLOCK_SIZE_M if TRANSPOSED_BLOCK_A else BLOCK_SIZE_K
+    A_BLOCKS_M = M // BLOCK_SIZE_M
+    A_BLOCKS_K = K // BLOCK_SIZE_K
+    a_stride_k = 1
+    a_stride_m = A_BLOCK_SIZE_K if BLOCKED_A else K
+    a_stride_block_k = A_BLOCK_SIZE_M * A_BLOCK_SIZE_K if BLOCKED_A else A_BLOCK_SIZE_K
+    a_stride_block_m = BLOCK_SIZE_M * K
+
+    b_stride_n = 1
+    b_stride_k = BLOCK_SIZE_N if BLOCKED_B else N
+    if TRANSPOSED_B:
+        b_stride_block_n = BLOCK_SIZE_N * K
+        b_stride_block_k = BLOCK_SIZE_K * BLOCK_SIZE_N
+    else:
+        b_stride_block_n = BLOCK_SIZE_K * BLOCK_SIZE_N if BLOCKED_B else BLOCK_SIZE_N
+        b_stride_block_k = BLOCK_SIZE_K * N
+
+    a_block_ptr = tl.make_block_ptr(base=a_ptr, shape=(A_BLOCKS_M, A_BLOCKS_K, A_BLOCK_SIZE_M, A_BLOCK_SIZE_K),
+                                    strides=(a_stride_block_m, a_stride_block_k, a_stride_m, a_stride_k),
+                                    offsets=(block_m, 0, 0, 0), block_shape=(1, 1, A_BLOCK_SIZE_M, A_BLOCK_SIZE_K),
+                                    order=(3, 2, 1, 0))
+    b_block_ptr = tl.make_block_ptr(base=b_ptr,
+                                    shape=(K // BLOCK_SIZE_K, N // BLOCK_SIZE_N, BLOCK_SIZE_K, BLOCK_SIZE_N),
+                                    strides=(b_stride_block_k, b_stride_block_n, b_stride_k, b_stride_n),
+                                    offsets=(0, block_n, 0, 0), block_shape=(1, 1, BLOCK_SIZE_K, BLOCK_SIZE_N),
+                                    order=(3, 2, 1, 0))
+    c_block_ptr = tl.make_block_ptr(base=c_ptr, shape=(M, N), strides=(N, 1),
+                                    offsets=(block_m * BLOCK_SIZE_M, block_n * BLOCK_SIZE_N),
+                                    block_shape=(BLOCK_SIZE_M, BLOCK_SIZE_N), order=(1, 0))
+
+    c = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_block_ptr).reshape((A_BLOCK_SIZE_M, A_BLOCK_SIZE_K))
+        b = tl.load(b_block_ptr).reshape((BLOCK_SIZE_K, BLOCK_SIZE_N))
+
+        if TRANSPOSED_BLOCK_A:
+            a = a.T
+
+        c += tl.dot(a, b, out_dtype=tl.float32)
+
+        a_block_ptr = tl.advance(a_block_ptr, (0, 1, 0, 0))
+        b_block_ptr = tl.advance(b_block_ptr, (1, 0, 0, 0))
+
+    tl.store(c_block_ptr, c)
+
+
+def matmul_fma(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor, ab: torch.Tensor, bb: torch.Tensor, M, N, K,
+               PREPACKED, BLOCKED_A, TRANSPOSED_BLOCK_A, BLOCKED_B, TRANSPOSED_B, num_threads=0):
+    #TODO: Currently masked load is not supported yet.
+    assert (M % BLOCK_SIZE_M == 0) and (N % BLOCK_SIZE_N == 0) and (
+        K % BLOCK_SIZE_K == 0), "Masking currently not supported, Matrix dimensions must be multiples of block size"
+    # 1D launch kernel where each block gets its own program.
+    grid = ((M // BLOCK_SIZE_M) * (N // BLOCK_SIZE_N), )
+    if (BLOCKED_A or BLOCKED_B) and not PREPACKED:
+        block_transpose_combined_kernel[grid](
+            a, ab, b, bb,  #
+            M, N, K,  #
+            BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N, BLOCK_SIZE_K=BLOCK_SIZE_K,  #
+            GROUP_SIZE_M=GROUP_SIZE_M,  #
+            BLOCKED_A=BLOCKED_A, TRANSPOSED_BLOCK_A=TRANSPOSED_BLOCK_A,  #
+            BLOCKED_B=BLOCKED_B, TRANSPOSED_B=TRANSPOSED_B)
+        if BLOCKED_A:
+            a = ab
+        if BLOCKED_B:
+            b = bb
+    matmul_kernel_fma[grid](
+        a, b, c,  #
+        M, N, K,  #
+        BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N, BLOCK_SIZE_K=BLOCK_SIZE_K,  #
+        GROUP_SIZE_M=GROUP_SIZE_M,  #
+        BLOCKED_A=BLOCKED_A, TRANSPOSED_BLOCK_A=TRANSPOSED_BLOCK_A,  #
+        BLOCKED_B=BLOCKED_B, TRANSPOSED_B=TRANSPOSED_B, num_threads=num_threads)
+    return c
+
+
+# %%
+# Unit Test
+# ---------
+#
+# We can test our custom matrix multiplication operation against a native torch implementation.
+torch.manual_seed(0)
+
+triton.runtime.driver.set_active_to_cpu()
+
+a = torch.randn((512, 512), device='cpu', dtype=torch.float32)
+b = torch.randn((512, 512), device='cpu', dtype=torch.float32)
+c = torch.empty((512, 512), device='cpu', dtype=torch.float32)
+torch_output = torch.matmul(a, b)
+rtol = 0
+a_tmp = torch.zeros((512 * 512 + (512 // BLOCK_SIZE_M) * (512 // BLOCK_SIZE_K) * 64), device='cpu', dtype=torch.float32)
+b_tmp = torch.zeros((512 * 512 + (512 // BLOCK_SIZE_K) * (512 // BLOCK_SIZE_N) * 64), device='cpu', dtype=torch.float32)
+triton_output = matmul_fma(a, b, c, a_tmp, b_tmp, 512, 512, 512, True, False, False, False, False, False)
+if torch.allclose(triton_output, torch_output, atol=1e-2, rtol=rtol):
+    print("✅ TritonCPU and TorchCPU match")
+else:
+    print("❌ TritonCPU and TorchCPU differ, the maximum difference is "
+          f'{torch.max(torch.abs(triton_output - torch_output))}')
+    assert False
+triton_output = matmul_fma(a, b, c, a_tmp, b_tmp, 512, 512, 512, False, True, True, True, True, True)
+if torch.allclose(triton_output, torch_output, atol=1e-2, rtol=rtol):
+    print("✅ TritonCPU pre-packed and TorchCPU match")
+else:
+    print("❌ TritonCPU pre-packed and TorchCPU differ, the maximum difference is "
+          f'{torch.max(torch.abs(triton_output - torch_output))}')
+    assert False
+
+# %%
+# Benchmark
+# ---------
+#
+# Square Matrix Performance
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# We can now compare the performance of our kernel against that of Pytorch. Here we focus on square matrices,
+# but feel free to arrange this script as you wish to benchmark any other matrix shape.
+
+
+def encode_triton_provider(blocked_a, transposed_a, blocked_b, transposed_b, prepack, single_thread, dtype):
+    assert dtype == 'float32' or dtype == 'bfloat16' or dtype == 'float16'
+    return f"triton-cpu{'-ba' if blocked_a else ''}{'-ta' if transposed_a else ''}{'-bb' if blocked_b else ''}{'-tb' if transposed_b else ''}{'-prepack' if prepack else ''}{'-st' if single_thread else ''}-{dtype}"
+
+
+def encode_torch_provider(single_thread, dtype):
+    assert dtype == 'float32' or dtype == 'bfloat16' or dtype == 'float16'
+    return f"torch-cpu-native{'-st' if single_thread else ''}-{dtype}"
+
+
+def decode_provider(provider):
+    if '-bfloat16' in provider:
+        dtype = torch.bfloat16
+    if '-float16' in provider:
+        dtype = torch.float16
+    elif '-float32' in provider:
+        dtype = torch.float32
+    if 'triton-cpu' in provider:
+        backend = 'triton-cpu'
+    elif 'torch-cpu-native' in provider:
+        backend = 'torch-cpu-native'
+    elif 'torch-cpu-compile' in provider:
+        backend = 'torch-cpu-compile'
+    return backend, '-ba' in provider, '-ta' in provider, '-bb' in provider, '-tb' in provider, '-prepack' in provider, '-st' in provider, dtype
+
+
+BLOCK_TRANSPOSE_A_OPTS = [(False, False)]
+BLOCK_TRANSPOSE_B_OPTS = [(True, True), (False, False)]
+PREPACK_OPTS = [False, True]
+SINGLE_THREAD_OPTS = [False]
+DTYPE_OPTS = ['float32']
+LINE_VALS = [
+    encode_triton_provider(blocked_a, transposed_a, blocked_b, transposed_b, prepack, single_thread, dtype)
+    for single_thread in SINGLE_THREAD_OPTS
+    for blocked_a, transposed_a in BLOCK_TRANSPOSE_A_OPTS
+    for blocked_b, transposed_b in BLOCK_TRANSPOSE_B_OPTS
+    for prepack in PREPACK_OPTS
+    for dtype in DTYPE_OPTS
+    if blocked_a or blocked_b or not prepack
+] + [encode_torch_provider(single_thread, dtype) for dtype in DTYPE_OPTS for single_thread in SINGLE_THREAD_OPTS]
+LINE_NAMES = LINE_VALS
+LINE_STYLES = None
+
+default_num_threads = torch.get_num_threads()
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["M", "N", "K"],  # Argument names to use as an x-axis for the plot
+        x_vals=[128 * i for i in range(2, 21)],  # Different possible values for `x_name`
+        line_arg='provider',  # Argument name whose value corresponds to a different line in the plot.
+        line_vals=LINE_VALS,  # Possible values for `line_arg`.
+        line_names=LINE_NAMES,  # Label name for the lines.
+        styles=LINE_STYLES,  # Line styles.
+        ylabel='GFLOPS',  # Label name for the y-axis.
+        plot_name=
+        # Name for the plot. Used also as a file name for saving the plot.
+        f'matmul-performance-fp32 (BLOCK_SIZE_M={BLOCK_SIZE_M}, BLOCK_SIZE_N={BLOCK_SIZE_N}, BLOCK_SIZE_K={BLOCK_SIZE_K}, GROUP_SIZE_M={GROUP_SIZE_M})',
+        args={},  # Values for function arguments not in `x_names` and `y_name`.
+    ))
+def benchmark(M, N, K, provider):
+
+    device = 'cpu' if 'cpu' in provider else 'cuda'
+    backend, blocked_a, transposed_a, blocked_b, transposed_b, prepack, single_thread, dtype = decode_provider(provider)
+    a = torch.randn((M, K), device=device, dtype=dtype)
+    b = torch.randn((K, N), device=device, dtype=dtype)
+
+    if single_thread:
+        torch.set_num_threads(1)
+    else:
+        torch.set_num_threads(default_num_threads)
+
+    if backend == 'triton-cpu':
+        c = torch.zeros((M, N), device=a.device, dtype=torch.float32)
+        a_tmp = torch.zeros((M * K + (M // BLOCK_SIZE_M) * (K // BLOCK_SIZE_K) * 64), device=device, dtype=dtype)
+        b_tmp = torch.zeros((K * N + (K // BLOCK_SIZE_K) * (N // BLOCK_SIZE_N) * 64), device=device, dtype=dtype)
+        c = torch.zeros((M, N), device=a.device, dtype=torch.float32)
+        if prepack and (blocked_a or blocked_b):
+            grid = ((M // BLOCK_SIZE_M) * (N // BLOCK_SIZE_N), )
+            block_transpose_combined_kernel[grid](
+                a, a_tmp, b, b_tmp,  #
+                M, N, K,  #
+                BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N, BLOCK_SIZE_K=BLOCK_SIZE_K,  #
+                GROUP_SIZE_M=GROUP_SIZE_M,  #
+                BLOCKED_A=blocked_a, TRANSPOSED_BLOCK_A=transposed_a,  #
+                BLOCKED_B=blocked_b, TRANSPOSED_B=transposed_b)
+            if blocked_a:
+                a = a_tmp
+            if blocked_b:
+                b = b_tmp
+    else:
+        c = torch.zeros((M, N), device=a.device, dtype=dtype)
+
+    quantiles = [0.5, 0.2, 0.8]
+    if backend == 'torch-cpu-native':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.matmul(a, b, out=c), quantiles=quantiles)
+    elif backend == 'torch-cpu-compile':
+        compiled = torch.compile(torch.matmul)
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: compiled(a, b, out=c), quantiles=quantiles)
+    elif backend == 'triton-cpu':
+        ms, min_ms, max_ms = triton.testing.do_bench(
+            lambda: matmul_fma(a, b, c, a_tmp, b_tmp, M, N, K, prepack, blocked_a, transposed_a, blocked_b,
+                               transposed_b, num_threads=int(single_thread)), quantiles=quantiles,
+            measure_time_with_hooks=True, rep=1000)
+    perf = lambda ms: 2 * M * N * K * 1e-9 / (ms * 1e-3)
+    return perf(ms), perf(max_ms), perf(min_ms)
+
+
+# %%
+# We can now run the decorated function above. Pass `print_data=True` to see the performance number, `show_plots=True` to plot them, and/or
+# `save_path='/path/to/results/' to save them to disk along with raw CSV data:
+benchmark.run(print_data=True, show_plots=True)

--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -175,6 +175,8 @@ class CPUBackend(BaseBackend):
             amx_fp16 = False
             amx_bf16 = 'amx-bf16' in self.cpu_features
             cpu.passes.ttcpuir.add_convert_dot_to_amx(pm, amx_int8, amx_fp16, amx_bf16)
+        if 'avx512f' in self.cpu_features:
+            cpu.passes.ttcpuir.add_convert_dot_to_fma(pm)
         cpu.passes.ttcpuir.add_convert_dot_generic(pm)
         promote_bf16_to_fp32 = self.cpu_arch == "x86_64" and "avx512bf16" not in self.cpu_features
         # We don't have any lowering for mixed precision matmuls, so always use casts for now

--- a/third_party/cpu/include/TritonCPUTransforms/Passes.h
+++ b/third_party/cpu/include/TritonCPUTransforms/Passes.h
@@ -36,6 +36,7 @@ createConvertDotProduct(bool useHorizontalSum);
 std::unique_ptr<OperationPass<ModuleOp>> createConvertDotToAMX();
 std::unique_ptr<OperationPass<ModuleOp>>
 createConvertDotToAMX(bool convertInt8, bool convertFp16, bool convertBf16);
+std::unique_ptr<OperationPass<ModuleOp>> createConvertDotToFMA();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertDotGeneric();
 std::unique_ptr<OperationPass<ModuleOp>> createCanonicalize();
 

--- a/third_party/cpu/include/TritonCPUTransforms/Passes.td
+++ b/third_party/cpu/include/TritonCPUTransforms/Passes.td
@@ -125,6 +125,18 @@ def ConvertDotToAMX : Pass<"triton-cpu-convert-dot-to-amx", "mlir::ModuleOp"> {
                              "mlir::triton::cpu::TritonCPUDialect"];
 }
 
+def ConvertDotToFMA : Pass<"triton-cpu-convert-dot-to-fma", "mlir::ModuleOp"> {
+    let summary = "Decompose dot product op to a series of FMA operations.";
+    let description = [{ }];
+
+    let constructor = "mlir::triton::cpu::createConvertDotToFMA()";
+
+    let dependentDialects = ["mlir::arith::ArithDialect",
+                             "mlir::vector::VectorDialect",
+                             "mlir::triton::TritonDialect",
+                             "mlir::triton::cpu::TritonCPUDialect"];
+}
+
 def ConvertDotGeneric : Pass<"triton-cpu-convert-dot-generic", "mlir::ModuleOp"> {
     let summary = "Generic convertion of dot product op.";
     let description = [{

--- a/third_party/cpu/lib/TritonCPUTransforms/CMakeLists.txt
+++ b/third_party/cpu/lib/TritonCPUTransforms/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_triton_library(TritonCPUTransforms
+    ConvertDotOp/ConvertDotCommon.cpp
     ConvertDotOp/ConvertDotGeneric.cpp
     ConvertDotOp/ConvertDotToAMX.cpp
+    ConvertDotOp/ConvertDotToFMA.cpp
     Canonicalize.cpp
     ConvertDotProduct.cpp
     ConvertUnsupportedOps.cpp

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotCommon.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotCommon.cpp
@@ -1,0 +1,190 @@
+#include "ConvertDotCommon.h"
+
+using namespace mlir;
+using namespace mlir::triton;
+using namespace mlir::triton::cpu;
+
+namespace mlir {
+namespace triton {
+namespace cpu {
+
+bool isLoopCarriedAcc(Value acc) {
+  LDBG("Check if accumulator can be held in tiles: " << acc);
+  if (!acc.hasOneUse()) {
+    LDBG("  No. Has multiple uses.");
+    for (auto op : acc.getUsers())
+      LDBG("    " << *op);
+    return false;
+  }
+
+  auto blockArg = dyn_cast<BlockArgument>(acc);
+  if (!blockArg) {
+    LDBG("  No. Not a block argument.");
+    return false;
+  }
+
+  auto forOp = dyn_cast<scf::ForOp>(blockArg.getOwner()->getParentOp());
+  if (!forOp) {
+    LDBG("  No. Not in a for-loop.");
+    return false;
+  }
+
+  blockArg.getArgNumber();
+
+  Value updAcc = acc.getUsers().begin()->getResult(0);
+  if (!updAcc.hasOneUse()) {
+    LDBG("  No. Has multiple uses.");
+    return false;
+  }
+
+  auto &updAccUse = *updAcc.getUses().begin();
+  if (!isa<scf::YieldOp>(updAccUse.getOwner()) ||
+      updAccUse.getOperandNumber() !=
+          (blockArg.getArgNumber() - forOp.getNumInductionVars())) {
+    LDBG("  No. Loop carried dependency not detected.");
+    return false;
+  }
+
+  LDBG("  Yes.");
+  return true;
+}
+
+Value getInitAccValue(Value val) {
+  auto blockArg = cast<BlockArgument>(val);
+  auto forOp = cast<scf::ForOp>(blockArg.getOwner()->getParentOp());
+  int initValIdx = blockArg.getArgNumber() - forOp.getNumInductionVars();
+  return forOp.getInitArgs()[initValIdx];
+}
+
+MemBuffer findInputBuffer(Value val, bool allowTransposed) {
+  MemBuffer buf;
+
+  if (allowTransposed) {
+    auto transposeOp = val.getDefiningOp<vector::TransposeOp>();
+    if (transposeOp) {
+      val = transposeOp.getVector();
+      buf.transposed = true;
+    }
+  }
+
+  auto valLoad = val.getDefiningOp<vector::TransferReadOp>();
+  if (!valLoad || hasMaskOrBoundsCheck(valLoad)) {
+    LDBG("Couldn't find a buffer with input: " << val);
+    return buf;
+  }
+
+  buf.memRef = valLoad.getSource();
+  buf.indices = valLoad.getIndices();
+  LLVM_DEBUG(
+      DBGS() << "Found buffer with input: " << val << "\n";
+      DBGS() << "  MemRef: " << buf.memRef << "\n"; DBGS() << "  Indices: ";
+      llvm::interleaveComma(buf.indices, llvm::dbgs()); llvm::dbgs() << "\n");
+
+  auto forOp = dyn_cast<scf::ForOp>(valLoad->getParentOp());
+  if (!forOp) {
+    LDBG("  Skip steps. Not in a for-loop.");
+    return buf;
+  }
+
+  auto extractMemRef = buf.memRef.getDefiningOp<ExtractMemRefOp>();
+  if (!extractMemRef) {
+    LDBG("  Skip steps. No ExtractMemRefOp.");
+    return buf;
+  }
+
+  ExtractIndicesOp extractIndices;
+  for (auto index : buf.indices) {
+    auto def = index.getDefiningOp<ExtractIndicesOp>();
+    if (!def || (extractIndices && def != extractIndices)) {
+      LDBG("  Skip steps. No ExtractIndicesOp.");
+      return buf;
+    }
+    extractIndices = def;
+  }
+
+  if (extractMemRef.getSrc() != extractIndices.getSrc()) {
+    LDBG("  Skip steps. Mismatched ExtractMemRefOp and ExtractIndicesOp.");
+    return buf;
+  }
+
+  BlockArgument blockPtrArg = dyn_cast<BlockArgument>(extractMemRef.getSrc());
+  if (!blockPtrArg) {
+    LDBG("  Skip steps. No block pointer arg.");
+    return buf;
+  }
+
+  OpOperand *yieldOp = forOp.getTiedLoopYieldedValue(blockPtrArg);
+  if (!yieldOp) {
+    LDBG("  Skip steps. No block pointer in yield.");
+    return buf;
+  }
+
+  auto advance = yieldOp->get().getDefiningOp<AdvanceOp>();
+  if (!advance) {
+    LDBG("  Skip steps. No AdvanceOp.");
+    return buf;
+  }
+
+  if (advance.getPtr() != blockPtrArg) {
+    LDBG("  Skip steps. AdvanceOp doesn't use block pointer arg.");
+    return buf;
+  }
+
+  buf.step = advance.getOffsets();
+  LLVM_DEBUG(DBGS() << "  Step: ";
+             llvm::interleaveComma(buf.step, llvm::dbgs());
+             llvm::dbgs() << "\n");
+
+  return buf;
+}
+
+Value maybeCast(Location loc, Value val, Type dstElemTy,
+                PatternRewriter &rewriter) {
+  VectorType srcTy = cast<VectorType>(val.getType());
+  if (srcTy.getElementType() == dstElemTy)
+    return val;
+
+  VectorType dstTy = srcTy.cloneWith(std::nullopt, dstElemTy);
+  if (srcTy.getElementType().isInteger()) {
+    if (srcTy.getElementTypeBitWidth() < dstTy.getElementTypeBitWidth())
+      return rewriter.create<arith::ExtSIOp>(loc, dstTy, val);
+    return rewriter.create<arith::TruncIOp>(loc, dstTy, val);
+  }
+
+  if (srcTy.getElementTypeBitWidth() < dstTy.getElementTypeBitWidth())
+    return rewriter.create<arith::ExtFOp>(loc, dstTy, val);
+  return rewriter.create<arith::TruncFOp>(loc, dstTy, val);
+}
+
+MemBuffer allocateTmpBuffer(Location loc, VectorType vecTy,
+                            Operation *allocaPoint, PatternRewriter &rewriter) {
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(allocaPoint);
+  auto memRefTy = MemRefType::get(vecTy.getShape(), vecTy.getElementType());
+  Value memRef = rewriter.create<memref::AllocaOp>(
+      loc, memRefTy, rewriter.getIntegerAttr(rewriter.getI64Type(), 64));
+  Value zeroIdx = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  SmallVector<Value> indices(2, zeroIdx);
+  return {memRef, indices};
+}
+
+Value shiftIndex(Location loc, Value index, int64_t offs,
+                 PatternRewriter &rewriter) {
+  if (!offs)
+    return index;
+
+  // Do constant folding right away here for better code readability
+  // after the pass.
+  auto cstOp = dyn_cast<arith::ConstantOp>(index.getDefiningOp());
+  if (cstOp) {
+    int64_t oldVal = cast<IntegerAttr>(cstOp.getValue()).getInt();
+    return rewriter.create<arith::ConstantIndexOp>(loc, oldVal + offs);
+  }
+
+  Value offsVal = rewriter.create<arith::ConstantIndexOp>(loc, offs);
+  return rewriter.create<arith::AddIOp>(loc, index.getType(), index, offsVal);
+}
+
+} // namespace cpu
+} // namespace triton
+} // namespace mlir

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotCommon.h
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotCommon.h
@@ -29,8 +29,8 @@ struct MemBuffer {
 };
 
 // Check if accumulator value is updated in a loop and has no other
-// usages than a dot op, that updates it. Tile loads/stores and casts
-// for such accumulators can be done outside of the loop.
+// usages than a dot op that updates it. Loads, stores, and casts
+// for such accumulator can be done outside of the loop.
 bool isLoopCarriedAcc(Value acc);
 
 // Get initial value for a loop-carried accumulator.

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotCommon.h
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotCommon.h
@@ -1,0 +1,72 @@
+#include "cpu/include/TritonCPUTransforms/OptCommon.h"
+
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonCPU/IR/Dialect.h"
+
+#define DEBUG_TYPE "triton-cpu-dot-conversion"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+namespace mlir {
+namespace triton {
+namespace cpu {
+
+// This structure describes input/output buffer.
+struct MemBuffer {
+  Value memRef;
+  SmallVector<Value> indices;
+  // If buffer is accessed in a loop and indices are advanced
+  // on each iteration, then step can hold those index offsets.
+  // Empty step doesn't mean indices are loop invariant.
+  SmallVector<Value> step;
+  // True if buffer holds transposed value.
+  bool transposed = false;
+
+  bool empty() const { return !memRef; }
+};
+
+// Check if accumulator value is updated in a loop and has no other
+// usages than a dot op, that updates it. Tile loads/stores and casts
+// for such accumulators can be done outside of the loop.
+bool isLoopCarriedAcc(Value acc);
+
+// Get initial value for a loop-carried accumulator.
+Value getInitAccValue(Value val);
+
+// Check if vector transfer read/write operation uses a mask
+// or involves a bounds check.
+template <typename T> bool hasMaskOrBoundsCheck(T op) {
+  auto inBounds = op.getInBounds();
+  Value mask = op.getMask();
+  bool hasBoundsCheck =
+      std::any_of(inBounds.begin(), inBounds.end(), [](Attribute attr) {
+        return !cast<mlir::BoolAttr>(attr).getValue();
+      });
+  return hasBoundsCheck || mask;
+}
+
+// Search for a buffer holding required value. If allowTransposed is true,
+// then buffer is allowed to hold both transposed and not transposed value.
+// Return empty buffer if no memory holding value was found.
+MemBuffer findInputBuffer(Value val, bool allowTransposed = false);
+
+// Cast vector to a specified element type using ext or trunc
+// operations. Return the original value if it already matches
+// the required element type.
+Value maybeCast(Location loc, Value val, Type dstElemTy,
+                PatternRewriter &rewriter);
+
+// Allocate temporary buffer on stack for specified vector type.
+MemBuffer allocateTmpBuffer(Location loc, VectorType vecTy,
+                            Operation *allocaPoint, PatternRewriter &rewriter);
+
+// Move index by specified offset. Do constannt folding if possible.
+Value shiftIndex(Location loc, Value index, int64_t offs,
+                 PatternRewriter &rewriter);
+
+} // namespace cpu
+} // namespace triton
+} // namespace mlir

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToFMA.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToFMA.cpp
@@ -1,0 +1,460 @@
+#include "ConvertDotCommon.h"
+
+#include "cpu/include/TritonCPUTransforms/Passes.h"
+
+#include "mlir/Dialect/Index/IR/IndexDialect.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include <iostream>
+#include <utility>
+
+namespace mlir {
+namespace triton {
+namespace cpu {
+#define GEN_PASS_DEF_CONVERTDOTTOFMA
+#include "cpu/include/TritonCPUTransforms/Passes.h.inc"
+} // namespace cpu
+} // namespace triton
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::triton;
+using namespace mlir::triton::cpu;
+
+namespace {
+
+// This structure is used to hold candidates for conversion to AMX
+// Mul[F|I]Op operations.
+struct FmaDotOpCandidate {
+  // Operation to convert.
+  cpu::DotOp op;
+  // Here we keep actual element types used by LHS, RHS, and accumulator for
+  // computation.
+  Type lhsElemTy;
+  Type rhsElemTy;
+  Type accElemTy;
+  // Accumulator size.
+  int64_t accVecSize;
+  int64_t accRows;
+  // If accumulator is updated in a loop, then this flag indicates if we
+  // should keep it in registers the whole loop.
+  bool keepAccOnRegs = false;
+  // Memory buffer holding LHS. Can be empty if LHS is not a result of a
+  // simple load.
+  MemBuffer lhsBuf;
+  // Memory buffer holding RHS. Can be empty if RHS is not a result of a
+  // simple load.
+  MemBuffer rhsBuf;
+};
+
+// Check if input and output types can be handled by AMX (possibly, using
+// additional casts for input/output). Returns true if AMX usage is possible.
+// In this case, tile element type fields of the candidate structure are
+// filled with actual types to be used in lowering.
+bool checkElemTypes(Type lhsElemTy, Type rhsElemTy, Type accElemTy,
+                    Type resElemTy, FmaDotOpCandidate &candidate) {
+  MLIRContext *ctx = lhsElemTy.getContext();
+  if (lhsElemTy.isInteger() || rhsElemTy.isInteger() || resElemTy.isInteger()) {
+    LDBG("Drop candidate because int types are not supported.");
+    return false;
+  }
+
+  // Find a type to use for computations. Here we assume FMA works on FP32
+  // and FP64, so smaller types are promoted. Flags should be added to cover
+  // other cases.
+  Type commonInputElemTy;
+  if (lhsElemTy.isF64() || rhsElemTy.isF64() || resElemTy.isF64())
+    commonInputElemTy = Float64Type::get(ctx);
+  else
+    commonInputElemTy = Float32Type::get(ctx);
+
+  candidate.lhsElemTy = commonInputElemTy;
+  candidate.rhsElemTy = commonInputElemTy;
+  candidate.accElemTy = commonInputElemTy;
+
+  return true;
+}
+
+// Check input shapes. Currently, support only 2D cases and ignore small
+// inputs.
+bool checkInputShapes(VectorType lhsTy, VectorType resTy) {
+  if (lhsTy.getRank() != 2)
+    return false;
+
+  if (resTy.getDimSize(1) < 8)
+    return false;
+
+  return true;
+}
+
+// Check if specified ContractionOp can be lowered to AMX operations.
+// If conversion is possible, then true is returned and candidate
+// structure is filled with detailed transformation info.
+bool isFmaCandidate(cpu::DotOp op, FmaDotOpCandidate &candidate) {
+  MLIRContext *ctx = op.getContext();
+  VectorType lhsTy = op.getA().getType();
+  VectorType rhsTy = op.getB().getType();
+  VectorType accTy = op.getC().getType();
+  VectorType resTy = op.getType();
+
+  LDBG("Considering candidate op: " << op);
+
+  // Check if input and output types match available hardware capabilities.
+  // If check is successful then effective element types are assigned to the
+  // candidate.
+  if (!checkElemTypes(lhsTy.getElementType(), rhsTy.getElementType(),
+                      accTy.getElementType(), resTy.getElementType(),
+                      candidate))
+    return false;
+
+  // Check input shapes.
+  if (!checkInputShapes(lhsTy, resTy))
+    return false;
+
+  candidate.op = op;
+  candidate.accVecSize = resTy.getDimSize(1);
+  candidate.accRows = resTy.getDimSize(0);
+  candidate.keepAccOnRegs = isLoopCarriedAcc(op.getC());
+
+  if (lhsTy.getElementType() == candidate.lhsElemTy)
+    candidate.lhsBuf = findInputBuffer(op.getA(), true);
+  if (rhsTy.getElementType() == candidate.rhsElemTy)
+    candidate.rhsBuf = findInputBuffer(op.getB(), false);
+
+  return true;
+}
+
+MemBuffer storeToTmpBuffer(Location loc, Value val, Operation *allocaPoint,
+                           PatternRewriter &rewriter) {
+  LDBG("Storing vector to a temporary buffer: " << val);
+  auto vecTy = cast<VectorType>(val.getType());
+  MemBuffer buf = allocateTmpBuffer(loc, vecTy, allocaPoint, rewriter);
+  rewriter.create<vector::TransferWriteOp>(loc, val, buf.memRef, buf.indices);
+  return buf;
+}
+
+SmallVector<Value> shiftIndices(Location loc, ArrayRef<Value> indices,
+                                bool transposed, int64_t m, int64_t n,
+                                PatternRewriter &rewriter) {
+  SmallVector<Value> res(indices.begin(), indices.end() - 2);
+  if (transposed)
+    std::swap(m, n);
+  res.push_back(shiftIndex(loc, *(indices.end() - 2), m, rewriter));
+  res.push_back(shiftIndex(loc, *(indices.end() - 1), n, rewriter));
+  return res;
+}
+
+SmallVector<Value> shiftIndices(Location loc, const MemBuffer &buf, int64_t m,
+                                int64_t n, PatternRewriter &rewriter) {
+  return shiftIndices(loc, buf.indices, buf.transposed, m, n, rewriter);
+}
+
+Value loadRow(Location loc, VectorType resTy, const MemBuffer &buf, int64_t m,
+              PatternRewriter &rewriter) {
+  assert(!buf.empty());
+  SmallVector<Value> indices = buf.indices;
+  indices[indices.size() - 2] =
+      shiftIndex(loc, indices[indices.size() - 2], m, rewriter);
+  return rewriter.create<vector::LoadOp>(loc, resTy, buf.memRef, indices);
+}
+
+void storeRow(Location loc, const MemBuffer &buf, int64_t rowIdx, Value vec,
+              PatternRewriter &rewriter) {
+  SmallVector<Value> indices = buf.indices;
+  indices[indices.size() - 2] =
+      shiftIndex(loc, buf.indices[indices.size() - 2], rowIdx, rewriter);
+  rewriter.create<vector::StoreOp>(loc, vec, buf.memRef, indices);
+}
+
+void storeRows(Location loc, const MemBuffer &buf,
+               const SmallVector<Value> &vecs, PatternRewriter &rewriter) {
+  SmallVector<Value> indices = buf.indices;
+  for (int64_t m = 0; m < vecs.size(); ++m)
+    storeRow(loc, buf, m, vecs[m], rewriter);
+}
+
+SmallVector<Value> extractRows(Location loc, Value vec,
+                               PatternRewriter &rewriter) {
+  VectorType vecTy = cast<VectorType>(vec.getType());
+  SmallVector<Value> res;
+  for (int64_t m = 0; m < vecTy.getDimSize(0); ++m) {
+    auto row =
+        rewriter.create<vector::ExtractOp>(loc, vec, SmallVector<int64_t>({m}));
+    res.push_back(row);
+  }
+  return res;
+}
+
+Value mergeRows(Location loc, VectorType resTy, const SmallVector<Value> &tiles,
+                PatternRewriter &rewriter) {
+  Value res =
+      rewriter.create<arith::ConstantOp>(loc, rewriter.getZeroAttr(resTy));
+  for (int64_t m = 0; m < tiles.size(); ++m)
+    res = rewriter.create<vector::InsertOp>(loc, tiles[m], res,
+                                            SmallVector<int64_t>({m}));
+  return res;
+}
+
+Value broadcastElem(Location loc, VectorType tileTy, const MemBuffer &buf,
+                    int64_t m, int64_t n, PatternRewriter &rewriter) {
+  SmallVector<Value> indices = shiftIndices(loc, buf, m, n, rewriter);
+  Value scalar = rewriter.create<memref::LoadOp>(loc, buf.memRef, indices);
+  return rewriter.create<vector::BroadcastOp>(loc, tileTy, scalar);
+}
+
+SmallVector<Value> computePrefetchIndices(Location loc, const MemBuffer &buf,
+                                          int64_t iters,
+                                          PatternRewriter &rewriter) {
+  SmallVector<Value> scaledStep;
+  Value itersVal;
+  for (auto step : buf.step) {
+    if (iters == 1)
+      scaledStep.push_back(rewriter.create<arith::IndexCastOp>(
+          loc, rewriter.getIndexType(), step));
+    else if (auto cstOp = dyn_cast<arith::ConstantOp>(step.getDefiningOp())) {
+      int64_t oldVal = cast<IntegerAttr>(cstOp.getValue()).getInt();
+      scaledStep.push_back(
+          rewriter.create<arith::ConstantIndexOp>(loc, oldVal * iters));
+    } else {
+      if (!itersVal)
+        itersVal =
+            rewriter.create<arith::ConstantIntOp>(loc, iters, step.getType());
+      scaledStep.push_back(rewriter.create<arith::IndexCastOp>(
+          loc, rewriter.getIndexType(),
+          rewriter.create<arith::MulIOp>(loc, step.getType(), step, itersVal)));
+    }
+  }
+
+  SmallVector<Value> res;
+  for (int64_t i = 0; i < scaledStep.size(); ++i)
+    res.push_back(rewriter.create<arith::AddIOp>(
+        loc, buf.indices[i].getType(), buf.indices[i], scaledStep[i]));
+  return res;
+}
+
+void prefetch(Location loc, const MemBuffer &buf, int64_t m, int64_t n,
+              ArrayRef<Value> prefetchIndices, int64_t hint,
+              PatternRewriter &rewriter) {
+  SmallVector<Value> indices =
+      shiftIndices(loc, prefetchIndices, buf.transposed, m, n, rewriter);
+  rewriter.create<memref::PrefetchOp>(loc, buf.memRef, indices, false, hint,
+                                      true);
+}
+
+LogicalResult convertCandidate(FmaDotOpCandidate &candidate,
+                               PatternRewriter &rewriter) {
+  cpu::DotOp op = candidate.op;
+  Location loc = op.getLoc();
+  VectorType lhsTy = cast<VectorType>(op.getA().getType());
+  VectorType rhsTy = cast<VectorType>(op.getB().getType());
+  VectorType accTy = cast<VectorType>(op.getC().getType());
+  VectorType resTy = cast<VectorType>(op.getResult().getType());
+  VectorType rhsVecTy =
+      VectorType::get(candidate.accVecSize, candidate.rhsElemTy);
+  VectorType accVecTy =
+      VectorType::get(candidate.accVecSize, candidate.accElemTy);
+
+  Operation *allocaPoint = op;
+  while (!isa<triton::FuncOp>(allocaPoint->getParentOp()))
+    allocaPoint = allocaPoint->getParentOp();
+
+  // Cast input data if required and prepare input buffer. It might be temporary
+  // buffers with stored vectors or the original input memory.
+  MemBuffer lhsBuf = candidate.lhsBuf;
+  if (lhsBuf.empty()) {
+    Value lhs = maybeCast(loc, op.getA(), candidate.lhsElemTy, rewriter);
+    lhsBuf = storeToTmpBuffer(loc, lhs, allocaPoint, rewriter);
+  }
+
+  MemBuffer rhsBuf = candidate.rhsBuf;
+  if (rhsBuf.empty()) {
+    Value rhs = maybeCast(loc, op.getB(), candidate.rhsElemTy, rewriter);
+    rhsBuf = storeToTmpBuffer(loc, rhs, allocaPoint, rewriter);
+  }
+
+  Value acc = maybeCast(loc, op.getC(), candidate.accElemTy, rewriter);
+  Value accToStore = acc;
+  scf::ForOp forOp;
+  if (candidate.keepAccOnRegs) {
+    forOp = cast<scf::ForOp>(op->getParentOp());
+    accToStore = getInitAccValue(acc);
+  }
+
+  SmallVector<Value> accVecs;
+  SmallVector<Value> accInitVecs;
+  if (candidate.keepAccOnRegs) {
+    // Initial tile values are loaded before the loop and then directly
+    // used within the loop. Later, new iter values will be added to
+    // add loop carried-dependencies for accumulator tiles and accInitTiles
+    // will be used as initializers for them.
+    OpBuilder::InsertionGuard g(rewriter);
+    rewriter.setInsertionPoint(forOp);
+    LDBG("Loading accumulator to tiles before the loop.");
+    accInitVecs = extractRows(loc, accToStore, rewriter);
+    accVecs = accInitVecs;
+  } else {
+    accVecs = extractRows(loc, acc, rewriter);
+  }
+
+  // Compute indices to be used by prefetch.
+  int64_t lhsPrefetchIters =
+      std::max(int64_t(128) / lhsTy.getNumElements(), int64_t(1));
+  auto lhsPrefetchIndices =
+      computePrefetchIndices(loc, candidate.lhsBuf, lhsPrefetchIters, rewriter);
+  int64_t rhsPrefetchIters =
+      std::max(int64_t(128) / rhsTy.getNumElements(), int64_t(1));
+  auto rhsPrefetchIndices =
+      computePrefetchIndices(loc, candidate.rhsBuf, rhsPrefetchIters, rewriter);
+  Value nextRhsVec = loadRow(loc, rhsVecTy, rhsBuf, 0, rewriter);
+  for (int64_t k = 0; k < lhsTy.getDimSize(1); ++k) {
+    Value rhsVec = nextRhsVec;
+
+    // Load next vector in advance to hide load latency.
+    if (k != lhsTy.getDimSize(1) - 1)
+      nextRhsVec = loadRow(loc, rhsVecTy, rhsBuf, k + 1, rewriter);
+
+    // Prefetch RHS to L2 cache.
+    if (!rhsPrefetchIndices.empty())
+      prefetch(loc, candidate.rhsBuf, k, 0, rhsPrefetchIndices, 3, rewriter);
+
+    Value nextLhsBroadcasted =
+        broadcastElem(loc, accVecTy, lhsBuf, 0, k, rewriter);
+    for (int64_t m = 0; m < candidate.accRows; ++m) {
+      Value lhsBroadcasted = nextLhsBroadcasted;
+
+      // Load next value in advance to hide load latency.
+      if (m != candidate.accRows - 1)
+        nextLhsBroadcasted =
+            broadcastElem(loc, accVecTy, lhsBuf, m + 1, k, rewriter);
+
+      // Prefetch LHS to L0 cache.
+      if (!lhsPrefetchIndices.empty() &&
+          ((k * candidate.accRows + m) % 16 == 0))
+        prefetch(loc, candidate.lhsBuf, m, k, lhsPrefetchIndices, 1, rewriter);
+
+      accVecs[m] = rewriter.create<vector::FMAOp>(loc, rhsVec, lhsBroadcasted,
+                                                  accVecs[m]);
+    }
+  }
+
+  if (candidate.keepAccOnRegs) {
+    // In this case we have the whole accumulator/result on tiles. Loop
+    // carried dependencies are not in place yet and should be added.
+    // After the loop, resulting tiles should either be stored to the
+    // output buffer, or moved to a vector though a temporary buffer.
+
+    // We don't need the original accumulator and contraction op anymore.
+    // Directly yield orig accumulator value, so it would be later removed
+    // as unused. The original contraction can be removed right away.
+    int64_t origResIdx = op.getResult().getUses().begin()->getOperandNumber();
+    rewriter.replaceOp(op, op.getC());
+
+    // Now, replace the loop with a new one to add loop carried dependency for
+    // accumulator tiles.
+    LDBG("Rewrite loop to introduce loop carried dependencies for accumulator "
+         "tiles.");
+    SmallVector<Value> newInitOperands;
+    SmallVector<Value> newYieldedValues;
+    for (int64_t m = 0; m < candidate.accRows; ++m) {
+      LDBG("Initial value\n  " << accInitVecs[m] << "\nis combined with\n  "
+                               << accVecs[m]);
+      newInitOperands.push_back(accInitVecs[m]);
+      newYieldedValues.push_back(accVecs[m]);
+    }
+    auto newForOp = cast<scf::ForOp>(*forOp.replaceWithAdditionalYields(
+        rewriter, newInitOperands, true,
+        [&newYieldedValues](OpBuilder &b, Location loc,
+                            ArrayRef<BlockArgument> newBBArgs) {
+          return newYieldedValues;
+        }));
+
+    // The resulting tiles are now in the new loop results.
+    auto resVecs = newForOp.getResults().take_back(newYieldedValues.size());
+    for (int64_t m = 0; m < candidate.accRows; ++m)
+      accVecs[m] = resVecs[m];
+
+    OpBuilder::InsertionGuard g(rewriter);
+    rewriter.setInsertionPointAfter(newForOp);
+    // Collect all results into a single vector.
+    LDBG("Merging resulting rows to replace loop result.");
+    VectorType resTy = accTy.cloneWith(std::nullopt, candidate.accElemTy);
+    Value newVal = mergeRows(loc, resTy, accVecs, rewriter);
+    // We might need to cast back to the original type.
+    newVal = maybeCast(loc, newVal, accTy.getElementType(), rewriter);
+    rewriter.replaceAllUsesWith(newForOp.getResult(origResIdx), newVal);
+  } else {
+    // The result is in the buffer. We should load it and replace the original
+    // constraction result.
+    LDBG("Merging resulting rows to replace orig op result.");
+    VectorType resTy = accTy.cloneWith(std::nullopt, candidate.accElemTy);
+    Value newVal = mergeRows(loc, resTy, accVecs, rewriter);
+    // We might need to cast back to the original type.
+    newVal = maybeCast(loc, newVal, accTy.getElementType(), rewriter);
+    rewriter.replaceOp(op, newVal);
+  }
+
+  return success();
+}
+
+struct ConvertDotToFMA
+    : public triton::cpu::impl::ConvertDotToFMABase<ConvertDotToFMA> {
+  ConvertDotToFMA() = default;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ModuleOp mod = getOperation();
+
+    SmallVector<FmaDotOpCandidate, 1> candidates;
+    mod->walk([this, &candidates](cpu::DotOp op) {
+      FmaDotOpCandidate candidate;
+      if (isFmaCandidate(op, candidate)) {
+        LLVM_DEBUG({
+          LDBG("Found FMA candidate");
+          LDBG("  Op: " << candidate.op);
+          LDBG("  LhsElemTy: " << candidate.lhsElemTy);
+          LDBG("  RhsElemTy: " << candidate.rhsElemTy);
+          LDBG("  AccElemTy: " << candidate.accElemTy);
+          LDBG("  AccVecSize: " << candidate.accVecSize);
+          LDBG("  AccRows: " << candidate.accRows);
+          LDBG("  KeepAccOnRegs: " << candidate.keepAccOnRegs);
+          if (!candidate.lhsBuf.empty()) {
+            LDBG("  LhsBuf: " << candidate.lhsBuf.memRef);
+            LDBG("  Transposed: " << candidate.lhsBuf.transposed);
+          }
+          if (!candidate.rhsBuf.empty()) {
+            LDBG("  RhsBuf: " << candidate.rhsBuf.memRef);
+            LDBG("  Transposed: " << candidate.rhsBuf.transposed);
+          }
+        });
+        candidates.push_back(candidate);
+      }
+      return WalkResult::advance();
+    });
+
+    for (auto &candidate : candidates) {
+      LDBG("Starting conversion of candidate: " << candidate.op);
+      PatternRewriter rewriter(context);
+      rewriter.setInsertionPoint(candidate.op);
+      if (succeeded(convertCandidate(candidate, rewriter))) {
+        LDBG("Conversion succeeded!");
+      } else {
+        LDBG("Conversion failed!");
+      }
+    }
+  }
+};
+
+} // namespace
+
+namespace mlir {
+namespace triton {
+namespace cpu {
+
+std::unique_ptr<OperationPass<ModuleOp>> createConvertDotToFMA() {
+  return std::make_unique<ConvertDotToFMA>();
+}
+
+} // namespace cpu
+} // namespace triton
+} // namespace mlir

--- a/third_party/cpu/triton_cpu.cc
+++ b/third_party/cpu/triton_cpu.cc
@@ -91,6 +91,9 @@ void init_triton_cpu_passes_ttcpuir(py::module &&m) {
     pm.addPass(mlir::triton::cpu::createConvertDotToAMX(
         convertInt8, convertFp16, convertBf16));
   });
+  m.def("add_convert_dot_to_fma", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::triton::cpu::createConvertDotToFMA());
+  });
   m.def("add_convert_dot_generic", [](mlir::PassManager &pm) {
     pm.addPass(mlir::triton::cpu::createConvertDotGeneric());
   });


### PR DESCRIPTION
This PR adds lowering for DotOp through vector FMA and broadcast operations. The lowering is quite simple and doesn't work well for all block sizes, so a block size fitting register file is preferred. It provides much better performance compared to the contraction operation lowering.

The patch also adds some fixes to the matmul tutorial to provide more measuring options. First, it utilizes block pointers to improve analysis and simplify code generation. Second, it introduces a padding feature to improve caching by avoiding power of two strides.

Here are the performance results for the current lowering through vector contraction op:

```
matmul-performance-torch.float32 (CACHE_PADDING=False PREPACKED=False PAD_B_ONLY=True GROUP_SIZE_M=8):
         M       N       K  TritonCPU 1   TritonCPU  TorchCPU (native)
0    256.0   256.0   256.0     7.008444  208.756250         266.680477
1    384.0   384.0   384.0     7.037777  269.310043        1143.445958
2    512.0   512.0   512.0     7.038876  277.117546         609.675895
3    640.0   640.0   640.0     7.070787  286.993461        1855.767899
4    768.0   768.0   768.0     7.009782  290.195857        1537.823776
5    896.0   896.0   896.0     7.028581  293.512130        2740.863129
6   1024.0  1024.0  1024.0     6.481916  275.566048        2517.403857
7   1152.0  1152.0  1152.0     7.030157  293.743336        3999.967758
8   1280.0  1280.0  1280.0     6.964409  292.484953        3277.685933
9   1408.0  1408.0  1408.0     7.021666  295.316153        3505.679013
10  1536.0  1536.0  1536.0     6.502502  277.653762        4338.997662
11  1664.0  1664.0  1664.0     6.970083  294.638160        4488.973249
12  1792.0  1792.0  1792.0     6.760696  287.476124        4696.579705
13  1920.0  1920.0  1920.0     6.970649  293.270995        4989.509636
14  2048.0  2048.0  2048.0     6.453451  275.972042        5102.363950
15  2176.0  2176.0  2176.0     6.892996  292.064724        5242.598378
16  2304.0  2304.0  2304.0     6.516752  278.238428        5339.505081
17  2432.0  2432.0  2432.0     6.830341  289.582060        5389.065772
18  2560.0  2560.0  2560.0     6.374564  272.799380        5427.722433
```

Here are results with the FMA pass used:

```
matmul-performance-torch.float32 (CACHE_PADDING=False PREPACKED=False PAD_B_ONLY=True GROUP_SIZE_M=8):
         M       N       K  TritonCPU 1    TritonCPU  TorchCPU (native)
0    256.0   256.0   256.0    84.234192   622.682483         272.395227
1    384.0   384.0   384.0    85.787907  1039.313328        1138.971759
2    512.0   512.0   512.0    89.306110  1495.700062         611.135505
3    640.0   640.0   640.0    87.683793  1757.461846        1860.038651
4    768.0   768.0   768.0    86.769409  1974.581834        1527.227452
5    896.0   896.0   896.0    87.748022  2170.535765        2760.432819
6   1024.0  1024.0  1024.0    53.942684  1996.266476        2493.590160
7   1152.0  1152.0  1152.0    87.103365  2573.812399        4030.042541
8   1280.0  1280.0  1280.0    78.312309  2557.204496        3291.480726
9   1408.0  1408.0  1408.0    86.944922  2821.794459        3539.799941
10  1536.0  1536.0  1536.0    54.837263  2019.201287        4284.861570
11  1664.0  1664.0  1664.0    85.833454  2835.290641        4504.741425
12  1792.0  1792.0  1792.0    64.847520  2287.982110        4701.276260
13  1920.0  1920.0  1920.0    85.060913  2816.037518        5005.366543
14  2048.0  2048.0  2048.0    54.181541  1970.398142        5108.159571
15  2176.0  2176.0  2176.0    81.200119  2779.553123        5230.722931
16  2304.0  2304.0  2304.0    55.733256  2139.537010        5310.082279
17  2432.0  2432.0  2432.0    76.065209  2727.850897        5401.544195
18  2560.0  2560.0  2560.0    52.850840  1965.135308        5448.324440
```

These are FMA results with padding enabled. Here we can avoid performance drops on some sizes:

```
matmul-performance-torch.float32 (CACHE_PADDING=True PREPACKED=False PAD_B_ONLY=True GROUP_SIZE_M=8):
         M       N       K  TritonCPU 1    TritonCPU  TorchCPU (native)
0    256.0   256.0   256.0    72.949955   558.867600         268.741773
1    384.0   384.0   384.0    77.125823   929.806476        1137.175635
2    512.0   512.0   512.0    83.999143  1401.244439         614.273587
3    640.0   640.0   640.0    84.664957  1524.495666        1864.343529
4    768.0   768.0   768.0    84.604859  1801.298949        1553.238187
5    896.0   896.0   896.0    84.444551  1878.818698        2723.251686
6   1024.0  1024.0  1024.0    85.769258  2103.116325        2480.075410
7   1152.0  1152.0  1152.0    86.848168  2320.548872        4011.834207
8   1280.0  1280.0  1280.0    86.634951  2402.316923        3278.833805
9   1408.0  1408.0  1408.0    86.930059  2469.336265        3523.858020
10  1536.0  1536.0  1536.0    87.198629  2506.812047        4335.929244
11  1664.0  1664.0  1664.0    87.281008  2527.454260        4488.361247
12  1792.0  1792.0  1792.0    86.853180  2601.301105        4718.554866
13  1920.0  1920.0  1920.0    86.117222  2621.744387        4981.533116
14  2048.0  2048.0  2048.0    82.660039  2676.202552        5038.594435
15  2176.0  2176.0  2176.0    84.022500  2645.374144        5233.303856
16  2304.0  2304.0  2304.0    82.671846  2719.971484        5307.135532
17  2432.0  2432.0  2432.0    82.197134  2682.406711        5399.380956
18  2560.0  2560.0  2560.0    81.888011  2718.030500        5184.562840
```

If we are interested in performance when we can ignore padding costs (e.g. process weights only once for inference), we can use PREPACKED option to ignore padding costs:

```
matmul-performance-torch.float32 (CACHE_PADDING=True PREPACKED=True PAD_B_ONLY=True GROUP_SIZE_M=8):
         M       N       K  TritonCPU 1    TritonCPU  TorchCPU (native)
0    256.0   256.0   256.0    79.610036   653.770435         267.452286
1    384.0   384.0   384.0    85.079409  1005.631517        1134.799678
2    512.0   512.0   512.0    87.532636  1527.301199         619.642050
3    640.0   640.0   640.0    86.998497  1747.420024        1871.767418
4    768.0   768.0   768.0    85.796267  1952.906215        1509.585868
5    896.0   896.0   896.0    87.414424  2157.243564        2737.679073
6   1024.0  1024.0  1024.0    87.174831  2480.578106        2460.009481
7   1152.0  1152.0  1152.0    88.315111  2617.867193        4003.993667
8   1280.0  1280.0  1280.0    87.280672  2724.798712        3259.025916
9   1408.0  1408.0  1408.0    88.526457  2850.948546        3531.726690
10  1536.0  1536.0  1536.0    87.764679  2749.347624        4315.063324
11  1664.0  1664.0  1664.0    88.147403  2856.626217        4476.378033
12  1792.0  1792.0  1792.0    87.558864  2915.255715        4344.708642
13  1920.0  1920.0  1920.0    86.867476  2837.949546        4756.190472
14  2048.0  2048.0  2048.0    85.014205  2915.286143        5110.188233
15  2176.0  2176.0  2176.0    84.818367  2936.145875        5211.733589
16  2304.0  2304.0  2304.0    83.467489  2972.995680        5315.340594
17  2432.0  2432.0  2432.0    82.483407  2943.624111        5383.422364
18  2560.0  2560.0  2560.0    82.622524  2940.045080        5115.043590
```

To evaluate possibilities to improve results through kernel modifications, I added a new blocked matmul tutorial. There we optionally change the layout of input data for better data locality. It supports multiple options for pre-processing both LHS and RHS and allows to compare their performance. Here are the results when we use a blocked layout for RHS (prepack in column name means layout change price was ignored).

Single thread:
```
matmul-performance-bf16 (BLOCK_SIZE_M=8, BLOCK_SIZE_N=32, BLOCK_SIZE_K=8, GROUP_SIZE_M=8):
         M       N       K  triton-cpu-bb-tb-st-float32  triton-cpu-bb-tb-prepack-st-float32  triton-cpu-st-float32  torch-cpu-native-st-float32
0    256.0   256.0   256.0                    81.696607                            84.464895              70.210052                    79.359020
1    384.0   384.0   384.0                   108.524852                           111.976063              86.270084                   113.624339
2    512.0   512.0   512.0                   123.694884                           128.112250              91.915599                   129.039819
3    640.0   640.0   640.0                   128.713663                           132.301042              93.096064                   135.867300
4    768.0   768.0   768.0                   127.903844                           131.282430              90.376665                   140.786211
5    896.0   896.0   896.0                   130.744368                           132.967943              91.334762                   141.910865
6   1024.0  1024.0  1024.0                   131.381638                           133.511512              54.326675                   142.349877
7   1152.0  1152.0  1152.0                   132.352811                           134.581067              90.521744                   145.063204
8   1280.0  1280.0  1280.0                   133.143446                           135.645516              83.127549                   145.091582
9   1408.0  1408.0  1408.0                   133.636818                           136.120497              88.607280                   146.154894
10  1536.0  1536.0  1536.0                   134.109253                           136.471275              54.921499                   147.217501
11  1664.0  1664.0  1664.0                   134.017928                           136.431090              86.824743                   145.044889
12  1792.0  1792.0  1792.0                   134.419619                           136.573808              63.146663                   147.900299
13  1920.0  1920.0  1920.0                   134.614521                           136.579132              85.544668                   148.478316
14  2048.0  2048.0  2048.0                   133.922156                           135.539775              54.563150                   147.964276
15  2176.0  2176.0  2176.0                   134.651667                           136.622749              79.855244                   148.696436
16  2304.0  2304.0  2304.0                   134.211121                           136.606094              56.165119                   149.060219
17  2432.0  2432.0  2432.0                   134.335383                           136.488440              75.453513                   148.931097
18  2560.0  2560.0  2560.0                   133.849690                           135.728972              52.652949                   149.094247
```

Multiple threads:
```
matmul-performance-bf16 (BLOCK_SIZE_M=8, BLOCK_SIZE_N=32, BLOCK_SIZE_K=8, GROUP_SIZE_M=8):
         M       N       K  triton-cpu-bb-tb-float32  triton-cpu-bb-tb-prepack-float32  triton-cpu-float32  torch-cpu-native-float32
0    256.0   256.0   256.0                561.478249                        736.707959          589.087239                257.708635
1    384.0   384.0   384.0               1050.244640                       1267.870611         1056.065136               1109.414015
2    512.0   512.0   512.0               1593.944323                       1813.041868         1532.087005                612.623454
3    640.0   640.0   640.0               1906.903928                       2319.499051         1798.642694               1878.252881
4    768.0   768.0   768.0               2255.633723                       2416.360401         1978.372343               1551.976881
5    896.0   896.0   896.0               2334.537906                       2890.740335         2160.359976               2764.163797
6   1024.0  1024.0  1024.0               2666.057098                       3040.612394         2062.177442               2424.649109
7   1152.0  1152.0  1152.0               2945.359195                       3501.236723         2347.677064               3988.522005
8   1280.0  1280.0  1280.0               3256.701333                       4012.643627         2438.030721               3165.916235
9   1408.0  1408.0  1408.0               3499.052301                       4361.914879         2534.732206               3499.218586
10  1536.0  1536.0  1536.0               3320.661094                       3933.713772         2054.186745               4327.383445
11  1664.0  1664.0  1664.0               3834.574392                       4681.549549         2570.068571               4456.700709
12  1792.0  1792.0  1792.0               3833.164000                       4765.670018         2267.101573               4706.207026
13  1920.0  1920.0  1920.0               4006.826231                       4814.920158         2584.381985               4988.130529
14  2048.0  2048.0  2048.0               4056.631820                       4909.244017         2042.732060               4909.326631
15  2176.0  2176.0  2176.0               4284.935721                       5140.160445         2602.996309               5202.643604
16  2304.0  2304.0  2304.0               4344.113066                       5101.554051         2119.188147               5337.437308
17  2432.0  2432.0  2432.0               4474.744440                       5312.884287         2597.644915               5384.322708
18  2560.0  2560.0  2560.0               4584.410834                       5401.233470         2025.822987               5311.491207
```

All results are measured on 48-core Intel Platinum 8468V. For better stability, the frequency was fixed, hyperthreading disabled, Intel OpenMP was used with KMP_AFFINITY to pin threads.