### PR TITLE
Initial support for tensor descriptors

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -128,7 +128,9 @@ jobs:
       - name: Run python unit tests for Intel
         if: matrix.config.target-os == 'ubuntu'
         run: |
-          python -m pytest -s -n 32 --device cpu python/test/unit/language/test_core.py -m cpu
+          python -m pytest -s -n 32 --device cpu -m cpu \
+            python/test/unit/language/test_core.py \
+            python/test/unit/language/test_tensor_descriptor.py
           python -m pytest -s -n 32 --device cpu \
             python/test/unit/cpu/test_math.py \
             python/test/unit/cpu/test_opt.py \

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3247,7 +3247,6 @@ def test_trans_2d(dtype_str, shape, perm, device):
     np.testing.assert_equal(to_numpy(expected), to_numpy(actual))
 
 
-@pytest.mark.xfail(run=False, reason="tensor descriptors NYI")
 @pytest.mark.cpu
 @pytest.mark.interpreter
 @pytest.mark.parametrize("dtype_str", ["int32", "int8"])

--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -7,11 +7,11 @@ import triton.language as tl
 from triton._internal_testing import is_hopper, is_sm12x, is_interpreter, numpy_random, to_triton, unwrap_tensor, tma_dtypes, to_numpy
 from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor
 from typing import Optional
-from triton._internal_testing import is_cuda, is_hip, is_hip_cdna3
+from triton._internal_testing import is_cuda, is_hip, is_hip_cdna3, is_cpu
 from triton.tools.tensor_descriptor import TensorDescriptor
 from triton import CompilationError
 
-
+@pytest.mark.cpu
 @pytest.mark.interpreter
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
 @pytest.mark.parametrize("num_ctas", [1, 2])
@@ -19,6 +19,8 @@ from triton import CompilationError
 def test_tensor_descriptor_load(dtype_str, num_ctas, M_BLOCK, N_BLOCK, device):
     if num_ctas == 2 and (not is_cuda() or torch.cuda.get_device_capability(0)[0] not in (9, 10)):
         pytest.skip("CTAs is unsupported for these cards")
