### PR TITLE
Fix benchmark.run exception by disabling ax.annotate

### DIFF
--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -329,13 +329,13 @@ class Mark:
                 y_min, y_max = df[y + '-min'], df[y + '-max']
                 col = bench.styles[i][0] if bench.styles else None
                 sty = bench.styles[i][1] if bench.styles else None
-                ax.plot(df[first_x], df[y], color=col, ls=sty)
-                ax.annotate(y, xy=(df[first_x], df[y]), xytext=(1.02 * df[first_x], df[y]), color=col)
+                ax.plot(df[first_x], df[y], label=y, color=col, ls=sty)
+                # ax.annotate(y, xy=(df[first_x], df[y]), xytext=(1.02 * df[first_x], df[y]), color=col)
                 if not y_min.isnull().all() and not y_max.isnull().all():
                     y_min = y_min.astype(float)
                     y_max = y_max.astype(float)
                     ax.fill_between(df[first_x], y_min, y_max, alpha=0.15, color=col)
-            # ax.legend()
+            ax.legend()
             ax.minorticks_on()
             ax.grid(which='minor', alpha=0.2)
             ax.grid(which='major', alpha=0.5)


### PR DESCRIPTION

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

# PR description
Refactor plot labeling and legend handling in #218

- Disabled ax.annotate and re-enabled ax.legend() to ensure triton-cpu behavior matches triton.