### PR TITLE
Remove unnecessary bounds checks.

### DIFF
--- a/third_party/cpu/include/TritonCPUTransforms/OptCommon.h
+++ b/third_party/cpu/include/TritonCPUTransforms/OptCommon.h
@@ -149,9 +149,12 @@ inline Value shapeCast(Location loc, Value in,
 #define op_sitofp(ty, val) rewriter.create<arith::SIToFPOp>(loc, ty, val)
 #define op_fptosi(ty, val) rewriter.create<arith::FPToSIOp>(loc, ty, val)
 #define op_read(ty, memRef, indices)                                           \
-  rewriter.create<vector::TransferReadOp>(loc, ty, memRef, indices)
+  rewriter.create<vector::TransferReadOp>(                                     \
+      loc, ty, memRef, indices, SmallVector<bool>(ty.getRank(), true))
 #define op_write(val, memRef, indices)                                         \
-  rewriter.create<vector::TransferWriteOp>(loc, val, memRef, indices)
+  rewriter.create<vector::TransferWriteOp>(                                    \
+      loc, val, memRef, indices,                                               \
+      SmallVector<bool>(cast<VectorType>(val.getType()).getRank(), true))
 #define op_interleave(lhs, rhs)                                                \
   rewriter.create<vector::InterleaveOp>(loc, lhs, rhs)
 #define op_extract(vec, idx) rewriter.create<vector::ExtractOp>(loc, vec, idx)


### PR DESCRIPTION
This patch removes useless bounds checks enabled by default for read/write operations emitted for AMX lowering. It doesn't improve performance (most checks can be statically removed anyway) but makes the resulting code cleaner.