+    if is_cpu() and M_BLOCK > 32 or N_BLOCK > 32:
+        pytest.skip("Large loads unsupported on CPU")
 
     @triton.jit
     def kernel(out_ptr, a_ptr, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
@@ -56,6 +58,7 @@ def test_tensor_descriptor_load(dtype_str, num_ctas, M_BLOCK, N_BLOCK, device):
     torch.testing.assert_close(expect, unwrap_tensor(out))
 
 
+@pytest.mark.cpu
 @pytest.mark.interpreter
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
 @pytest.mark.parametrize("num_ctas", [1, 2])
@@ -63,6 +66,8 @@ def test_tensor_descriptor_load(dtype_str, num_ctas, M_BLOCK, N_BLOCK, device):
 def test_tensor_descriptor_store(dtype_str, num_ctas, M_BLOCK, N_BLOCK, device):
     if num_ctas == 2 and (not is_cuda() or torch.cuda.get_device_capability(0)[0] not in (9, 10)):
         pytest.skip("CTAs is unsupported for these cards")
+    if is_cpu() and M_BLOCK > 32 or N_BLOCK > 32:
+        pytest.skip("Large stores unsupported on CPU")
 
     @triton.jit
     def kernel(out_ptr, a_ptr, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
@@ -110,6 +115,7 @@ def test_tensor_descriptor_store(dtype_str, num_ctas, M_BLOCK, N_BLOCK, device):
 
 
 # Exercise the functional load/store builtins once to ensure they map through.
+@pytest.mark.cpu
 @pytest.mark.interpreter
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
 def test_tensor_descriptor_functional_interface(dtype_str, device):
@@ -156,10 +162,13 @@ def test_tensor_descriptor_functional_interface(dtype_str, device):
     torch.testing.assert_close(unwrap_tensor(inp), unwrap_tensor(out))
 
 
+@pytest.mark.cpu
 @pytest.mark.interpreter
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
 @pytest.mark.parametrize("K_BLOCK", [16, 32, 64, 128])
 def test_tensor_descriptor_load3d(dtype_str, K_BLOCK, device):
+    if is_cpu() and K_BLOCK > 32:
+        pytest.skip("Large loads unsupported on CPU")
 
     @triton.jit
     def kernel(out_ptr, a_ptr, M, N, K, stride_m, stride_n, stride_k, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr,
@@ -204,11 +213,13 @@ def test_tensor_descriptor_load3d(dtype_str, K_BLOCK, device):
     expect = unwrap_tensor(inp)
     torch.testing.assert_close(expect, actual)
 
-
+@pytest.mark.cpu
 @pytest.mark.interpreter
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
 @pytest.mark.parametrize("K_BLOCK", [16, 32, 64, 128])
 def test_tensor_descriptor_store3d(dtype_str, K_BLOCK, device):
+    if is_cpu() and K_BLOCK > 32:
+        pytest.skip("Large stores unsupported on CPU")
 
     @triton.jit
     def kernel(out_ptr, a_ptr, M, N, K, stride_m, stride_n, stride_k, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr,
@@ -253,6 +264,7 @@ def test_tensor_descriptor_store3d(dtype_str, K_BLOCK, device):
     torch.testing.assert_close(expect, actual)
 
 
+@pytest.mark.cpu
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
 @pytest.mark.parametrize("num_ctas", [1, 2])
 @pytest.mark.parametrize("ndim", [1, 2, 3, 4, 5])
@@ -260,6 +272,8 @@ def test_tensor_descriptor_store3d(dtype_str, K_BLOCK, device):
 def test_tensor_descriptor_load_nd(dtype_str, num_ctas, ndim, INNER_BLOCK, device):
     if num_ctas == 2 and (not is_cuda() or torch.cuda.get_device_capability(0)[0] not in (9, 10)):
         pytest.skip("CTAs is unsupported for these cards")
+    if is_cpu() and INNER_BLOCK > 32:
+        pytest.skip("Large block size unsupported on CPU")
 
     @triton.jit
     def kernel(out_ptr, a_ptr, shape, strides, BLOCK_SHAPE):

--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -11,6 +11,7 @@ from triton._internal_testing import is_cuda, is_hip, is_hip_cdna3, is_cpu
 from triton.tools.tensor_descriptor import TensorDescriptor
 from triton import CompilationError
 
+
 @pytest.mark.cpu
 @pytest.mark.interpreter
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
@@ -212,6 +213,7 @@ def test_tensor_descriptor_load3d(dtype_str, K_BLOCK, device):
     actual = unwrap_tensor(out)
     expect = unwrap_tensor(inp)
     torch.testing.assert_close(expect, actual)
+
 
 @pytest.mark.cpu
 @pytest.mark.interpreter

--- a/python/tutorials/cpu-blocked-matmul.py
+++ b/python/tutorials/cpu-blocked-matmul.py
@@ -75,19 +75,17 @@ def block_transpose_combined_kernel(in_a, out_a, in_b, out_b, M, N, K, BLOCK_SIZ
         A_OUT_STRIDE_BLOCK_K: tl.constexpr = BLOCK_SIZE_M * BLOCK_SIZE_K
         for in_block_k in tl.range(in_block_n, A_OUT_BLOCKS_K, N // BLOCK_SIZE_N):
             a_out_block_k = in_block_k
-            a_in_ptr = tl.make_block_ptr(base=in_a, shape=(M, K), strides=(K, 1),
-                                         offsets=(in_block_m * BLOCK_SIZE_M, in_block_k * BLOCK_SIZE_K),
-                                         block_shape=(BLOCK_SIZE_M, BLOCK_SIZE_K), order=(1, 0))
-            a_out_ptr = tl.make_block_ptr(
+            a_in_desc = tl.make_tensor_descriptor(
+                base=in_a, shape=(M, K), strides=(K, 1), block_shape=(BLOCK_SIZE_M, BLOCK_SIZE_K))
+            a_out_desc = tl.make_tensor_descriptor(
                 base=out_a, shape=(A_OUT_BLOCKS_M, A_OUT_BLOCKS_K, A_OUT_BLOCK_SIZE_M, A_OUT_BLOCK_SIZE_K),
                 strides=(A_OUT_STRIDE_BLOCK_M, A_OUT_STRIDE_BLOCK_K, A_OUT_STRIDE_M, 1),
-                offsets=(a_out_block_m, a_out_block_k, 0, 0),
-                block_shape=(1, 1, A_OUT_BLOCK_SIZE_M, A_OUT_BLOCK_SIZE_K), order=(3, 2, 1, 0))
-            val = tl.load(a_in_ptr)
+                block_shape=(1, 1, A_OUT_BLOCK_SIZE_M, A_OUT_BLOCK_SIZE_K))
+            val = a_in_desc.load((in_block_m * BLOCK_SIZE_M, in_block_k * BLOCK_SIZE_K))
             if TRANSPOSED_BLOCK_A:
                 val = val.T
             val = tl.reshape(val, (1, 1, A_OUT_BLOCK_SIZE_M, A_OUT_BLOCK_SIZE_K))
-            tl.store(a_out_ptr, val)
+            a_out_desc.store((a_out_block_m, a_out_block_k, 0, 0), val)
 
     if BLOCKED_B:
         B_PACKED_NUM: tl.constexpr = 32 // in_b.type.element_ty.primitive_bitwidth if PACKED_B else 1
@@ -100,30 +98,28 @@ def block_transpose_combined_kernel(in_a, out_a, in_b, out_b, M, N, K, BLOCK_SIZ
         for in_block_k in tl.range(in_block_m, K // BLOCK_SIZE_K, M // BLOCK_SIZE_M):
             b_out_block_k = in_block_n if TRANSPOSED_B else in_block_k
             b_out_block_n = in_block_k if TRANSPOSED_B else in_block_n
-            b_in_ptr = tl.make_block_ptr(base=in_b, shape=(K, N), strides=(N, 1),
-                                         offsets=(in_block_k * BLOCK_SIZE_K, in_block_n * BLOCK_SIZE_N),
-                                         block_shape=(1, BLOCK_SIZE_N), order=(1, 0))
-            b_out_ptr = tl.make_block_ptr(
+            b_in_desc = tl.make_tensor_descriptor(
+                base=in_b, shape=(K, N), strides=(N, 1), block_shape=(1, BLOCK_SIZE_N))
+            b_out_desc = tl.make_tensor_descriptor(
                 base=out_b, shape=(B_OUT_BLOCKS_K, B_OUT_BLOCKS_N, PACKED_BLOCK_SIZE_K, PACKED_BLOCK_SIZE_N),
                 strides=(B_OUT_STRIDE_BLOCK_K, B_OUT_STRIDE_BLOCK_N, PACKED_BLOCK_SIZE_N, 1),
-                offsets=(b_out_block_k, b_out_block_n, 0, 0), block_shape=(1, 1, 1, PACKED_BLOCK_SIZE_N),
-                order=(3, 2, 1, 0))
+                block_shape=(1, 1, 1, PACKED_BLOCK_SIZE_N))
             for i in tl.range(0, BLOCK_SIZE_K // B_PACKED_NUM):
-                row1 = tl.load(b_in_ptr).reshape((BLOCK_SIZE_N, ))
+                row1 = b_in_desc.load(
+                    (in_block_k * BLOCK_SIZE_K + i * B_PACKED_NUM, in_block_n * BLOCK_SIZE_N)).reshape((BLOCK_SIZE_N, ))
                 if B_PACKED_NUM > 1:
-                    b_in_ptr = tl.advance(b_in_ptr, (1, 0))
-                    row2 = tl.load(b_in_ptr).reshape((BLOCK_SIZE_N, ))
+                    row2 = b_in_desc.load(
+                        (in_block_k * BLOCK_SIZE_K + i * B_PACKED_NUM + 1, in_block_n * BLOCK_SIZE_N)).reshape((BLOCK_SIZE_N, ))
                     if B_PACKED_NUM > 2:
-                        b_in_ptr = tl.advance(b_in_ptr, (1, 0))
-                        row3 = tl.load(b_in_ptr).reshape((BLOCK_SIZE_N, ))
-                        b_in_ptr = tl.advance(b_in_ptr, (1, 0))
-                        row4 = tl.load(b_in_ptr).reshape((BLOCK_SIZE_N, ))
+                        row3 = b_in_desc.load(
+                            (in_block_k * BLOCK_SIZE_K + i * B_PACKED_NUM + 2, in_block_n * BLOCK_SIZE_N)).reshape((BLOCK_SIZE_N, ))
+                        row4 = b_in_desc.load(
+                            (in_block_k * BLOCK_SIZE_K + i * B_PACKED_NUM + 3, in_block_n * BLOCK_SIZE_N)).reshape((BLOCK_SIZE_N, ))
                         row1 = tl.ravel(tl.join(row1, row3))
                         row2 = tl.ravel(tl.join(row2, row4))
                     row1 = tl.ravel(tl.join(row1, row2))
-                tl.store(b_out_ptr, row1.reshape((1, 1, 1, PACKED_BLOCK_SIZE_N)))
-                b_in_ptr = tl.advance(b_in_ptr, (1, 0))
-                b_out_ptr = tl.advance(b_out_ptr, (0, 0, 1, 0))
+                b_out_desc.store(
+                    (b_out_block_k, b_out_block_n, i, 0), row1.reshape((1, 1, 1, PACKED_BLOCK_SIZE_N)))
 
 
 # Matmul kernel that computes a single output block [BLOCK_SIZE_M, BLOCK_SIZE_N]. LHS can be in the
@@ -166,7 +162,7 @@ def matmul_kernel(a_ptr, b_ptr, c_ptr, M, N, K, BLOCK_SIZE_M: tl.constexpr, BLOC
     A_BLOCK_SIZE_K: tl.constexpr = BLOCK_SIZE_M if TRANSPOSED_BLOCK_A else BLOCK_SIZE_K
     A_BLOCKS_M = M // BLOCK_SIZE_M
     A_BLOCKS_K = K // BLOCK_SIZE_K
-    a_stride_k = 1
+    a_stride_k: tl.constexpr = 1
     a_stride_m = A_BLOCK_SIZE_K if BLOCKED_A else K
     a_stride_block_k = A_BLOCK_SIZE_M * A_BLOCK_SIZE_K if BLOCKED_A else A_BLOCK_SIZE_K
     a_stride_block_m = BLOCK_SIZE_M * K
@@ -175,7 +171,7 @@ def matmul_kernel(a_ptr, b_ptr, c_ptr, M, N, K, BLOCK_SIZE_M: tl.constexpr, BLOC
     PACKED_BLOCK_SIZE_K: tl.constexpr = BLOCK_SIZE_K // B_PACKED_NUM if PACKED_B else BLOCK_SIZE_K
     PACKED_BLOCK_SIZE_N: tl.constexpr = BLOCK_SIZE_N * B_PACKED_NUM if PACKED_B else BLOCK_SIZE_N
     assert BLOCKED_B or not TRANSPOSED_B
-    b_stride_n = 1
+    b_stride_n: tl.constexpr = 1
     b_stride_k = PACKED_BLOCK_SIZE_N if BLOCKED_B else N * B_PACKED_NUM
     if TRANSPOSED_B:
         b_stride_block_n = BLOCK_SIZE_N * K
@@ -184,22 +180,19 @@ def matmul_kernel(a_ptr, b_ptr, c_ptr, M, N, K, BLOCK_SIZE_M: tl.constexpr, BLOC
         b_stride_block_n = BLOCK_SIZE_K * BLOCK_SIZE_N if BLOCKED_B else PACKED_BLOCK_SIZE_N
         b_stride_block_k = BLOCK_SIZE_K * N
 
-    a_block_ptr = tl.make_block_ptr(base=a_ptr, shape=(A_BLOCKS_M, A_BLOCKS_K, A_BLOCK_SIZE_M, A_BLOCK_SIZE_K),
-                                    strides=(a_stride_block_m, a_stride_block_k, a_stride_m, a_stride_k),
-                                    offsets=(block_m, 0, 0, 0), block_shape=(1, 1, A_BLOCK_SIZE_M, A_BLOCK_SIZE_K),
-                                    order=(3, 2, 1, 0))
-    b_block_ptr = tl.make_block_ptr(
-        base=b_ptr, shape=(K // BLOCK_SIZE_K, N // BLOCK_SIZE_N, PACKED_BLOCK_SIZE_K, PACKED_BLOCK_SIZE_N),
-        strides=(b_stride_block_k, b_stride_block_n, b_stride_k, b_stride_n), offsets=(0, block_n, 0, 0),
-        block_shape=(1, 1, PACKED_BLOCK_SIZE_K, PACKED_BLOCK_SIZE_N), order=(3, 2, 1, 0))
-    c_block_ptr = tl.make_block_ptr(base=c_ptr, shape=(M, N), strides=(N, 1),
-                                    offsets=(block_m * BLOCK_SIZE_M, block_n * BLOCK_SIZE_N),
-                                    block_shape=(BLOCK_SIZE_M, BLOCK_SIZE_N), order=(1, 0))
+    a_desc = tl.make_tensor_descriptor(base=a_ptr, shape=(A_BLOCKS_M, A_BLOCKS_K, A_BLOCK_SIZE_M, A_BLOCK_SIZE_K),
+                                       strides=(a_stride_block_m, a_stride_block_k, a_stride_m, a_stride_k),
+                                       block_shape=(1, 1, A_BLOCK_SIZE_M, A_BLOCK_SIZE_K))
+    b_desc = tl.make_tensor_descriptor(base=b_ptr,
+                                       shape=(K // BLOCK_SIZE_K, N // BLOCK_SIZE_N, PACKED_BLOCK_SIZE_K, PACKED_BLOCK_SIZE_N),
+                                       strides=(b_stride_block_k, b_stride_block_n, b_stride_k, b_stride_n),
+                                       block_shape=(1, 1, PACKED_BLOCK_SIZE_K, PACKED_BLOCK_SIZE_N))
+    c_desc = tl.make_tensor_descriptor(base=c_ptr, shape=(M, N), strides=(N, 1), block_shape=(BLOCK_SIZE_M, BLOCK_SIZE_N))
 
     c = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=OUT_DTYPE)
-    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
-        a = tl.load(a_block_ptr).reshape((A_BLOCK_SIZE_M, A_BLOCK_SIZE_K))
-        b = tl.load(b_block_ptr).reshape((PACKED_BLOCK_SIZE_K, PACKED_BLOCK_SIZE_N))
+    for block_k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = a_desc.load((block_m, block_k, 0, 0)).reshape((A_BLOCK_SIZE_M, A_BLOCK_SIZE_K))
+        b = b_desc.load((block_k, block_n, 0, 0)).reshape((PACKED_BLOCK_SIZE_K, PACKED_BLOCK_SIZE_N))
 
         if TRANSPOSED_BLOCK_A:
             a = a.T
@@ -209,10 +202,7 @@ def matmul_kernel(a_ptr, b_ptr, c_ptr, M, N, K, BLOCK_SIZE_M: tl.constexpr, BLOC
 
         c += tl.dot(a, b, out_dtype=OUT_DTYPE)
 
-        a_block_ptr = tl.advance(a_block_ptr, (0, 1, 0, 0))
-        b_block_ptr = tl.advance(b_block_ptr, (1, 0, 0, 0))
-
-    tl.store(c_block_ptr, c)
+    c_desc.store((block_m * BLOCK_SIZE_M, block_n * BLOCK_SIZE_N), c)
 
 
 def matmul(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor, ab: torch.Tensor, bb: torch.Tensor, M, N, K, PREPACKED,

--- a/python/tutorials/cpu-blocked-matmul.py
+++ b/python/tutorials/cpu-blocked-matmul.py
@@ -75,8 +75,8 @@ def block_transpose_combined_kernel(in_a, out_a, in_b, out_b, M, N, K, BLOCK_SIZ
         A_OUT_STRIDE_BLOCK_K: tl.constexpr = BLOCK_SIZE_M * BLOCK_SIZE_K
         for in_block_k in tl.range(in_block_n, A_OUT_BLOCKS_K, N // BLOCK_SIZE_N):
             a_out_block_k = in_block_k
-            a_in_desc = tl.make_tensor_descriptor(
-                base=in_a, shape=(M, K), strides=(K, 1), block_shape=(BLOCK_SIZE_M, BLOCK_SIZE_K))
+            a_in_desc = tl.make_tensor_descriptor(base=in_a, shape=(M, K), strides=(K, 1),
+                                                  block_shape=(BLOCK_SIZE_M, BLOCK_SIZE_K))
             a_out_desc = tl.make_tensor_descriptor(
                 base=out_a, shape=(A_OUT_BLOCKS_M, A_OUT_BLOCKS_K, A_OUT_BLOCK_SIZE_M, A_OUT_BLOCK_SIZE_K),
                 strides=(A_OUT_STRIDE_BLOCK_M, A_OUT_STRIDE_BLOCK_K, A_OUT_STRIDE_M, 1),
@@ -98,8 +98,8 @@ def block_transpose_combined_kernel(in_a, out_a, in_b, out_b, M, N, K, BLOCK_SIZ
         for in_block_k in tl.range(in_block_m, K // BLOCK_SIZE_K, M // BLOCK_SIZE_M):
             b_out_block_k = in_block_n if TRANSPOSED_B else in_block_k
             b_out_block_n = in_block_k if TRANSPOSED_B else in_block_n
-            b_in_desc = tl.make_tensor_descriptor(
-                base=in_b, shape=(K, N), strides=(N, 1), block_shape=(1, BLOCK_SIZE_N))
+            b_in_desc = tl.make_tensor_descriptor(base=in_b, shape=(K, N), strides=(N, 1),
+                                                  block_shape=(1, BLOCK_SIZE_N))
             b_out_desc = tl.make_tensor_descriptor(
                 base=out_b, shape=(B_OUT_BLOCKS_K, B_OUT_BLOCKS_N, PACKED_BLOCK_SIZE_K, PACKED_BLOCK_SIZE_N),
                 strides=(B_OUT_STRIDE_BLOCK_K, B_OUT_STRIDE_BLOCK_N, PACKED_BLOCK_SIZE_N, 1),
@@ -109,17 +109,19 @@ def block_transpose_combined_kernel(in_a, out_a, in_b, out_b, M, N, K, BLOCK_SIZ
                     (in_block_k * BLOCK_SIZE_K + i * B_PACKED_NUM, in_block_n * BLOCK_SIZE_N)).reshape((BLOCK_SIZE_N, ))
                 if B_PACKED_NUM > 1:
                     row2 = b_in_desc.load(
-                        (in_block_k * BLOCK_SIZE_K + i * B_PACKED_NUM + 1, in_block_n * BLOCK_SIZE_N)).reshape((BLOCK_SIZE_N, ))
+                        (in_block_k * BLOCK_SIZE_K + i * B_PACKED_NUM + 1, in_block_n * BLOCK_SIZE_N)).reshape(
+                            (BLOCK_SIZE_N, ))
                     if B_PACKED_NUM > 2:
                         row3 = b_in_desc.load(
-                            (in_block_k * BLOCK_SIZE_K + i * B_PACKED_NUM + 2, in_block_n * BLOCK_SIZE_N)).reshape((BLOCK_SIZE_N, ))
+                            (in_block_k * BLOCK_SIZE_K + i * B_PACKED_NUM + 2, in_block_n * BLOCK_SIZE_N)).reshape(
+                                (BLOCK_SIZE_N, ))
                         row4 = b_in_desc.load(
-                            (in_block_k * BLOCK_SIZE_K + i * B_PACKED_NUM + 3, in_block_n * BLOCK_SIZE_N)).reshape((BLOCK_SIZE_N, ))
+                            (in_block_k * BLOCK_SIZE_K + i * B_PACKED_NUM + 3, in_block_n * BLOCK_SIZE_N)).reshape(
+                                (BLOCK_SIZE_N, ))
                         row1 = tl.ravel(tl.join(row1, row3))
                         row2 = tl.ravel(tl.join(row2, row4))
                     row1 = tl.ravel(tl.join(row1, row2))
-                b_out_desc.store(
-                    (b_out_block_k, b_out_block_n, i, 0), row1.reshape((1, 1, 1, PACKED_BLOCK_SIZE_N)))
+                b_out_desc.store((b_out_block_k, b_out_block_n, i, 0), row1.reshape((1, 1, 1, PACKED_BLOCK_SIZE_N)))
 
 
 # Matmul kernel that computes a single output block [BLOCK_SIZE_M, BLOCK_SIZE_N]. LHS can be in the
@@ -183,11 +185,12 @@ def matmul_kernel(a_ptr, b_ptr, c_ptr, M, N, K, BLOCK_SIZE_M: tl.constexpr, BLOC
     a_desc = tl.make_tensor_descriptor(base=a_ptr, shape=(A_BLOCKS_M, A_BLOCKS_K, A_BLOCK_SIZE_M, A_BLOCK_SIZE_K),
                                        strides=(a_stride_block_m, a_stride_block_k, a_stride_m, a_stride_k),
                                        block_shape=(1, 1, A_BLOCK_SIZE_M, A_BLOCK_SIZE_K))
-    b_desc = tl.make_tensor_descriptor(base=b_ptr,
-                                       shape=(K // BLOCK_SIZE_K, N // BLOCK_SIZE_N, PACKED_BLOCK_SIZE_K, PACKED_BLOCK_SIZE_N),
-                                       strides=(b_stride_block_k, b_stride_block_n, b_stride_k, b_stride_n),
-                                       block_shape=(1, 1, PACKED_BLOCK_SIZE_K, PACKED_BLOCK_SIZE_N))
-    c_desc = tl.make_tensor_descriptor(base=c_ptr, shape=(M, N), strides=(N, 1), block_shape=(BLOCK_SIZE_M, BLOCK_SIZE_N))
+    b_desc = tl.make_tensor_descriptor(
+        base=b_ptr, shape=(K // BLOCK_SIZE_K, N // BLOCK_SIZE_N, PACKED_BLOCK_SIZE_K, PACKED_BLOCK_SIZE_N),
+        strides=(b_stride_block_k, b_stride_block_n, b_stride_k, b_stride_n),
+        block_shape=(1, 1, PACKED_BLOCK_SIZE_K, PACKED_BLOCK_SIZE_N))
+    c_desc = tl.make_tensor_descriptor(base=c_ptr, shape=(M, N), strides=(N, 1),
+                                       block_shape=(BLOCK_SIZE_M, BLOCK_SIZE_N))
 
     c = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=OUT_DTYPE)
     for block_k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):

--- a/third_party/cpu/lib/TritonCPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/cpu/lib/TritonCPUToLLVM/MemoryOpToLLVM.cpp
@@ -4,6 +4,7 @@
 
 #include "mlir/Analysis/DataFlowFramework.h"
 #include "mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h"
+#include "mlir/Conversion/LLVMCommon/MemRefBuilder.h"
 #include "mlir/Conversion/LLVMCommon/VectorPattern.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Index/IR/IndexDialect.h"
@@ -308,6 +309,32 @@ struct PtrSelectConversion : public OpConversionPattern<arith::SelectOp> {
   }
 };
 
+struct MakeTensorDescOpConversion
+    : public OpConversionPattern<MakeTensorDescOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(MakeTensorDescOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto structTy = getTypeConverter()->convertType(op.getType());
+    auto i64Ty = IntegerType::get(getContext(), 64);
+
+    auto d = MemRefDescriptor::poison(rewriter, loc, structTy);
+    d.setAlignedPtr(rewriter, loc, adaptor.getBase());
+    d.setConstantOffset(rewriter, loc, 0);
+    for (auto [i, v] : llvm::enumerate(op.getShape()))
+      d.setSize(rewriter, loc, i,
+                LLVM::ZExtOp::create(rewriter, loc, i64Ty, v));
+    for (auto [i, v] : llvm::enumerate(op.getStrides()))
+      d.setStride(rewriter, loc, i, v);
+
+    rewriter.replaceOp(op, static_cast<Value>(d));
+
+    return success();
+  }
+};
+
 struct MemoryOpToLLVM
     : public triton::impl::MemoryOpToLLVMBase<MemoryOpToLLVM> {
   using MemoryOpToLLVMBase::MemoryOpToLLVMBase;
@@ -335,6 +362,7 @@ struct MemoryOpToLLVM
     patterns.add<AddPtrOpConversion>(typeConverter, context);
     patterns.add<PtrBitcastConversion>(typeConverter, context);
     patterns.add<PtrSelectConversion>(typeConverter, context);
+    patterns.add<MakeTensorDescOpConversion>(typeConverter, context);
 
     if (failed(applyPartialConversion(mod, convTarget, std::move(patterns))))
       return signalPassFailure();

--- a/third_party/cpu/lib/TritonCPUToLLVM/TypeConverter.cpp
+++ b/third_party/cpu/lib/TritonCPUToLLVM/TypeConverter.cpp
@@ -18,6 +18,9 @@ TritonCPUToLLVMTypeConverter::TritonCPUToLLVMTypeConverter(
   addConversion([&](x86::amx::TileType type) {
     return LLVM::LLVMX86AMXType::get(type.getContext());
   });
+  addConversion([&](TensorDescType type) -> std::optional<Type> {
+    return convertTritonTensorDescType(type);
+  });
 }
 
 Type TritonCPUToLLVMTypeConverter::convertTritonPointerType(
@@ -50,4 +53,21 @@ Type TritonCPUToLLVMTypeConverter::convertTritonTensorType(
     return VectorType::get(type.getShape(),
                            IntegerType::get(type.getContext(), 64));
   llvm_unreachable("No tensor types are expected in TTCIR");
+}
+
+Type TritonCPUToLLVMTypeConverter::convertTritonTensorDescType(
+    TensorDescType type) {
+  auto ctx = type.getContext();
+  auto rank = type.getBlockType().getRank();
+  auto i64Ty = IntegerType::get(ctx, 64);
+
+  // Mimic a MemRef descriptor.
+  SmallVector<Type, 5> types;
+  types.push_back(LLVM::LLVMPointerType::get(ctx)); // allocated ptr (unused)
+  types.push_back(LLVM::LLVMPointerType::get(ctx)); // aligned ptr (= base ptr)
+  types.push_back(i64Ty);                           // offset (unused)
+  types.push_back(
+      LLVM::LLVMArrayType::get(ctx, i64Ty, rank)); // sizes (= shape)
+  types.push_back(LLVM::LLVMArrayType::get(ctx, i64Ty, rank)); // strides
+  return LLVM::LLVMStructType::getLiteral(ctx, types);
 }

--- a/third_party/cpu/lib/TritonCPUToLLVM/TypeConverter.h
+++ b/third_party/cpu/lib/TritonCPUToLLVM/TypeConverter.h
@@ -18,6 +18,7 @@ public:
 
   Type convertTritonPointerType(triton::PointerType type);
   Type convertTritonTensorType(RankedTensorType type);
+  Type convertTritonTensorDescType(TensorDescType type);
 };
 
 #endif

--- a/third_party/cpu/lib/TritonToTritonCPU/ConvertMemoryOps.cpp
+++ b/third_party/cpu/lib/TritonToTritonCPU/ConvertMemoryOps.cpp
@@ -10,6 +10,7 @@
 #include "mlir/Dialect/Index/IR/IndexOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -135,6 +136,47 @@ struct MemoryOpConversion : public OpConversionPattern<OpT> {
     vector::TransferWriteOp::create(rewriter, vals.getLoc(), vec, memRef,
                                     indices);
     return memRef;
+  }
+
+  void castToIndex(ValueRange values, SmallVectorImpl<Value> &indexValues,
+                   ConversionPatternRewriter &rewriter, Location loc) const {
+    for (Value v : values)
+      indexValues.push_back(arith::IndexCastOp::create(
+          rewriter, loc, rewriter.getIndexType(), v));
+  }
+
+  Type getSignlessElementTy(RankedTensorType tensorTy) const {
+    auto elemTy = tensorTy.getElementType();
+    if (elemTy.isInteger() && !elemTy.isSignlessInteger())
+      elemTy =
+          IntegerType::get(elemTy.getContext(), elemTy.getIntOrFloatBitWidth());
+    return elemTy;
+  }
+
+  Value extractMemRef(MakeTensorDescOp makeDescOp,
+                      ConversionPatternRewriter &rewriter) const {
+    auto getConstOrDynamic = [&](Value v) {
+      if (auto maybeConst = getConstantIntValue(rewriter.getRemappedValue(v)))
+        return *maybeConst;
+      return ShapedType::kDynamic;
+    };
+    SmallVector<int64_t> shape, strides;
+    llvm::transform(makeDescOp.getShape(), std::back_inserter(shape),
+                    getConstOrDynamic);
+    llvm::transform(makeDescOp.getStrides(), std::back_inserter(strides),
+                    getConstOrDynamic);
+
+    auto memRefTy = MemRefType::get(
+        shape, getSignlessElementTy(makeDescOp.getType().getBlockType()),
+        StridedLayoutAttr::get(getContext(), /*offset=*/0, strides));
+
+    // No need for an explicit extract operation, because tensor descriptors are
+    // immutable, and the tt.tensordesc type will be lowered to the same LLVM
+    // representation as the MemRef type.
+    return UnrealizedConversionCastOp::create(
+               rewriter, makeDescOp.getLoc(), memRefTy,
+               rewriter.getRemappedValue(makeDescOp))
+        .getResult(0);
   }
 
 protected:
@@ -583,6 +625,81 @@ struct CpuLoadOpConversion : public MemoryOpConversion<triton::cpu::LoadOp> {
   }
 };
 
+struct DescriptorLoadOpConversion
+    : public MemoryOpConversion<DescriptorLoadOp> {
+  using MemoryOpConversion::MemoryOpConversion;
+
+  LogicalResult
+  matchAndRewrite(DescriptorLoadOp descLoadOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (descLoadOp.getCache() != CacheModifier::NONE)
+      return rewriter.notifyMatchFailure(
+          descLoadOp, "Non-default cache modifier not yet supported");
+    if (descLoadOp.getEvict() != EvictionPolicy::NORMAL)
+      return rewriter.notifyMatchFailure(
+          descLoadOp, "Non-default eviction policy not yet supported");
+
+    auto makeDescOp = descLoadOp.getDesc().getDefiningOp<MakeTensorDescOp>();
+    if (!makeDescOp)
+      return rewriter.notifyMatchFailure(
+          descLoadOp, "Host-side tensor descriptors are unsupported");
+    if (makeDescOp.getPadding() != PaddingOption::PAD_ZERO)
+      return rewriter.notifyMatchFailure(
+          descLoadOp, "Non-default padding mode not yet supported");
+
+    auto loc = descLoadOp.getLoc();
+
+    auto blockTy = makeDescOp.getType().getBlockType();
+    auto elemTy = getSignlessElementTy(blockTy);
+    auto vectorTy = VectorType::get(blockTy.getShape(), elemTy);
+
+    Value memRef = extractMemRef(makeDescOp, rewriter);
+
+    SmallVector<Value> indices;
+    castToIndex(adaptor.getIndices(), indices, rewriter, loc);
+
+    auto paddingVal =
+        arith::ConstantOp::create(rewriter, loc, rewriter.getZeroAttr(elemTy));
+
+    // TODO: The descriptor-load op doesn't give any in-bounds guarantees
+    // (instead expects hardware support), so the transfer_read op needs to do
+    // bounds checking.
+    rewriter.replaceOpWithNewOp<vector::TransferReadOp>(
+        descLoadOp, vectorTy, memRef, indices, paddingVal);
+
+    return success();
+  }
+};
+
+struct DescriptorStoreOpConversion
+    : public MemoryOpConversion<DescriptorStoreOp> {
+  using MemoryOpConversion::MemoryOpConversion;
+
+  LogicalResult
+  matchAndRewrite(DescriptorStoreOp descStoreOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto makeDescOp = descStoreOp.getDesc().getDefiningOp<MakeTensorDescOp>();
+    if (!makeDescOp)
+      return rewriter.notifyMatchFailure(
+          descStoreOp, "Host-side tensor descriptors are unsupported");
+
+    auto loc = descStoreOp.getLoc();
+
+    Value memRef = extractMemRef(makeDescOp, rewriter);
+
+    SmallVector<Value> indices;
+    castToIndex(adaptor.getIndices(), indices, rewriter, loc);
+
+    // TODO: The descriptor-store op doesn't give any in-bounds guarantees
+    // (instead expects hardware support), so the transfer_write op needs to do
+    // bounds checking.
+    rewriter.replaceOpWithNewOp<vector::TransferWriteOp>(
+        descStoreOp, adaptor.getSrc(), memRef, indices);
+
+    return success();
+  }
+};
+
 class MemoryOpConversionTarget : public ConversionTarget {
 public:
   explicit MemoryOpConversionTarget(MLIRContext &ctx) : ConversionTarget(ctx) {
@@ -594,7 +711,9 @@ public:
     addLegalDialect<TritonCPUDialect>();
     addLegalOp<mlir::UnrealizedConversionCastOp>();
 
-    addIllegalOp<mlir::triton::cpu::StoreOp, mlir::triton::cpu::LoadOp>();
+    addIllegalOp<mlir::triton::cpu::StoreOp, mlir::triton::cpu::LoadOp,
+                 mlir::triton::DescriptorLoadOp,
+                 mlir::triton::DescriptorStoreOp>();
 
     // Allow only scalar loads and stores.
     addDynamicallyLegalOp<triton::LoadOp>([](triton::LoadOp loadOp) {
@@ -624,9 +743,10 @@ struct ConvertMemoryOps
     TritonToTritonCPUTypeConverter pointerConverter;
     RewritePatternSet patterns(context);
     patterns.add<LoadOpConversion, StoreOpConversion, CpuStoreOpConversion,
-                 CpuLoadOpConversion>(axisInfoAnalysis, shapeInfoAnalysis,
-                                      pointerConverter, context,
-                                      useGatherScatter);
+                 CpuLoadOpConversion, DescriptorLoadOpConversion,
+                 DescriptorStoreOpConversion>(
+        axisInfoAnalysis, shapeInfoAnalysis, pointerConverter, context,
+        useGatherScatter);
 
     if (failed(applyPartialConversion(mod, convTarget, std::move(patterns))))
       return signalPassFailure();

--- a/third_party/cpu/lib/TritonToTritonCPU/ConvertMemoryOps.cpp
+++ b/third_party/cpu/lib/TritonToTritonCPU/ConvertMemoryOps.cpp
@@ -140,21 +140,15 @@ struct MemoryOpConversion : public OpConversionPattern<OpT> {
 
   void castToIndex(ValueRange values, SmallVectorImpl<Value> &indexValues,
                    ConversionPatternRewriter &rewriter, Location loc) const {
+    Type indexTy = rewriter.getIndexType();
     for (Value v : values)
-      indexValues.push_back(arith::IndexCastOp::create(
-          rewriter, loc, rewriter.getIndexType(), v));
-  }
-
-  Type getSignlessElementTy(RankedTensorType tensorTy) const {
-    auto elemTy = tensorTy.getElementType();
-    if (elemTy.isInteger() && !elemTy.isSignlessInteger())
-      elemTy =
-          IntegerType::get(elemTy.getContext(), elemTy.getIntOrFloatBitWidth());
-    return elemTy;
+      indexValues.push_back(
+          arith::IndexCastOp::create(rewriter, loc, indexTy, v));
   }
 
   Value extractMemRef(MakeTensorDescOp makeDescOp,
                       ConversionPatternRewriter &rewriter) const {
+    // TODO: Extend shape analysis to handle tensor descriptors?
     auto getConstOrDynamic = [&](Value v) {
       if (auto maybeConst = getConstantIntValue(rewriter.getRemappedValue(v)))
         return *maybeConst;
@@ -166,8 +160,12 @@ struct MemoryOpConversion : public OpConversionPattern<OpT> {
     llvm::transform(makeDescOp.getStrides(), std::back_inserter(strides),
                     getConstOrDynamic);
 
+    // Ignore signedness information in tensor descriptors for now.
+    auto elemTy = makeDescOp.getType().getBlockType().getElementType();
+    if (elemTy.isInteger() && !elemTy.isSignlessInteger())
+      elemTy = rewriter.getIntegerType(elemTy.getIntOrFloatBitWidth());
     auto memRefTy = MemRefType::get(
-        shape, getSignlessElementTy(makeDescOp.getType().getBlockType()),
+        shape, elemTy,
         StridedLayoutAttr::get(getContext(), /*offset=*/0, strides));
 
     // No need for an explicit extract operation, because tensor descriptors are
@@ -649,17 +647,16 @@ struct DescriptorLoadOpConversion
 
     auto loc = descLoadOp.getLoc();
 
-    auto blockTy = makeDescOp.getType().getBlockType();
-    auto elemTy = getSignlessElementTy(blockTy);
-    auto vectorTy = VectorType::get(blockTy.getShape(), elemTy);
+    auto vectorTy =
+        cast<VectorType>(getTypeConverter()->convertType(descLoadOp.getType()));
 
     Value memRef = extractMemRef(makeDescOp, rewriter);
 
     SmallVector<Value> indices;
     castToIndex(adaptor.getIndices(), indices, rewriter, loc);
 
-    auto paddingVal =
-        arith::ConstantOp::create(rewriter, loc, rewriter.getZeroAttr(elemTy));
+    auto paddingVal = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getZeroAttr(vectorTy.getElementType()));
 
     // TODO: The descriptor-load op doesn't give any in-bounds guarantees
     // (instead expects hardware support), so the transfer_read op needs to do

--- a/third_party/cpu/lib/TritonToTritonCPU/TypeConverter.h
+++ b/third_party/cpu/lib/TritonToTritonCPU/TypeConverter.h
@@ -12,8 +12,6 @@ public:
   using TypeConverter::convertType;
 
   TritonToTritonCPUTypeConverter();
-
-  Type convertTritonPointerType(triton::PointerType type);
 };
 
 #endif


### PR DESCRIPTION
Upstream removal of the block pointer abstraction in the IR necessitates support for tensor descriptors in the CPU backend. Fortunately, the lowering is similar. This PR adds initial support and enables a small number of tests.