### PR TITLE
[RUNTIME] Reduce runtime dependency on torch

### DIFF
--- a/third_party/cpu/backend/driver.py
+++ b/third_party/cpu/backend/driver.py
@@ -488,12 +488,35 @@ class CPUDriver(DriverBase):
         return do_bench_cpu
 
     def get_empty_cache_for_benchmark(self):
-        import torch
+        import numpy as np
 
         # A typical LLC size for high-end server CPUs are ~400MB.
         cache_size = 512 * 1024 * 1024
-        return torch.empty(int(cache_size // 4), dtype=torch.int, device='cpu')
+        return np.empty(int(cache_size // 4), dtype=np.int32)
 
-    # TODO maybe CPU should do anything here
     def clear_cache(self, cache):
-        cache.zero_()
+        global tl
+        import triton.language as tl
+
+        class Pointer:
+
+            def __init__(self, data):
+                self.data = data
+                self.dtype = data.dtype
+
+            def data_ptr(self):
+                return self.data.ctypes.data
+
+        @triton.jit
+        def clear_kernel(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr, TILE_SIZE: tl.constexpr):
+            pid = tl.program_id(axis=0)
+            block_start = pid * BLOCK_SIZE
+            for i in range(0, tl.cdiv(BLOCK_SIZE, TILE_SIZE)):
+                offsets = block_start + i * TILE_SIZE + tl.arange(0, TILE_SIZE)
+                mask = offsets < n_elements
+                tl.store(x_ptr + offsets, 0, mask=mask)
+
+        n_elements = len(cache)
+        BLOCK_SIZE = 4096
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]), )
+        clear_kernel[grid](Pointer(cache), n_elements, BLOCK_SIZE, TILE_SIZE=16)


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
Fixes https://github.com/triton-lang/triton-cpu/issues/204. It is now possible to import triton, execute a kernel, and autotune, all without torch.

Relatively straightforward translation of `torch.tensor` -> `np.array`, `torch.float` -> `np.float32`, `np.quantile` -> `torch.quantile` (note the default method for both is `linear`), and so on. Luckily numpy has `np.min`, `np.max`, `np.mean`, `np.median`, and `np.all` with the same semantics as the respective torch functions, so the same `getattr(np, return_mode)(times)` trick can be used.

I was getting

```
ImportError: ~/.triton/cache/TMED6KFKLZGWOEVFFCXVTCPBLE/__triton_cpu_launcher.so: undefined symbol: omp_get_thread_num
```

which was fixed either by importing torch or by adding `omp` to `libraries` in the cpu driver,

https://github.com/triton-lang/triton-cpu/blob/daa7eb01e1f3fe60d0e0b9a643886f32d3c3ffe7/third_party/cpu/backend/driver.py#L28

but I can't seem to replicate this anymore.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because runtime change.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)