### PR TITLE
Fix extra-store in matmul tutorial.

### DIFF
--- a/python/tutorials/03-matrix-multiplication-cpu.py
+++ b/python/tutorials/03-matrix-multiplication-cpu.py
@@ -273,7 +273,7 @@ def matmul_kernel(
         offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
         offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
         c_tile_ptr = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
-    tl.store(c_tile_ptr, c)
+        tl.store(c_tile_ptr, c)
 
 
 # %%


### PR DESCRIPTION
Avoid extra store when block pointers are used in the 03 tutorial for CPU.