### PR TITLE
Add dummy nvidia headers for offline builds

### DIFF
--- a/third_party/nvidia/backend/include/cuda.h
+++ b/third_party/nvidia/backend/include/cuda.h
@@ -1,0 +1,1 @@
+typedef void *cudaStream_t;


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
Fixes https://github.com/triton-lang/triton-cpu/issues/202. Based on my read of `download_and_copy`, specifically the usage of [`shutil.copytree`](https://docs.python.org/3/library/shutil.html#shutil.copytree) and [`shutil.copy`](https://docs.python.org/3/library/shutil.html#shutil.copy), this should be safely replaced by the actual nvidia headers once they are downloaded, but I have not actually tested this.

https://github.com/triton-lang/triton-cpu/blob/daa7eb01e1f3fe60d0e0b9a643886f32d3c3ffe7/python/setup.py#L297-L330

https://github.com/triton-lang/triton-cpu/blob/daa7eb01e1f3fe60d0e0b9a643886f32d3c3ffe7/python/setup.py#L327-L330

[`shutil.copytree`](https://docs.python.org/3/library/shutil.html#shutil.copytree) 

> If _dirs\_exist\_ok_ is true, the copying operation will continue if it encounters existing directories, and files within the _dst_ tree will be overwritten by corresponding files from the _src_ tree.

[`shutil.copy`](https://docs.python.org/3/library/shutil.html#shutil.copy)

> If _dst_ specifies a file that already exists, it will be replaced. Returns the path to the newly created file.

Opening here instead of triton upstream because it's most relevant to the cpu backend and there probably won't be any merge conflicts (as `third_party/nvidia/backend/include` is [ignored upstream](https://github.com/triton-lang/triton/blob/a2b398e0bb1b120f31cf386d6ae3261c3ab84207/.gitignore#L58-L60)).

cc @pawelszczerbuk

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because this is a build change.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
