### PR TITLE
AMX lowering improvements

### DIFF
--- a/python/tutorials/03-matrix-multiplication-cpu.py
+++ b/python/tutorials/03-matrix-multiplication-cpu.py
@@ -156,7 +156,7 @@ import triton.language as tl
 import os
 
 DTYPE = getattr(torch, (os.getenv("DTYPE", "float32")))
-# Chosse block size depending on dtype. We have more register
+# Choose block size depending on dtype. We have more register
 # capacity for bfloat16/float16 compared to float32.
 BLOCK_SIZE_M = 8 if DTYPE == torch.float32 else 32
 BLOCK_SIZE_N = 32
@@ -306,7 +306,7 @@ def matmul_preprocess_input(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor, n
         K % BLOCK_SIZE_K == 0), "Masking currently not supported, Matrix dimensions must be multiples of block size"
     if c is None:
         # Allocates output.
-        c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+        c = torch.empty((M, N), device=a.device, dtype=torch.float32)
     else:
         assert c.shape == (M, N), "Incompatible dimensions"
 

--- a/third_party/cpu/include/TritonCPUTransforms/OptCommon.h
+++ b/third_party/cpu/include/TritonCPUTransforms/OptCommon.h
@@ -125,12 +125,14 @@ inline Value shapeCast(Location loc, Value in,
 } // namespace mlir
 
 #define int_cst(ty, val) intCst(loc, ty, val, rewriter)
+#define index_cst(val) rewriter.create<arith::ConstantIndexOp>(loc, val)
 #define cst_like(src, val) cstLike(loc, src, val, rewriter)
 
 #define op_addi(lhs, rhs) rewriter.create<arith::AddIOp>(loc, lhs, rhs)
 #define op_addf(lhs, rhs) rewriter.create<arith::AddFOp>(loc, lhs, rhs)
 #define op_subi(lhs, rhs) rewriter.create<arith::SubIOp>(loc, lhs, rhs)
 #define op_subf(lhs, rhs) rewriter.create<arith::SubFOp>(loc, lhs, rhs)
+#define op_muli(lhs, rhs) rewriter.create<arith::MulIOp>(loc, lhs, rhs)
 #define op_mulf(lhs, rhs) rewriter.create<arith::MulFOp>(loc, lhs, rhs)
 #define op_bitcast(ty, val) rewriter.create<arith::BitcastOp>(loc, ty, val)
 #define op_lshr(lhs, rhs) rewriter.create<arith::ShRUIOp>(loc, lhs, rhs)
@@ -146,6 +148,15 @@ inline Value shapeCast(Location loc, Value in,
   rewriter.create<arith::SelectOp>(loc, cond, val, other)
 #define op_sitofp(ty, val) rewriter.create<arith::SIToFPOp>(loc, ty, val)
 #define op_fptosi(ty, val) rewriter.create<arith::FPToSIOp>(loc, ty, val)
+#define op_read(ty, memRef, indices)                                           \
+  rewriter.create<vector::TransferReadOp>(loc, ty, memRef, indices)
+#define op_write(val, memRef, indices)                                         \
+  rewriter.create<vector::TransferWriteOp>(loc, val, memRef, indices)
+#define op_interleave(lhs, rhs)                                                \
+  rewriter.create<vector::InterleaveOp>(loc, lhs, rhs)
+#define op_extract(vec, idx) rewriter.create<vector::ExtractOp>(loc, vec, idx)
+#define op_store(val, mem, idx)                                                \
+  rewriter.create<vector::StoreOp>(loc, val, mem, idx)
 
 #define op_icmp_eq(lhs, rhs)                                                   \
   rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, lhs, rhs)

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToAMX.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToAMX.cpp
@@ -1,4 +1,4 @@
-#include "cpu/include/TritonCPUTransforms/OptCommon.h"
+#include "ConvertDotCommon.h"
 
 #include "cpu/include/TritonCPUTransforms/Passes.h"
 
@@ -24,23 +24,11 @@ namespace cpu {
 } // namespace triton
 } // namespace mlir
 
