### PR TITLE
[XSMM] libxsmm ukernel backend

### DIFF
--- a/include/triton/Dialect/TritonCPU/IR/TritonCPUOps.td
+++ b/include/triton/Dialect/TritonCPU/IR/TritonCPUOps.td
@@ -205,6 +205,8 @@ def TTC_BrgemmCreate : TTC_Op<"brgemm_create", [NoMemoryEffect]> {
     AnyTypeOf<[AnyInteger, Index]>:$lda,
     AnyTypeOf<[AnyInteger, Index]>:$ldb,
     AnyTypeOf<[AnyInteger, Index]>:$ldc,
+    AnyTypeOf<[AnyInteger, Index]>:$stepA,
+    AnyTypeOf<[AnyInteger, Index]>:$stepB,
     // TODO: Maybe Use properties
     TypeAttr:$dtypeA,
     TypeAttr:$dtypeB,

--- a/python/tutorials/cpu-blocked-matmul.py
+++ b/python/tutorials/cpu-blocked-matmul.py
@@ -317,6 +317,8 @@ def decode_provider(provider):
         ukernel = None
     if '-ukOneDNN' in provider:
         ukernel = "OneDNN"
+    if '-ukXSMM' in provider:
+        ukernel = "XSMM"
 
     if 'triton-cpu' in provider:
         backend = 'triton-cpu'
@@ -332,7 +334,7 @@ BLOCK_TRANSPOSE_PACK_B_OPTS = [(True, True, True), (True, True, False), (False, 
 PREPACK_OPTS = [False, True]
 SINGLE_THREAD_OPTS = [False]
 DTYPE_OPTS = [DTYPE]
-UKERNEL_OPTS = [None, "OneDNN"]
+UKERNEL_OPTS = [None, "OneDNN", "XSMM"]
 LINE_VALS = [
     encode_triton_provider(blocked_a, transposed_a, blocked_b, transposed_b, packed_b, prepack, single_thread, dtype,
                            ukernel)

--- a/test/TritonCPU/dot-to-xsmm.mlir
+++ b/test/TritonCPU/dot-to-xsmm.mlir
@@ -1,9 +1,5 @@
 // RUN: triton-opt %s -split-input-file -triton-cpu-convert-dot-to-ukernels="ukernels=XSMM" -cse  | FileCheck %s
 
-// RUN: triton-opt %s -split-input-file -triton-cpu-convert-dot-to-ukernels="ukernels=XSMM" -cse \
-// RUN:  -triton-cpu-ukernels-to-xsmm-llvm \
-// RUN: | FileCheck %s --check-prefix=LLVM
-
 // Replacement of a triton_cpu.dot operation with triton_cpu.brgemm_execute
 
 // CHECK-LABEL: @test_two_tiles_four_mulf
@@ -23,9 +19,6 @@
 // CHECK:       %[[BLOCKEDB_SIZE:.+]] = arith.muli %[[BLOCK]], %[[BTW]] : i64
 // CHECK:       "triton_cpu.brgemm_execute"(%[[ONEDNN_HANDLE]], %[[LHS_SUBVIEW]], %[[RHS_SUBVIEW]], %[[ACC_BUF]], %c0, %c0, %[[BLOCKEDB_SIZE]], %c1) : (index, memref<16x64xbf16, strided<[64, 1], offset: ?>>, memref<64x32xbf16, strided<[32, 1], offset: ?>>, memref<16x32xf32>, index, index, i64, index) -> ()
 // CHECK:       %[[RES:.+]] = vector.transfer_read %[[ACC_BUF]][%c0, %c0], %cst_10 : memref<16x32xf32>, vector<16x32xf32>
-
-// LLVM: llvm.call @xsmm_brgemm_dispatch
-// LLVM: llvm.call @xsmm_brgemm_invoke
 
 #loc = loc(unknown)
 module {
@@ -91,9 +84,6 @@ module {
 // CHECK:       %[[BLOCKEDB_SIZE:.+]] = arith.muli %[[BLOCK]], %[[BTW]] : i64
 // CHECK:       "triton_cpu.brgemm_execute"(%[[ONEDNN_HANDLE]], %[[LHS_SUBVIEW]], %[[RHS_SUBVIEW]], %[[ACC_BUF]], %[[LHS_STEP]], %[[RHS_STEP]], %[[BLOCKEDB_SIZE]], %[[NUM_BATCHES]]) : (index, memref<64x64xbf16, strided<[128, 1], offset: ?>>, memref<64x32xbf16, strided<[32, 1], offset: ?>>, memref<64x32xf32>, index, index, i64, index) -> ()
 // CHECK:       %[[RES:.+]] = vector.transfer_read %[[ACC_BUF]][%c0, %c0], %cst_10 {in_bounds = [true, true]} : memref<64x32xf32>, vector<64x32xf32>
-
-// LLVM: llvm.call @xsmm_brgemm_dispatch
-// LLVM: llvm.call @xsmm_brgemm_invoke
 
 #loc = loc(unknown)
 module {
@@ -173,9 +163,6 @@ module {
 // CHECK-NEXT:    scf.yield %[[RES_IV]], %[[LHS_IV_UPD]], %[[RHS_IV_UPD]] : vector<32x32xf32>, !tt.ptr<tensor<1x1x32x32xbf16>>, !tt.ptr<tensor<1x1x16x64xbf16>>
 // CHECK-NEXT:  }
 // CHECK:       %[[RES:.+]] = vector.transfer_read %[[RES_ALLOCA]][%c0, %c0], %cst_3 {in_bounds = [true, true]} : memref<32x32xf32>, vector<32x32xf32>
-
-// LLVM: llvm.call @xsmm_brgemm_dispatch
-// LLVM: llvm.call @xsmm_brgemm_invoke
 
 #loc = loc(unknown)
 module {

--- a/third_party/cpu/CMakeLists.txt
+++ b/third_party/cpu/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Find OneDNN ukernel library
 find_package(dnnl CONFIG)
 if (dnnl_FOUND)
   message(STATUS "Found OneDNN/DNNL")
@@ -9,6 +10,24 @@ else ()
   message(STATUS "Could NOT find OneDNN/DNNL")
 endif()
 
+# Find XSMM ukernel library
+find_library(LIBXSMM xsmm
+  PATHS ENV XSMM_LIBRARY_DIRS
+)
+find_path(LIBXSMM_INCLUDE_DIR
+  NAMES libxsmm.h
+  PATHS ENV XSMM_INCLUDE_DIRS
+)
+if (LIBXSMM AND LIBXSMM_INCLUDE_DIR)
+  set(xsmm_FOUND True)
+  message(STATUS "Found XSMM: " ${LIBXSMM})
+  add_compile_definitions(XSMM_AVAILABLE)
+  include_directories(${LIBXSMM_INCLUDE_DIR})
+else ()
+  message(STATUS "Could NOT find XSMM")
+endif()
+
+# Build Triton-CPU plugin
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 add_subdirectory(include)
@@ -18,13 +37,20 @@ if(TRITON_BUILD_PYTHON_MODULE)
   target_link_libraries(TritonCPU PUBLIC MLIRVectorToSCF MLIRAffineToStandard MLIRMathToLibm MLIRAMXToLLVMIRTranslation MLIRMemRefTransforms PRIVATE Python3::Module pybind11::headers)
 endif()
 
+# Configure and build Triton-CPU runtime
+set(TRITON_CPU_RUNTIME_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/runtime/cpu_runtime.cpp)
+set(TRITON_CPU_RUNTIME_LIBS LLVMSupport)
 if (dnnl_FOUND)
-  add_library(TritonCPURuntime SHARED ${CMAKE_CURRENT_SOURCE_DIR}/runtime/cpu_runtime.cpp ${CMAKE_CURRENT_SOURCE_DIR}/runtime/runtime_onednn.cpp)
-  target_link_libraries(TritonCPURuntime PRIVATE LLVMSupport DNNL::dnnl)
-else ()
-  add_library(TritonCPURuntime SHARED ${CMAKE_CURRENT_SOURCE_DIR}/runtime/cpu_runtime.cpp)
-  target_link_libraries(TritonCPURuntime PRIVATE LLVMSupport)
+  set(TRITON_CPU_RUNTIME_SOURCES ${TRITON_CPU_RUNTIME_SOURCES} ${CMAKE_CURRENT_SOURCE_DIR}/runtime/runtime_onednn.cpp)
+  set(TRITON_CPU_RUNTIME_LIBS ${TRITON_CPU_RUNTIME_LIBS} DNNL::dnnl)
 endif()
+if(xsmm_FOUND)
+  set(TRITON_CPU_RUNTIME_SOURCES ${TRITON_CPU_RUNTIME_SOURCES} ${CMAKE_CURRENT_SOURCE_DIR}/runtime/runtime_xsmm.cpp)
+  set(TRITON_CPU_RUNTIME_LIBS ${TRITON_CPU_RUNTIME_LIBS} ${LIBXSMM})
+endif()
+
+add_library(TritonCPURuntime SHARED ${TRITON_CPU_RUNTIME_SOURCES})
+target_link_libraries(TritonCPURuntime PRIVATE ${TRITON_CPU_RUNTIME_LIBS})
 
 # Build and link sleef
 set(SLEEF_BUILD_SHARED_LIBS ON CACHE BOOL "Build sleef shared lib" FORCE)

--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -92,6 +92,16 @@ class CPUOptions:
                 "Warning! Triton build was made without OneDNN support. Check if \"CMAKE_PREFIX_PATH\" contains path to OneDNN during build. \n\t -------OneDNN will NOT be used-------",
                 stacklevel=1)
             return None
+
+        if ukernels == Ukernels.XSMM and not cpu.xsmm_available():
+            import warnings
+            # Warns on each compileation
+            warnings.simplefilter('once', category=UserWarning)
+            warnings.warn(
+                "Warning! Triton build was made without XSMM support. Check if \"CMAKE_PREFIX_PATH\" contains path to XSMM during build. \n\t -------XSMM will NOT be used-------",
+                stacklevel=1)
+            return None
+
         return ukernels
 
 
@@ -233,6 +243,8 @@ class CPUBackend(BaseBackend):
         pm.enable_debug()
         if options.get_ukernels() == Ukernels.OneDNN:
             cpu.passes.ttcpuir.add_ukernels_to_onednn_llvmir(pm)
+        if options.get_ukernels() == Ukernels.XSMM:
+            cpu.passes.ttcpuir.add_ukernels_to_xsmm_llvmir(pm)
         cpu.passes.ttcpuir.add_lower_vector_multi_dim(pm)
         cpu.passes.ttcpuir.add_expand_strided_metadata(pm)
         cpu.passes.ttcpuir.add_vector_to_scf(pm, True, 1, False)

--- a/third_party/cpu/include/TritonCPUToLLVM/Passes.h
+++ b/third_party/cpu/include/TritonCPUToLLVM/Passes.h
@@ -32,6 +32,7 @@ std::unique_ptr<OperationPass<triton::FuncOp>> createLowerMultiReductionPass();
 std::unique_ptr<OperationPass<ModuleOp>> createAtomicOpsToLLVMPass();
 std::unique_ptr<OperationPass<ModuleOp>> createDebugOpsToLLVMPass();
 std::unique_ptr<OperationPass<ModuleOp>> createUkernelOpsToOneDNNLLVMPass();
+std::unique_ptr<OperationPass<ModuleOp>> createUkernelOpsToXSMMLLVMPass();
 std::unique_ptr<OperationPass<ModuleOp>>
 createMathToVecLibPass(VecLib lib = VecLib::Sleef,
                        std::set<std::string> cpu_features = {});

--- a/third_party/cpu/include/TritonCPUToLLVM/Passes.td
+++ b/third_party/cpu/include/TritonCPUToLLVM/Passes.td
@@ -77,6 +77,17 @@ def UkernelOpsToOneDNNLLVM : Pass<"triton-cpu-ukernels-to-onednn-llvm", "mlir::M
                              "mlir::triton::TritonDialect"];
 }
 
+def UkernelOpsToXSMMLLVM : Pass<"triton-cpu-ukernels-to-xsmm-llvm", "mlir::ModuleOp"> {
+    let summary = "Convert ukernel operations to XSMM LLVM runtime calls.";
+    let description = [{}];
+    let constructor = "mlir::triton::cpu::createUkernelOpsToXSMMLLVMPass()";
+
+    let dependentDialects = ["mlir::arith::ArithDialect",
+                             "mlir::LLVM::LLVMDialect",
+                             "mlir::triton::cpu::TritonCPUDialect",
+                             "mlir::triton::TritonDialect"];
+}
+
 def MathToVecLib : Pass<"triton-cpu-math-to-vec-lib", "mlir::ModuleOp"> {
     let summary = "Convert vector math operations to vector libm or sleef calls.";
     let description = [{

--- a/third_party/cpu/include/TritonCPUTransforms/Passes.h
+++ b/third_party/cpu/include/TritonCPUTransforms/Passes.h
@@ -17,6 +17,7 @@ namespace cpu {
 
 enum class Ukernels {
   OneDNN,
+  XSMM,
 };
 
 #define GEN_PASS_DECL

--- a/third_party/cpu/include/TritonCPUTransforms/Passes.td
+++ b/third_party/cpu/include/TritonCPUTransforms/Passes.td
@@ -145,10 +145,12 @@ def ConvertDotOpToUkernelOps : Pass<"triton-cpu-convert-dot-to-ukernels", "mlir:
     let options = [
         Option<"ukernels", "ukernels",
                "mlir::triton::cpu::Ukernels", /*default*/"mlir::triton::cpu::Ukernels::OneDNN",
-               "Ukernels provider to be used for replacement of dot op (OneDNN/Xsmm/etc).",
+               "Ukernels provider to be used for replacement of dot op (OneDNN/XSMM/etc).",
                [{::llvm::cl::values(
                clEnumValN(mlir::triton::cpu::Ukernels::OneDNN, "oneDNN",
-                "Use OneDNN as a ukernels provider")
+                "Use OneDNN as a ukernels provider"),
+               clEnumValN(mlir::triton::cpu::Ukernels::XSMM, "XSMM",
+                "Use XSMM as a ukernels provider")
               )}]>,
     ];
 

--- a/third_party/cpu/lib/TritonCPUToLLVM/CMakeLists.txt
+++ b/third_party/cpu/lib/TritonCPUToLLVM/CMakeLists.txt
@@ -2,6 +2,7 @@ add_triton_library(TritonCPUToLLVM
     AtomicOpsToLLVM.cpp
     DebugOpsToLLVM.cpp
     UkernelOpsToOneDNNLLVM.cpp
+    UkernelOpsToXSMMLLVM.cpp
     FuncOpToLLVM.cpp
     GetProgramIdOpToLLVM.cpp
     LowerMultiReduction.cpp

--- a/third_party/cpu/lib/TritonCPUToLLVM/UkernelOpsToXSMMLLVM.cpp
+++ b/third_party/cpu/lib/TritonCPUToLLVM/UkernelOpsToXSMMLLVM.cpp
@@ -108,12 +108,11 @@ struct BrgemmCreateConversion : public ConvertOpToLLVMPattern<BrgemmCreate> {
     auto inXsmmType = b.i64_val(getXSMMDataTypeVal(adaptor.getDtypeA()));
     auto outXsmmType = b.i64_val(getXSMMDataTypeVal(adaptor.getDtypeC()));
 
-    auto brgemmArgs =
-        SmallVector<Value>{adaptor.getM(),     adaptor.getN(),
-                           adaptor.getKK(),    adaptor.getLda(),
-                           adaptor.getLdb(),   adaptor.getLdc(),
-                           adaptor.getStepA(), adaptor.getStepB(),
-                           inXsmmType,         outXsmmType};
+    auto brgemmArgs = SmallVector<Value>{adaptor.getM(),     adaptor.getN(),
+                                         adaptor.getKK(),    adaptor.getLda(),
+                                         adaptor.getLdb(),   adaptor.getLdc(),
+                                         adaptor.getStepA(), adaptor.getStepB(),
+                                         inXsmmType,         outXsmmType};
     SmallVector<Type> brgemmArgTypes{i64_ty, i64_ty, i64_ty, i64_ty, i64_ty,
                                      i64_ty, i64_ty, i64_ty, i64_ty, i64_ty};
 
@@ -157,8 +156,8 @@ struct BrgemmExecuteConversion : public ConvertOpToLLVMPattern<BrgemmExecute> {
                        cast<MemRefType>(brgemmOp.getCPtr().getType())),
         adaptor.getNumBatches()};
 
-    auto brgemmArgTypes =
-        SmallVector<Type>{ptr_ty(ctx), ptr_ty(ctx), ptr_ty(ctx), ptr_ty(ctx), i64_ty};
+    auto brgemmArgTypes = SmallVector<Type>{ptr_ty(ctx), ptr_ty(ctx),
+                                            ptr_ty(ctx), ptr_ty(ctx), i64_ty};
 
     auto dispatched = LLVM::createLLVMCallOp(
         rewriter, loc,
@@ -171,8 +170,7 @@ struct BrgemmExecuteConversion : public ConvertOpToLLVMPattern<BrgemmExecute> {
 };
 
 struct UkernelOpsToXSMMLLVM
-    : public triton::cpu::impl::UkernelOpsToXSMMLLVMBase<
-    UkernelOpsToXSMMLLVM> {
+    : public triton::cpu::impl::UkernelOpsToXSMMLLVMBase<UkernelOpsToXSMMLLVM> {
   using UkernelOpsToXSMMLLVMBase::UkernelOpsToXSMMLLVMBase;
 
   void runOnOperation() override {

--- a/third_party/cpu/lib/TritonCPUToLLVM/UkernelOpsToXSMMLLVM.cpp
+++ b/third_party/cpu/lib/TritonCPUToLLVM/UkernelOpsToXSMMLLVM.cpp
@@ -1,0 +1,206 @@
+#include "TypeConverter.h"
+#include "Utility.h"
+
+#include "cpu/include/TritonCPUToLLVM/Passes.h"
+
+#include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
+#include "mlir/Conversion/LLVMCommon/LoweringOptions.h"
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Dialect/GPU/IR/GPUOps.h.inc"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonCPU/IR/Dialect.h"
+
+#if defined(XSMM_AVAILABLE)
+#include "libxsmm_typedefs.h"
+#endif
+void assert_on_xsmm_missing() {
+#if !defined(XSMM_AVAILABLE)
+  assert(false && "No XSMM with uKernels available. Pass will be redundant.");
+#endif
+}
+
+namespace mlir {
+namespace triton {
+namespace cpu {
+#define GEN_PASS_DEF_UKERNELOPSTOXSMMLLVM
+#include "cpu/include/TritonCPUToLLVM/Passes.h.inc"
+} // namespace cpu
+} // namespace triton
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::triton;
+using namespace mlir::triton::cpu;
+
+namespace {
+
+inline Value intLLVMConst(Location loc, Type ty, int64_t val,
+                          PatternRewriter &rewriter) {
+  return rewriter.create<LLVM::ConstantOp>(
+      loc, IntegerAttr::get(getElementTypeOrSelf(ty), val));
+}
+
+static inline int64_t getXSMMDataTypeVal(Type ty) {
+#if defined(XSMM_AVAILABLE)
+  ty = getElementTypeOrSelf(ty);
+
+  // Float types
+  if (ty.isF32())
+    return static_cast<int64_t>(LIBXSMM_DATATYPE_F32);
+  if (ty.isBF16())
+    return static_cast<int64_t>(LIBXSMM_DATATYPE_BF16);
+  if (ty.isF16())
+    return static_cast<int64_t>(LIBXSMM_DATATYPE_F16);
+#endif
+  assert_on_xsmm_missing();
+  llvm_unreachable("Unexpected type for conversion to XSMM type.");
+}
+
+class TritonLLVMConversionTarget : public ConversionTarget {
+public:
+  explicit TritonLLVMConversionTarget(MLIRContext &ctx)
+      : ConversionTarget(ctx) {
+    addLegalDialect<LLVM::LLVMDialect>();
+    addLegalOp<mlir::UnrealizedConversionCastOp>();
+  }
+};
+
+LLVM::LLVMFuncOp getFuncDecl(ConversionPatternRewriter &rewriter,
+                             StringRef funcName, SmallVector<Type> argsType,
+                             Type resultType) {
+  auto moduleOp = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
+  Operation *funcOp = moduleOp.lookupSymbol(funcName);
+  if (funcOp)
+    return cast<LLVM::LLVMFuncOp>(*funcOp);
+
+  auto *ctx = rewriter.getContext();
+
+  auto funcType =
+      LLVM::LLVMFunctionType::get(resultType, argsType, /*isVarArg*/ false);
+
+  ConversionPatternRewriter::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPointToStart(moduleOp.getBody());
+
+  return rewriter.create<LLVM::LLVMFuncOp>(UnknownLoc::get(ctx), funcName,
+                                           funcType);
+}
+
+struct BrgemmCreateConversion : public ConvertOpToLLVMPattern<BrgemmCreate> {
+  using ConvertOpToLLVMPattern<BrgemmCreate>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(BrgemmCreate brgemmOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = brgemmOp.getLoc();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    IntegerType integer64 = IntegerType::get(rewriter.getContext(), 64);
+
+    std::string dispatchName = "xsmm_brgemm_dispatch";
+
+    if (getElementTypeOrSelf(brgemmOp.getDtypeA()) !=
+        getElementTypeOrSelf(brgemmOp.getDtypeB()))
+      return rewriter.notifyMatchFailure(
+          brgemmOp, "expects the same element type for input operands");
+
+    auto inXsmmType = b.i64_val(getXSMMDataTypeVal(adaptor.getDtypeA()));
+    auto outXsmmType = b.i64_val(getXSMMDataTypeVal(adaptor.getDtypeC()));
+
+    auto brgemmArgs =
+        SmallVector<Value>{adaptor.getM(),     adaptor.getN(),
+                           adaptor.getKK(),    adaptor.getLda(),
+                           adaptor.getLdb(),   adaptor.getLdc(),
+                           adaptor.getStepA(), adaptor.getStepB(),
+                           inXsmmType,         outXsmmType};
+    SmallVector<Type> brgemmArgTypes{i64_ty, i64_ty, i64_ty, i64_ty, i64_ty,
+                                     i64_ty, i64_ty, i64_ty, i64_ty, i64_ty};
+
+    auto dispatched = LLVM::createLLVMCallOp(
+        rewriter, loc,
+        getFuncDecl(
+            rewriter, dispatchName, brgemmArgTypes,
+            getTypeConverter()->convertType(brgemmOp.getResult().getType())),
+        brgemmArgs);
+
+    rewriter.replaceOp(brgemmOp, dispatched.getResult());
+    return success();
+  };
+};
+
+struct BrgemmExecuteConversion : public ConvertOpToLLVMPattern<BrgemmExecute> {
+  using ConvertOpToLLVMPattern<BrgemmExecute>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(BrgemmExecute brgemmOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    auto loc = brgemmOp.getLoc();
+    auto ctx = rewriter.getContext();
+
+    std::string invokeName = "xsmm_brgemm_invoke";
+
+    auto brgemm_kernel_hash_ptr = rewriter.create<LLVM::IntToPtrOp>(
+        loc, ptr_ty(ctx), adaptor.getBrgemmKernelHash());
+
+    auto brgemmArgs = SmallVector<Value>{
+        brgemm_kernel_hash_ptr,
+        MemRefDescriptor(adaptor.getAPtr())
+            .bufferPtr(rewriter, loc, *getTypeConverter(),
+                       cast<MemRefType>(brgemmOp.getAPtr().getType())),
+        MemRefDescriptor(adaptor.getBPtr())
+            .bufferPtr(rewriter, loc, *getTypeConverter(),
+                       cast<MemRefType>(brgemmOp.getBPtr().getType())),
+        MemRefDescriptor(adaptor.getCPtr())
+            .bufferPtr(rewriter, loc, *getTypeConverter(),
+                       cast<MemRefType>(brgemmOp.getCPtr().getType())),
+        adaptor.getNumBatches()};
+
+    auto brgemmArgTypes =
+        SmallVector<Type>{ptr_ty(ctx), ptr_ty(ctx), ptr_ty(ctx), ptr_ty(ctx), i64_ty};
+
+    auto dispatched = LLVM::createLLVMCallOp(
+        rewriter, loc,
+        getFuncDecl(rewriter, invokeName, brgemmArgTypes, void_ty(ctx)),
+        brgemmArgs);
+
+    rewriter.replaceOp(brgemmOp, dispatched);
+    return success();
+  };
+};
+
+struct UkernelOpsToXSMMLLVM
+    : public triton::cpu::impl::UkernelOpsToXSMMLLVMBase<
+    UkernelOpsToXSMMLLVM> {
+  using UkernelOpsToXSMMLLVMBase::UkernelOpsToXSMMLLVMBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ModuleOp mod = getOperation();
+
+    mlir::LowerToLLVMOptions option(context);
+    TritonCPUToLLVMTypeConverter typeConverter(context, option);
+    TritonLLVMConversionTarget conversionTarget(*context);
+
+    RewritePatternSet patterns(context);
+
+    patterns.add<BrgemmCreateConversion, BrgemmExecuteConversion>(
+        typeConverter);
+
+    if (failed(applyPartialConversion(mod, conversionTarget,
+                                      std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+} // anonymous namespace
+
+namespace mlir::triton::cpu {
+
+std::unique_ptr<OperationPass<ModuleOp>> createUkernelOpsToXSMMLLVMPass() {
+  return std::make_unique<UkernelOpsToXSMMLLVM>();
+}
+
+} // namespace mlir::triton::cpu

--- a/third_party/cpu/runtime/runtime_xsmm.cpp
+++ b/third_party/cpu/runtime/runtime_xsmm.cpp
@@ -1,0 +1,135 @@
+#if !defined(XSMM_AVAILABLE)
+#error "XSMM ukernel is missing"
+#endif // !XSMM_AVAILABLE
+
+#include "libxsmm.h"
+#include "libxsmm_utils.h"
+
+#include <stdint.h>
+#include <stdio.h>
+
+#if defined(_MSC_VER)
+#define EXPORT __declspec(dllexport)
+#elif defined(__GNUC__)
+#define EXPORT __attribute__((visibility("default")))
+#else
+#define EXPORT
+#endif
+
+extern "C" {
+
+// Helper debug XSMM GEMM shape printer.
+static void printXsmmGemmShape(const libxsmm_gemm_shape &gemmShape,
+                               FILE *outfile) {
+  fprintf(outfile, "M: %d\n", gemmShape.m);
+  fprintf(outfile, "N: %d\n", gemmShape.n);
+  fprintf(outfile, "K: %d\n", gemmShape.k);
+  fprintf(outfile, "lda: %d\n", gemmShape.lda);
+  fprintf(outfile, "ldb: %d\n", gemmShape.ldb);
+  fprintf(outfile, "ldc: %d\n", gemmShape.ldc);
+  fprintf(outfile, "a_in_type: %d\n", gemmShape.a_in_type);
+  fprintf(outfile, "b_in_type: %d\n", gemmShape.b_in_type);
+  fprintf(outfile, "comp_type: %d\n", gemmShape.comp_type);
+  fprintf(outfile, "out_type: %d\n", gemmShape.out_type);
+}
+
+// Helper debug XSMM BRGEMM config printer.
+static void
+printXsmmBrgemmCfg(const libxsmm_gemm_batch_reduce_config &brgemmConfig,
+                   FILE *outfile) {
+  fprintf(outfile, "br_type: %d\n", brgemmConfig.br_type);
+  fprintf(outfile, "br_stride_a_hint: %d\n", brgemmConfig.br_stride_a_hint);
+  fprintf(outfile, "br_stride_b_hint: %d\n", brgemmConfig.br_stride_b_hint);
+  fprintf(outfile, "br_unroll_hint: %d\n", brgemmConfig.br_unroll_hint);
+}
+
+// Returns XSMM compute type for an input data type.
+static libxsmm_datatype getXsmmCompType(libxsmm_datatype in_dtype) {
+  switch (in_dtype) {
+  case LIBXSMM_DATATYPE_F32:
+  case LIBXSMM_DATATYPE_F16:
+  case LIBXSMM_DATATYPE_BF16:
+    return LIBXSMM_DATATYPE_F32;
+  default:
+    return LIBXSMM_DATATYPE_UNSUPPORTED;
+  }
+}
+
+EXPORT void *xsmm_brgemm_dispatch(int64_t m, int64_t n, int64_t k, int64_t lda,
+                                  int64_t ldb, int64_t ldc,
+                                  int64_t stride_a_in_bytes,
+                                  int64_t stride_b_in_bytes, int64_t in_dtype,
+                                  int64_t out_dtype) {
+  libxsmm_blasint lda_int = lda;
+  libxsmm_blasint ldb_int = ldb;
+  libxsmm_blasint ldc_int = ldc;
+  libxsmm_blasint m_int = m;
+  libxsmm_blasint n_int = n;
+  libxsmm_blasint k_int = k;
+
+  libxsmm_bitfield l_flags = 0;
+  libxsmm_bitfield l_prefetch_flags = 0;
+
+  auto xsmm_in_dtype = static_cast<libxsmm_datatype>(in_dtype);
+  auto xsmm_out_dtype = static_cast<libxsmm_datatype>(out_dtype);
+
+  // LIBXSMM col-major - swap A with B.
+  libxsmm_gemm_shape l_shape;
+  l_shape.m = n_int;
+  l_shape.n = m_int;
+  l_shape.k = k_int;
+  l_shape.lda = ldb_int;
+  l_shape.ldb = lda_int;
+  l_shape.ldc = ldc_int;
+  // TODO: Add support for mixed precision inputs.
+  l_shape.a_in_type = xsmm_in_dtype;
+  l_shape.b_in_type = xsmm_in_dtype;
+  l_shape.out_type = xsmm_out_dtype;
+  // Get accumulator type based on the input data type.
+  // Only the final result is converted back to the specified output type.
+  l_shape.comp_type = getXsmmCompType(xsmm_in_dtype);
+  assert(l_shape.comp_type != LIBXSMM_DATATYPE_UNSUPPORTED &&
+         "unsupported input type for comp_type selection");
+
+  libxsmm_gemm_batch_reduce_config l_brconfig;
+  l_brconfig.br_type = LIBXSMM_GEMM_BATCH_REDUCE_STRIDE;
+
+  // LIBXSMM col-major - swap A with B.
+  l_brconfig.br_stride_a_hint = stride_b_in_bytes;
+  l_brconfig.br_stride_b_hint = stride_a_in_bytes;
+  l_brconfig.br_unroll_hint = 0;
+
+  // Generate the executable JIT code.
+  // Ukernels are cached internally by LIBXSMM.
+  void *sgemm = (void *)libxsmm_dispatch_brgemm(l_shape, l_flags,
+                                                l_prefetch_flags, l_brconfig);
+  if (!sgemm) {
+    fprintf(stderr, "failed to generate brgemm func\n");
+    fprintf(stderr, "in_dtype: %u\n", xsmm_in_dtype);
+    fprintf(stderr, "out_dtype: %u\n", xsmm_out_dtype);
+    printXsmmGemmShape(l_shape, stderr);
+    printXsmmBrgemmCfg(l_brconfig, stderr);
+    exit(-1);
+  }
+
+  return sgemm;
+}
+
+EXPORT void xsmm_brgemm_invoke(void *handle, void *A_ptr, void *B_ptr,
+                               void *C_ptr, int64_t num_batches) {
+  libxsmm_gemm_param gemm_param;
+
+  unsigned long long num_batches_var = num_batches;
+  gemm_param.op.tertiary = (void *)&num_batches_var;
+
+  // LIBXSMM col-major - swap A with B.
+  gemm_param.a.primary = B_ptr;
+  gemm_param.b.primary = A_ptr;
+  gemm_param.c.primary = C_ptr;
+
+  libxsmm_xmmfunction sgemm;
+  sgemm.gemm = reinterpret_cast<libxsmm_gemmfunction>(handle);
+  sgemm.gemm(&gemm_param);
+}
+
+} // extern C

--- a/third_party/cpu/triton_cpu.cc
+++ b/third_party/cpu/triton_cpu.cc
@@ -39,6 +39,14 @@ bool is_onednn_available() {
 #endif
 }
 
+bool is_xsmm_available() {
+#ifdef XSMM_AVAILABLE
+  return true;
+#else
+  return false;
+#endif
+}
+
 namespace py = pybind11;
 
 void init_triton_cpu_passes_ttcpuir(py::module &&m) {
@@ -49,7 +57,8 @@ void init_triton_cpu_passes_ttcpuir(py::module &&m) {
       .value("libmvec", cpu::VecLib::Mvec);
 
   py::enum_<cpu::Ukernels>(m, "Ukernels")
-      .value("OneDNN", cpu::Ukernels::OneDNN);
+      .value("OneDNN", cpu::Ukernels::OneDNN)
+      .value("XSMM", cpu::Ukernels::XSMM);
 
   m.def("add_scalarize", [](mlir::PassManager &pm, bool skip_gather_scatter) {
     pm.addPass(
@@ -163,6 +172,9 @@ void init_triton_cpu_passes_ttcpuir(py::module &&m) {
   m.def("add_ukernels_to_onednn_llvmir", [](mlir::PassManager &pm) {
     pm.addPass(mlir::triton::cpu::createUkernelOpsToOneDNNLLVMPass());
   });
+  m.def("add_ukernels_to_xsmm_llvmir", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::triton::cpu::createUkernelOpsToXSMMLLVMPass());
+  });
   m.def("add_expand_strided_metadata", [](mlir::PassManager &pm) {
     pm.addPass(mlir::memref::createExpandStridedMetadataPass());
   });
@@ -230,6 +242,8 @@ void init_triton_cpu(py::module &&m) {
   });
 
   m.def("onednn_available", is_onednn_available);
+
+  m.def("xsmm_available", is_xsmm_available);
 
   m.def("load_dialects", [](mlir::MLIRContext &context) {
     mlir::DialectRegistry registry;


### PR DESCRIPTION
Adds libxsmm as a new XSMM ukernel target for CPU lowering.
Initial lowering covers basic support for FP32 and BF16 data types across different extensions and architectures.

Summary of changes:
  - Extends ukernel handle creator to allow reuse for both backends
  - Adds prebuilt libxsmm as an optional external build dependency
  - Adds XSMM runtime and lowering pass