-#define DEBUG_TYPE "triton-cpu-dot-to-amx"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
-
 using namespace mlir;
 using namespace mlir::triton;
 using namespace mlir::triton::cpu;
 
 namespace {
-
-// This struct describes buffers used to load/store AMX tiles.
-struct AmxBuffer {
-  Value memRef;
-  SmallVector<Value, 2> indices;
-
-  bool empty() const { return !memRef; }
-};
 
 // This structure is used to hold candidates for conversion to AMX
 // Mul[F|I]Op operations.
@@ -75,7 +63,7 @@ struct AmxDotOpCandidate {
   // If resulting tiles are not required to be trasfered to vectors and can be
   // directly stored to the output memory instead, then this field holds a
   // buffer to use.
-  AmxBuffer outBuf;
+  MemBuffer outBuf;
   // If output buffer is used then keep the original vector store here.
   Operation *origStore = nullptr;
 };
@@ -182,50 +170,6 @@ bool checkInputShapes(VectorType lhsTy, VectorType resTy) {
   return true;
 }
 
-// Check if accumulator value is updated in a loop and has no other
-// usages than a dot op, that updates it. Tile loads/stores and casts
-// for such accumulators can be done outside of the loop.
-bool isLoopCarriedAcc(Value acc) {
-  LDBG("Check if accumulator can be held in tiles: " << acc);
-  if (!acc.hasOneUse()) {
-    LDBG("  No. Has multiple uses.");
-    for (auto op : acc.getUsers())
-      LDBG("    " << *op);
-    return false;
-  }
-
-  auto blockArg = dyn_cast<BlockArgument>(acc);
-  if (!blockArg) {
-    LDBG("  No. Not a block argument.");
-    return false;
-  }
-
-  auto forOp = dyn_cast<scf::ForOp>(blockArg.getOwner()->getParentOp());
-  if (!forOp) {
-    LDBG("  No. Not in a for-loop.");
-    return false;
-  }
-
-  blockArg.getArgNumber();
-
-  Value updAcc = acc.getUsers().begin()->getResult(0);
-  if (!updAcc.hasOneUse()) {
-    LDBG("  No. Has multiple uses.");
-    return false;
-  }
-
-  auto &updAccUse = *updAcc.getUses().begin();
-  if (!isa<scf::YieldOp>(updAccUse.getOwner()) ||
-      updAccUse.getOperandNumber() !=
-          (blockArg.getArgNumber() - forOp.getNumInductionVars())) {
-    LDBG("  No. Loop carried dependency not detected.");
-    return false;
-  }
-
-  LDBG("  Yes.");
-  return true;
-}
-
 // Return a value that holds the resulting loop carried accumulator value.
 // It's one of ForOp's results.
 Value getResValueForLoopCarriedAcc(cpu::DotOp op) {
@@ -239,11 +183,11 @@ Value getResValueForLoopCarriedAcc(cpu::DotOp op) {
 // by input shapes and types. Block sizes are chosen to minimize number of
 // tile loads/stores including tile register spills.
 void setupBlockAndTileSizes(ArrayRef<int64_t> lhsShape,
-                            ArrayRef<int64_t> rhsShape,
+                            ArrayRef<int64_t> resShape,
                             AmxDotOpCandidate &candidate) {
-  int64_t m = lhsShape[0];
-  int64_t n = rhsShape[1];
-  int64_t k = rhsShape[0];
+  int64_t m = resShape[0];
+  int64_t n = resShape[1];
+  int64_t k = lhsShape[1];
   int64_t tileM = std::min(m, (int64_t)16);
   int64_t tileN = std::min(n, (int64_t)16);
   int64_t tileK = std::min(
@@ -288,7 +232,7 @@ void findOutputBuffer(Value val, AmxDotOpCandidate &candidate) {
   if (val.hasOneUse()) {
     auto store = dyn_cast<vector::TransferWriteOp>(*val.user_begin());
     if (store && !hasMaskOrBoundsCheck(store))
-      candidate.outBuf = AmxBuffer{store.getSource(), store.getIndices()};
+      candidate.outBuf = MemBuffer{store.getSource(), store.getIndices()};
     candidate.origStore = store;
   }
 }
@@ -319,15 +263,16 @@ bool isAmxCandidate(cpu::DotOp op, bool supportInt8, bool supportFp16,
     return false;
 
   candidate.op = op;
-  setupBlockAndTileSizes(lhsTy.getShape(), rhsTy.getShape(), candidate);
+  setupBlockAndTileSizes(lhsTy.getShape(), resTy.getShape(), candidate);
   candidate.keepAccOnTiles = isLoopCarriedAcc(op.getC());
 
   // Can't keep acc in a tile the whole loop right now:
   // https://github.com/llvm/llvm-project/issues/109481
   if (candidate.keepAccOnTiles) {
-    // We might not have enough tiles to hold accumulator. In this case
-    // keep it in a bufffer.
-    if (candidate.tilesInBlockM * candidate.tilesInBlockN > 1) {
+    // We might not have enough tiles to hold the whole accumulator. If we
+    // have more than one block, keep it in a bufffer.
+    if (candidate.tilesInBlockM * candidate.tileM < resTy.getDimSize(0) ||
+        candidate.tilesInBlockN * candidate.tileN < resTy.getDimSize(1)) {
       LDBG("Accumulator is too big to keep on tiles. Keep it bufferized "
            "insterad.");
       candidate.keepAccOnTiles = false;
@@ -335,14 +280,6 @@ bool isAmxCandidate(cpu::DotOp op, bool supportInt8, bool supportFp16,
     } else {
       findOutputBuffer(getResValueForLoopCarriedAcc(op), candidate);
     }
-
-    // TODO: fix LLVM bug and remove this code.
-    LDBG("Avoid accumulator on tiles due to LLVM bug: "
-         "https://github.com/llvm/llvm-project/issues/109481.");
-    LDBG("Keep accumulator bufferized instead.");
-    candidate.keepAccOnTiles = false;
-    candidate.keepAccInBuf = true;
-    candidate.outBuf = AmxBuffer{};
   } else {
     findOutputBuffer(op.getResult(), candidate);
   }
@@ -350,52 +287,11 @@ bool isAmxCandidate(cpu::DotOp op, bool supportInt8, bool supportFp16,
   return true;
 }
 
-// Cast vector to a specified element type using ext or trunc
-// operations. Return the original value if it already matches
-// the required element type.
-Value maybeCast(Location loc, Value val, Type dstElemTy,
-                PatternRewriter &rewriter) {
-  VectorType srcTy = cast<VectorType>(val.getType());
-  if (srcTy.getElementType() == dstElemTy)
-    return val;
-
-  VectorType dstTy = srcTy.cloneWith(std::nullopt, dstElemTy);
-  if (srcTy.getElementType().isInteger()) {
-    if (srcTy.getElementTypeBitWidth() < dstTy.getElementTypeBitWidth())
-      return rewriter.create<arith::ExtSIOp>(loc, dstTy, val);
-    return rewriter.create<arith::TruncIOp>(loc, dstTy, val);
-  }
-
-  if (srcTy.getElementTypeBitWidth() < dstTy.getElementTypeBitWidth())
-    return rewriter.create<arith::ExtFOp>(loc, dstTy, val);
-  return rewriter.create<arith::TruncFOp>(loc, dstTy, val);
-}
-
-// Get initial value for a loop-carried accumulator.
-Value getInitAccValue(Value val) {
-  auto blockArg = cast<BlockArgument>(val);
-  auto forOp = cast<scf::ForOp>(blockArg.getOwner()->getParentOp());
-  int initValIdx = blockArg.getArgNumber() - forOp.getNumInductionVars();
-  return forOp.getInitArgs()[initValIdx];
-}
-
 template <typename T> T getSwizzledRhsTileType(T origTileType) {
   int64_t rowsPerGroup = 32 / origTileType.getElementTypeBitWidth();
   SmallVector<int64_t> shape({origTileType.getDimSize(0) / rowsPerGroup,
                               origTileType.getDimSize(1) * rowsPerGroup});
   return origTileType.cloneWith(shape, origTileType.getElementType());
-}
-
-AmxBuffer allocateTmpBuffer(Location loc, VectorType vecTy,
-                            Operation *allocaPoint, PatternRewriter &rewriter) {
-  OpBuilder::InsertionGuard g(rewriter);
-  rewriter.setInsertionPoint(allocaPoint);
-  auto memRefTy = MemRefType::get(vecTy.getShape(), vecTy.getElementType());
-  Value memRef = rewriter.create<memref::AllocaOp>(
-      loc, memRefTy, rewriter.getIntegerAttr(rewriter.getI64Type(), 64));
-  Value zeroIdx = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-  SmallVector<Value, 2> indices(2, zeroIdx);
-  return {memRef, indices};
 }
 
 // In AMX, element values shoud be packed to 32-bit groups that would be
@@ -418,25 +314,78 @@ void interleaveAndStore(Location loc, Value val, Value buf,
   int64_t rowsPerGroup = 32 / valTy.getElementTypeBitWidth();
   assert(rowsPerGroup == 2 || rowsPerGroup == 4);
   assert(valTy.getDimSize(0) % rowsPerGroup == 0);
-  Value zeroIdx = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value zeroIdx = index_cst(0);
   for (int64_t i = 0; i < valTy.getDimSize(0); i += rowsPerGroup) {
     Value row1, row2;
     if (rowsPerGroup == 2) {
-      row1 = rewriter.create<vector::ExtractOp>(loc, val, i);
-      row2 = rewriter.create<vector::ExtractOp>(loc, val, i + 1);
+      row1 = op_extract(val, i);
+      row2 = op_extract(val, i + 1);
     } else {
-      row1 = rewriter.create<vector::InterleaveOp>(
-          loc, rewriter.create<vector::ExtractOp>(loc, val, i),
-          rewriter.create<vector::ExtractOp>(loc, val, i + 2));
-      row2 = rewriter.create<vector::InterleaveOp>(
-          loc, rewriter.create<vector::ExtractOp>(loc, val, i + 1),
-          rewriter.create<vector::ExtractOp>(loc, val, i + 3));
+      row1 = op_interleave(op_extract(val, i), op_extract(val, i + 2));
+      row2 = op_interleave(op_extract(val, i + 1), op_extract(val, i + 3));
     }
-    Value shuffled = rewriter.create<vector::InterleaveOp>(loc, row1, row2);
-    Value idx = rewriter.create<arith::ConstantIndexOp>(loc, i / rowsPerGroup);
-    rewriter.create<vector::StoreOp>(loc, shuffled, buf,
-                                     SmallVector<Value>({idx, zeroIdx}));
+    Value shuffled = op_interleave(row1, row2);
+    Value idx = index_cst(i / rowsPerGroup);
+    op_store(shuffled, buf, SmallVector<Value>({idx, zeroIdx}));
   }
+}
+
+Value loadWithPrefetch(Location loc, VectorType ty, Value memRef,
+                       ArrayRef<Value> indices, ArrayRef<Value> step,
+                       PatternRewriter &rewriter) {
+  Value res = op_read(ty, memRef, indices);
+  if (!step.empty()) {
+    SmallVector<Value> prefetchIndices;
+    for (int64_t i = 0; i < indices.size(); ++i) {
+      prefetchIndices.push_back(
+          op_addi(indices[i], rewriter.create<arith::IndexCastOp>(
+                                  loc, rewriter.getIndexType(), step[i])));
+    }
+    rewriter.create<memref::PrefetchOp>(loc, memRef, prefetchIndices, false, 1,
+                                        true);
+  }
+  return res;
+}
+
+// Copy tensor with packing using for-loop. See interleaveAndStore for more
+// details.
+void copyWithInterleave(Location loc, VectorType srcTy, const MemBuffer &src,
+                        const MemBuffer &dst, PatternRewriter &rewriter) {
+  int64_t rowsPerGroup = 32 / srcTy.getElementTypeBitWidth();
+  Value lower = index_cst(0);
+  Value upper = index_cst(srcTy.getDimSize(0) / rowsPerGroup);
+  Value one = index_cst(1);
+  Value rowsPerGroupVal = index_cst(rowsPerGroup);
+  VectorType srcVecTy =
+      VectorType::get({srcTy.getDimSize(1)}, srcTy.getElementType());
+  auto forOp = rewriter.create<scf::ForOp>(loc, lower, upper, one);
+  Value ivVal = forOp.getInductionVar();
+  rewriter.setInsertionPointToStart(forOp.getBody());
+  SmallVector<Value> srcIndices = src.indices;
+  int64_t mDimIdx = srcIndices.size() - 2;
+  Value scaledM = op_muli(ivVal, rowsPerGroupVal);
+  srcIndices[mDimIdx] = op_addi(srcIndices[mDimIdx], scaledM);
+  Value row1 = loadWithPrefetch(loc, srcVecTy, src.memRef, srcIndices, src.step,
+                                rewriter);
+  srcIndices[mDimIdx] = op_addi(srcIndices[mDimIdx], one);
+  Value row2 = loadWithPrefetch(loc, srcVecTy, src.memRef, srcIndices, src.step,
+                                rewriter);
+  if (rowsPerGroup == 4) {
+    srcIndices[mDimIdx] = op_addi(srcIndices[mDimIdx], one);
+    Value row3 = loadWithPrefetch(loc, srcVecTy, src.memRef, srcIndices,
+                                  src.step, rewriter);
+    srcIndices[mDimIdx] = op_addi(srcIndices[mDimIdx], one);
+    Value row4 = loadWithPrefetch(loc, srcVecTy, src.memRef, srcIndices,
+                                  src.step, rewriter);
+    row1 = op_interleave(row1, row3);
+    row2 = op_interleave(row2, row4);
+  }
+  Value shuffled = op_interleave(row1, row2);
+  SmallVector<Value> dstIndices = dst.indices;
+  dstIndices[dstIndices.size() - 2] =
+      op_addi(dstIndices[dstIndices.size() - 2], ivVal);
+  op_write(shuffled, dst.memRef, dstIndices);
+  rewriter.setInsertionPointAfter(forOp);
 }
 
 // Prepare temporary buffers to be used for tile loads. If the original
@@ -446,18 +395,25 @@ void interleaveAndStore(Location loc, Value val, Value buf,
 //
 // If interleave flag is set, then pre-pack RHS before store. See
 // interleaveAndStore for more details.
-AmxBuffer prepareTensorBuffer(Location loc, Value val, bool interleave,
+MemBuffer prepareTensorBuffer(Location loc, Value val, bool interleave,
                               bool skipForZeros, bool readOnly,
                               Operation *allocaPoint,
                               PatternRewriter &rewriter) {
   LDBG("Preparing buffer (interleave=" << interleave
                                        << ") for a vector: " << val);
-  auto valLoad = val.getDefiningOp<vector::TransferReadOp>();
-  if (valLoad && !interleave && readOnly && !hasMaskOrBoundsCheck(valLoad)) {
-    Value memRef = valLoad.getSource();
-    ValueRange indices = valLoad.getIndices();
-    LDBG("  Reusing the original memref for a buffer: " << memRef);
-    return {memRef, indices};
+  auto vecTy = cast<VectorType>(val.getType());
+  MemBuffer inputBuf = findInputBuffer(val);
+  if (!inputBuf.empty()) {
+    if (interleave) {
+      LDBG("  Copying from the original memref with interleave: "
+           << inputBuf.memRef);
+      auto tmpBuf = allocateTmpBuffer(loc, getSwizzledRhsTileType(vecTy),
+                                      allocaPoint, rewriter);
+      copyWithInterleave(loc, vecTy, inputBuf, tmpBuf, rewriter);
+      return tmpBuf;
+    }
+    LDBG("  Reusing the original memref for a buffer: " << inputBuf.memRef);
+    return inputBuf;
   }
 
   if (skipForZeros && isZeroConst(val)) {
@@ -465,15 +421,14 @@ AmxBuffer prepareTensorBuffer(Location loc, Value val, bool interleave,
     return {};
   }
 
-  auto vecTy = cast<VectorType>(val.getType());
   if (interleave)
     vecTy = getSwizzledRhsTileType(vecTy);
-  AmxBuffer buf = allocateTmpBuffer(loc, vecTy, allocaPoint, rewriter);
+  MemBuffer buf = allocateTmpBuffer(loc, vecTy, allocaPoint, rewriter);
 
   if (interleave) {
     interleaveAndStore(loc, val, buf.memRef, rewriter);
   } else {
-    rewriter.create<vector::TransferWriteOp>(loc, val, buf.memRef, buf.indices);
+    op_write(val, buf.memRef, buf.indices);
   }
 
   return buf;
@@ -482,8 +437,8 @@ AmxBuffer prepareTensorBuffer(Location loc, Value val, bool interleave,
 // Return a buffer where the final result should be stored. If result can
 // be directly stored to the output memory, then it is used as an output
 // buffer. Otherwise, re-use accumulator buffer or create a new one.
-AmxBuffer prepareResultBuffer(Location loc, Value val, const AmxBuffer &accBuf,
-                              const AmxBuffer &outBuf, Operation *allocaPoint,
+MemBuffer prepareResultBuffer(Location loc, Value val, const MemBuffer &accBuf,
+                              const MemBuffer &outBuf, Operation *allocaPoint,
                               PatternRewriter &rewriter) {
   if (!outBuf.empty()) {
     LDBG("Output memory will be used for direct tile stores.");
@@ -500,37 +455,22 @@ AmxBuffer prepareResultBuffer(Location loc, Value val, const AmxBuffer &accBuf,
                            rewriter);
 }
 
-Value shiftIndex(Location loc, Value index, int64_t offs,
-                 PatternRewriter &rewriter) {
-  if (!offs)
-    return index;
-
-  // Do constant folding right away here for better code readability
-  // after the pass.
-  auto cstOp = dyn_cast<arith::ConstantOp>(index.getDefiningOp());
-  if (cstOp) {
-    int64_t oldVal = cast<IntegerAttr>(cstOp.getValue()).getInt();
-    return rewriter.create<arith::ConstantIndexOp>(loc, oldVal + offs);
-  }
-
-  Value offsVal = rewriter.create<arith::ConstantIndexOp>(loc, offs);
-  return rewriter.create<arith::AddIOp>(loc, index.getType(), index, offsVal);
-}
-
-SmallVector<Value, 2> shiftIndices(Location loc, ArrayRef<Value> indices,
-                                   amx::TileType tileTy, int64_t tilesInBlockM,
-                                   int64_t tilesInBlockN, int64_t blockM,
-                                   int64_t blockN, int64_t tileM, int64_t tileN,
-                                   PatternRewriter &rewriter) {
+SmallVector<Value> shiftIndices(Location loc, ArrayRef<Value> indices,
+                                amx::TileType tileTy, int64_t tilesInBlockM,
+                                int64_t tilesInBlockN, int64_t blockM,
+                                int64_t blockN, int64_t tileM, int64_t tileN,
+                                PatternRewriter &rewriter) {
   int64_t blockOffsM = blockM * tilesInBlockM * tileTy.getDimSize(0);
   int64_t blockOffsN = blockN * tilesInBlockN * tileTy.getDimSize(1);
   int64_t tileOffsM = blockOffsM + tileM * tileTy.getDimSize(0);
   int64_t tileOffsN = blockOffsN + tileN * tileTy.getDimSize(1);
-  return {shiftIndex(loc, indices[0], tileOffsM, rewriter),
-          shiftIndex(loc, indices[1], tileOffsN, rewriter)};
+  SmallVector<Value> res(indices.begin(), indices.end() - 2);
+  res.push_back(shiftIndex(loc, *(indices.end() - 2), tileOffsM, rewriter));
+  res.push_back(shiftIndex(loc, *(indices.end() - 1), tileOffsN, rewriter));
+  return res;
 }
 
-Value loadTile(Location loc, amx::TileType tileTy, const AmxBuffer &buf,
+Value loadTile(Location loc, amx::TileType tileTy, const MemBuffer &buf,
                int64_t tilesInBlockM, int64_t tilesInBlockN, int64_t blockM,
                int64_t blockN, int64_t tileM, int64_t tileN,
                PatternRewriter &rewriter) {
@@ -541,7 +481,7 @@ Value loadTile(Location loc, amx::TileType tileTy, const AmxBuffer &buf,
 }
 
 void storeTile(Location loc, amx::TileType tileTy, Value val,
-               const AmxBuffer &buf, int64_t tilesInBlockM,
+               const MemBuffer &buf, int64_t tilesInBlockM,
                int64_t tilesInBlockN, int64_t blockM, int64_t blockN,
                int64_t tileM, int64_t tileN, PatternRewriter &rewriter) {
   auto indices =
@@ -551,7 +491,7 @@ void storeTile(Location loc, amx::TileType tileTy, Value val,
 }
 
 SmallVector<SmallVector<Value>>
-loadBlockTiles(Location loc, amx::TileType tileTy, const AmxBuffer &buf,
+loadBlockTiles(Location loc, amx::TileType tileTy, const MemBuffer &buf,
                int64_t tilesInBlockM, int64_t tilesInBlockN, int64_t blockM,
                int64_t blockN, PatternRewriter &rewriter) {
   SmallVector<SmallVector<Value>> res(tilesInBlockM);
@@ -567,22 +507,18 @@ loadBlockTiles(Location loc, amx::TileType tileTy, const AmxBuffer &buf,
   return res;
 }
 
-// Move acc to a tile for the whole loop. It might be loads from memory or
-// zero tiles.
-SmallVector<SmallVector<Value>>
-moveLoopAccToTiles(Location loc, amx::TileType tileTy, const AmxBuffer &buf,
-                   int64_t tilesInBlockM, int64_t tilesInBlockN,
-                   PatternRewriter &rewriter) {
-  LDBG("Loading accumulator to tiles before the loop.");
-  auto res = loadBlockTiles(loc, tileTy, buf, tilesInBlockM, tilesInBlockN, 0,
-                            0, rewriter);
-
-  // TODO: add new block args into ForOp and return them instead.
-  // Yield directly uses them for now and will be patched after mul
-  // ops generation.
-  llvm_unreachable("Not yet supported.");
-
-  return res;
+void storeBlockTiles(Location loc, amx::TileType tileTy, const MemBuffer &buf,
+                     int64_t blockM, int64_t blockN,
+                     const SmallVector<SmallVector<Value>> &tiles,
+                     PatternRewriter &rewriter) {
+  int64_t tilesInBlockM = tiles.size();
+  int64_t tilesInBlockN = tiles[0].size();
+  for (int64_t m = 0; m < tilesInBlockM; ++m) {
+    for (int64_t n = 0; n < tilesInBlockN; ++n) {
+      storeTile(loc, tileTy, tiles[m][n], buf, tilesInBlockM, tilesInBlockN,
+                blockM, blockN, m, n, rewriter);
+    }
+  }
 }
 
 // Multiply two blocks. LHS block is preloaded to tiles with the following
@@ -590,8 +526,8 @@ moveLoopAccToTiles(Location loc, amx::TileType tileTy, const AmxBuffer &buf,
 // Optionally, results can also be stored to accBuf.
 void multiplyBlocksPreloadLhs(Location loc, amx::TileType lhsTileTy,
                               amx::TileType rhsTileTy, amx::TileType accTileTy,
-                              const AmxBuffer &lhsBuf, const AmxBuffer &rhsBuf,
-                              const AmxBuffer &accBuf, int64_t blockM,
+                              const MemBuffer &lhsBuf, const MemBuffer &rhsBuf,
+                              const MemBuffer &accBuf, int64_t blockM,
                               int64_t blockN, int64_t blockK,
                               int64_t tilesInBlockM, int64_t tilesInBlockN,
                               SmallVector<SmallVector<Value>> &accTiles,
@@ -626,8 +562,8 @@ void multiplyBlocksPreloadLhs(Location loc, amx::TileType lhsTileTy,
 // Similar to multiplyBlocksPreloadLhs but here RHS is preloaded to tiles.
 void multiplyBlocksPreloadRhs(Location loc, amx::TileType lhsTileTy,
                               amx::TileType rhsTileTy, amx::TileType accTileTy,
-                              const AmxBuffer &lhsBuf, const AmxBuffer &rhsBuf,
-                              const AmxBuffer &accBuf, int64_t blockM,
+                              const MemBuffer &lhsBuf, const MemBuffer &rhsBuf,
+                              const MemBuffer &accBuf, int64_t blockM,
                               int64_t blockN, int64_t blockK,
                               int64_t tilesInBlockM, int64_t tilesInBlockN,
                               SmallVector<SmallVector<Value>> &accTiles,
@@ -691,11 +627,11 @@ LogicalResult convertCandidate(AmxDotOpCandidate &candidate,
   // Cast input data if required and prepare input buffer. It might be temporary
   // buffers with stored vectors or the original input memory.
   Value lhs = maybeCast(loc, op.getA(), candidate.lhsTileElemTy, rewriter);
-  AmxBuffer lhsBuf =
+  MemBuffer lhsBuf =
       prepareTensorBuffer(loc, lhs, false, false, true, allocaPoint, rewriter);
 
   Value rhs = maybeCast(loc, op.getB(), candidate.rhsTileElemTy, rewriter);
-  AmxBuffer rhsBuf =
+  MemBuffer rhsBuf =
       prepareTensorBuffer(loc, rhs, true, false, true, allocaPoint, rewriter);
 
   Value acc = maybeCast(loc, op.getC(), candidate.accTileElemTy, rewriter);
@@ -705,7 +641,7 @@ LogicalResult convertCandidate(AmxDotOpCandidate &candidate,
     forOp = cast<scf::ForOp>(op->getParentOp());
     accToStore = getInitAccValue(acc);
   }
-  AmxBuffer accBuf;
+  MemBuffer accBuf;
   {
     // If accumulator is bufferized then we should move initial values before
     // the loop.
@@ -717,14 +653,24 @@ LogicalResult convertCandidate(AmxDotOpCandidate &candidate,
                             false, allocaPoint, rewriter);
   }
 
-  AmxBuffer resBuf = prepareResultBuffer(
+  MemBuffer resBuf = prepareResultBuffer(
       loc, op.getResult(), accBuf, candidate.outBuf, allocaPoint, rewriter);
 
   SmallVector<SmallVector<Value>> accTiles;
-  if (candidate.keepAccOnTiles)
-    accTiles =
-        moveLoopAccToTiles(loc, accTileTy, accBuf, candidate.tilesInBlockM,
-                           candidate.tilesInBlockN, rewriter);
+  SmallVector<SmallVector<Value>> accInitTiles;
+  if (candidate.keepAccOnTiles) {
+    // Initial tile values are loaded before the loop and then directly
+    // used within the loop. Later, new iter values will be added to
+    // add loop carried-dependencies for accumulator tiles and accInitTiles
+    // will be used as initializers for them.
+    OpBuilder::InsertionGuard g(rewriter);
+    rewriter.setInsertionPoint(forOp);
+    LDBG("Loading accumulator to tiles before the loop.");
+    accInitTiles =
+        loadBlockTiles(loc, accTileTy, accBuf, candidate.tilesInBlockM,
+                       candidate.tilesInBlockN, 0, 0, rewriter);
+    accTiles = accInitTiles;
+  }
 
   int64_t blocksInAccM =
       accTy.getDimSize(0) / candidate.tileM / candidate.tilesInBlockM;
@@ -743,6 +689,7 @@ LogicalResult convertCandidate(AmxDotOpCandidate &candidate,
         // TODO: enable forward store for acc kept in tiles.
         bool storeAcc =
             !candidate.keepAccOnTiles && (blocK == (tilesInVectorK - 1));
+
         // We need to choose which block (LHS or RHS) to keep on tiles.
         // E.g. for ACC block 4x1 tiles, LHS block is also 4 tiles, so
         // we would use all tile registers trying to keep both ACC and
@@ -762,37 +709,98 @@ LogicalResult convertCandidate(AmxDotOpCandidate &candidate,
     }
   }
 
-  // TODO: For keepAccOnTiles fix YieldOp to use mul results.
-  // TODO: For keepAccOnTiles move all new forOp results to vector through a
-  // buffer.
-  if (candidate.keepAccOnTiles)
-    llvm_unreachable("Not yet supported.");
+  if (candidate.keepAccOnTiles) {
+    // In this case we have the whole accumulator/result on tiles. Loop
+    // carried dependencies are not in place yet and should be added.
+    // After the loop, resulting tiles should either be stored to the
+    // output buffer, or moved to a vector though a temporary buffer.
 
-  if (candidate.keepAccInBuf) {
-    int resIdx = op.getResult().getUses().begin()->getOperandNumber();
-    Value loopRes = forOp.getResult(resIdx);
+    // We don't need the original accumulator and contraction op anymore.
+    // Directly yield orig accumulator value, so it would be later removed
+    // as unused. The original contraction can be removed right away.
+    int64_t origResIdx = op.getResult().getUses().begin()->getOperandNumber();
+    rewriter.replaceOp(op, op.getC());
+
+    // Now, replace the loop with a new one to add loop carried dependency for
+    // accumulator tiles.
+    LDBG("Rewrite loop to introduce loop carried dependencies for accumulator "
+         "tiles.");
+    SmallVector<Value> newInitOperands;
+    SmallVector<Value> newYieldedValues;
+    for (int64_t m = 0; m < candidate.tilesInBlockM; ++m)
+      for (int64_t n = 0; n < candidate.tilesInBlockN; ++n) {
+        LDBG("Initial value\n  " << accInitTiles[m][n]
+                                 << "\nis combined with\n  " << accTiles[m][n]);
+        newInitOperands.push_back(accInitTiles[m][n]);
+        newYieldedValues.push_back(accTiles[m][n]);
+      }
+    auto newForOp = cast<scf::ForOp>(*forOp.replaceWithAdditionalYields(
+        rewriter, newInitOperands, true,
+        [&newYieldedValues](OpBuilder &b, Location loc,
+                            ArrayRef<BlockArgument> newBBArgs) {
+          return newYieldedValues;
+        }));
+
+    // The resulting tiles are now in the new loop results.
+    auto resTiles = newForOp.getResults().take_back(newYieldedValues.size());
+    for (int64_t m = 0; m < candidate.tilesInBlockM; ++m)
+      for (int64_t n = 0; n < candidate.tilesInBlockN; ++n) {
+        accTiles[m][n] = resTiles[m * candidate.tilesInBlockN + n];
+      }
+
+    OpBuilder::InsertionGuard g(rewriter);
+    rewriter.setInsertionPointAfter(newForOp);
+    if (candidate.outBuf.empty()) {
+      // Move tiles to a vector through a temporary buffer and use it instead
+      // of the original one.
+      LDBG("Moving resulting tiles to a vector through memory.");
+      VectorType resTy = accTy.cloneWith(std::nullopt, candidate.accTileElemTy);
+      storeBlockTiles(loc, accTileTy, resBuf, 0, 0, accTiles, rewriter);
+      Value newVal = op_read(resTy, resBuf.memRef, resBuf.indices);
+      // We might need to cast back to the original type.
+      newVal = maybeCast(loc, newVal, accTy.getElementType(), rewriter);
+      rewriter.replaceAllUsesWith(newForOp.getResult(origResIdx), newVal);
+    } else {
+      // Store tiles directly to the output buffer and remove the original
+      // store.
+      LDBG("Storing  resulting tiles to the output memory.");
+      OpBuilder::InsertionGuard g(rewriter);
+      rewriter.setInsertionPoint(candidate.origStore);
+      storeBlockTiles(loc, accTileTy, candidate.outBuf, 0, 0, accTiles,
+                      rewriter);
+      rewriter.eraseOp(candidate.origStore);
+    }
+  } else if (candidate.keepAccInBuf) {
+    // The result is in the buffer. We should load it and replace one of the
+    // loop results. The original contraction op can be removed.
+    // TODO: should we try to store to the output buffer on the last iteration?
+    Value loopRes = forOp.getTiedLoopResult(cast<BlockArgument>(op.getC()));
     LDBG(
         "Loading buffererized accumulator to a vector to replace loop result.");
     OpBuilder::InsertionGuard g(rewriter);
     rewriter.setInsertionPointAfter(forOp);
-    Value newVal = rewriter.create<vector::TransferReadOp>(
-        loc, cast<VectorType>(acc.getType()), resBuf.memRef, resBuf.indices);
+    Value newVal =
+        op_read(cast<VectorType>(acc.getType()), resBuf.memRef, resBuf.indices);
     // We might need to cast back to the original type.
     newVal = maybeCast(loc, newVal, accTy.getElementType(), rewriter);
     rewriter.replaceAllUsesWith(loopRes, newVal);
-    // For now, just use init value for unused ForOp result instead of
-    // its removal.
+    // Directly yield orig accumulator iter value. It will be removed as unused
+    // later.
     rewriter.replaceOp(op, op.getC());
   } else if (candidate.outBuf.empty()) {
+    // The result is in the buffer. We should load it and replace the original
+    // constraction result.
     LDBG("Loading the result to a vector to replace orig op result.");
-    Value newVal = rewriter.create<vector::TransferReadOp>(
-        loc, cast<VectorType>(acc.getType()), resBuf.memRef, resBuf.indices);
+    Value newVal =
+        op_read(cast<VectorType>(acc.getType()), resBuf.memRef, resBuf.indices);
     // We might need to cast back to the original type.
     newVal = maybeCast(loc, newVal, accTy.getElementType(), rewriter);
     rewriter.replaceOp(op, newVal);
   } else {
+    // The result is already in the output buffer. We just need to remove the
+    // original contraction and store operation.
     LDBG("Removing original operation and its use.");
-    rewriter.eraseOp(*op.getResult().user_begin());
+    rewriter.eraseOp(candidate.origStore);
     rewriter.eraseOp(op);
   }
 


### PR DESCRIPTION
Initial AMX lowering was constrained by limitations in LLVM that forced suboptimal code generation. With all those problems fixed, AMX code generation can be improved. Mostly, improvements avoid unnecessary data copies in memory and tile spills/fills. 

Here are the current matmul results:

```
matmul-performance-torch.bfloat16 (USE_BLOCK_POINTERS=True CACHE_PADDING=False PREPACKED=False PAD_B_ONLY=True GROUP_SIZE_M=8):
         M       N       K  TritonCPU 1     TritonCPU  TorchCPU (native)
0    256.0   256.0   256.0   195.246945    869.475833         302.701015
1    384.0   384.0   384.0   244.640081   2029.952337         794.682071
2    512.0   512.0   512.0   276.182932   2750.447317        1544.400887
3    640.0   640.0   640.0   301.045105   3350.790461        2272.750134
4    768.0   768.0   768.0   312.554210   4373.262161        3399.006962
5    896.0   896.0   896.0   318.047795   5105.212381        4131.773014
6   1024.0  1024.0  1024.0   237.993479   5962.283454        6218.541663
7   1152.0  1152.0  1152.0   335.322137   7208.262983        6867.067108
8   1280.0  1280.0  1280.0   344.532034   7907.947486        7946.819412
9   1408.0  1408.0  1408.0   353.308430   8261.630399        9284.388374
10  1536.0  1536.0  1536.0   310.406393   8181.302247       11420.598421
11  1664.0  1664.0  1664.0   357.119743   9980.877595       12659.548744
12  1792.0  1792.0  1792.0   354.152714  10799.703727       13796.558676
13  1920.0  1920.0  1920.0   351.161998  11598.066462       16367.481370
14  2048.0  2048.0  2048.0   200.469883   8711.803768       17280.321799
15  2176.0  2176.0  2176.0   298.020309  11348.637272       17392.940757
16  2304.0  2304.0  2304.0   263.087228  10874.170959       19325.259548
17  2432.0  2432.0  2432.0   268.050970  10999.271674       20994.428169
18  2560.0  2560.0  2560.0   203.458730   9307.164552       22451.871090
```

Here are the results with the patch applied:

```
matmul-performance-torch.bfloat16 (USE_BLOCK_POINTERS=True CACHE_PADDING=False PREPACKED=False PAD_B_ONLY=True GROUP_SIZE_M=8):
         M       N       K  TritonCPU 1     TritonCPU  TorchCPU (native)
0    256.0   256.0   256.0   231.292629    867.030418         287.964012
1    384.0   384.0   384.0   277.452410   1891.786649         795.595270
2    512.0   512.0   512.0   334.645753    268.986601        1500.187999
3    640.0   640.0   640.0   355.651065   3467.534838        2305.896213
4    768.0   768.0   768.0   384.188944   4516.579608        3416.729400
5    896.0   896.0   896.0   380.991359   5196.789675        4075.434094
6   1024.0  1024.0  1024.0   295.561415   6471.863075        6046.602183
7   1152.0  1152.0  1152.0   408.233164   7505.557900        6834.817432
8   1280.0  1280.0  1280.0   425.907791   8350.137242        8007.965112
9   1408.0  1408.0  1408.0   435.965567   8956.487153        9234.167915
10  1536.0  1536.0  1536.0   386.115042   2569.795873       11371.662764
11  1664.0  1664.0  1664.0   446.291293  11102.243675       12680.201085
12  1792.0  1792.0  1792.0   444.647878  12120.592252       13765.578469
13  1920.0  1920.0  1920.0   450.166483  13127.780064       16448.472573
14  2048.0  2048.0  2048.0   246.879478  10215.069991       17578.027278
15  2176.0  2176.0  2176.0   432.292666  13973.864008       17382.537709
16  2304.0  2304.0  2304.0   403.378976  14640.284675       19367.917193
17  2432.0  2432.0  2432.0   412.136434  15065.026245       21133.744352
18  2560.0  2560.0  2560.0   261.675464  11172.655003       22272.778410
```

Blocked version doesn't work for bfloat16 on the current main, so I have only numbers collected with the patch applied:

```
matmul-performance-bfloat16 (BLOCK_SIZE_M=32, BLOCK_SIZE_N=32, BLOCK_SIZE_K=32, GROUP_SIZE_M=8):
         M       N       K  triton-cpu-bb-tb-bfloat16  triton-cpu-bb-tb-prepack-bfloat16  triton-cpu-bfloat16  torch-cpu-native-bfloat16
0    256.0   256.0   256.0                 723.288271                         999.446445           923.886376                 297.325865
1    384.0   384.0   384.0                1812.806767                        2346.247213          2107.805473                 790.039161
2    512.0   512.0   512.0                2737.451411                        3278.679899          2884.943600                1516.790459
3    640.0   640.0   640.0                3539.555613                        3997.592209          3633.707870                2213.162320
4    768.0   768.0   768.0                4471.651170                        5006.420386          4680.480174                3255.815727
5    896.0   896.0   896.0                5480.804509                        6183.071949          5488.260198                3948.002950
6   1024.0  1024.0  1024.0                6323.883703                        6777.709755          6405.159324                5984.900706
7   1152.0  1152.0  1152.0                6840.716634                        7979.206067          7531.310644                6675.570388
8   1280.0  1280.0  1280.0                7774.212617                        8839.388346          8255.283227                7759.004159
9   1408.0  1408.0  1408.0                8641.195056                        9835.446022          8900.045013                9161.469424
10  1536.0  1536.0  1536.0               10220.077987                       11061.242488          8905.789361               11271.583583
11  1664.0  1664.0  1664.0               10257.019797                       12024.657446         10658.086727               12455.259068
12  1792.0  1792.0  1792.0               11173.606653                       13540.516012         11864.687564               13912.102775
13  1920.0  1920.0  1920.0               12632.869561                       15081.582872         12888.272194               16210.349786
14  2048.0  2048.0  2048.0               14822.759978                       16875.055907         10065.555978               17306.744130
15  2176.0  2176.0  2176.0               14625.348019                       17958.024597         13529.561401               17173.269085
16  2304.0  2304.0  2304.0               15187.539211                       19444.855317         14210.339634               19164.768329
17  2432.0  2432.0  2432.0               16665.409248                       20757.513109         14402.238295               21085.539485
18  2560.0  2560.0  2560.0               18216.156579                       21968.677507         11061.245241               22509.887374
```

