### PR TITLE
Improve tensor descriptor support

### DIFF
--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -345,7 +345,6 @@ def test_tensor_descriptor_store_nd(dtype_str, num_ctas, ndim, INNER_BLOCK, devi
     if is_cpu() and INNER_BLOCK > 32:
         pytest.skip("Large block size unsupported on CPU")
 
-
     @triton.jit
     def kernel(out_ptr, a_ptr, shape, strides, BLOCK_SHAPE):
         desc = tl.make_tensor_descriptor(

--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -334,6 +334,7 @@ def test_tensor_descriptor_load_nd(dtype_str, num_ctas, ndim, INNER_BLOCK, devic
     torch.testing.assert_close(expect, actual)
 
 
+@pytest.mark.cpu
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
 @pytest.mark.parametrize("num_ctas", [1, 2])
 @pytest.mark.parametrize("ndim", [1, 2, 3, 4, 5])
@@ -341,6 +342,9 @@ def test_tensor_descriptor_load_nd(dtype_str, num_ctas, ndim, INNER_BLOCK, devic
 def test_tensor_descriptor_store_nd(dtype_str, num_ctas, ndim, INNER_BLOCK, device):
     if num_ctas == 2 and (not is_cuda() or torch.cuda.get_device_capability(0)[0] not in (9, 10)):
         pytest.skip("CTAs is unsupported for these cards")
+    if is_cpu() and INNER_BLOCK > 32:
+        pytest.skip("Large block size unsupported on CPU")
+
 
     @triton.jit
     def kernel(out_ptr, a_ptr, shape, strides, BLOCK_SHAPE):
@@ -399,6 +403,7 @@ def test_tensor_descriptor_store_nd(dtype_str, num_ctas, ndim, INNER_BLOCK, devi
     torch.testing.assert_close(expect, actual)
 
 
+@pytest.mark.cpu
 @pytest.mark.interpreter
 def test_tensor_descriptor_padding(device):
 
@@ -448,14 +453,16 @@ def test_tensor_descriptor_padding(device):
     in_desc = TensorDescriptor(input, input.shape, input.stride(), dummy_block, padding=padding)
     grid = (triton.cdiv(OM, M_BLOCK), triton.cdiv(ON, N_BLOCK))
     device_tma_load[grid](input, out_device_tma, IM, IN, OM, ON, M_BLOCK, N_BLOCK, padding)
-    host_tma_load[grid](in_desc, out_host_tma, OM, ON, M_BLOCK, N_BLOCK)
+    if not is_cpu():
+        host_tma_load[grid](in_desc, out_host_tma, OM, ON, M_BLOCK, N_BLOCK)
     expected = torch.zeros((OM, ON), device=device, dtype=torch.float32)
     expected[0:IN, 0:IM] = input
     expected[:, IN:ON] = float('nan')
     expected[IM:OM, :] = float('nan')
 
     torch.testing.assert_close(expected, out_device_tma, equal_nan=True)
-    torch.testing.assert_close(expected, out_host_tma, equal_nan=True)
+    if not is_cpu():
+        torch.testing.assert_close(expected, out_host_tma, equal_nan=True)
 
 
 @triton.jit(noinline=True)

--- a/test/TritonCPU/dot-to-amx.mlir
+++ b/test/TritonCPU/dot-to-amx.mlir
@@ -469,3 +469,79 @@ module {
     tt.return loc(#loc)
   } loc(#loc)
 } loc(#loc)
+
+// -----
+
+// Regression test: If an extra buffer is required for the accumulator, ensure
+// that the initial value is stored to the buffer before the AMX tiles are
+// initialized from it.
+
+// CHECK-LABEL: regr_test_uninitialized_acc_buffer
+// CHECK: %[[ACC_TDESC:.+]] = tt.make_tensor_descriptor %arg2,
+// CHECK: %[[ACC_MEMREF:.+]] = triton_cpu.extract_memref %[[ACC_TDESC]]
+// CHECK: %[[ACC_INIT:.+]] = vector.transfer_read %[[ACC_MEMREF]]
+// CHECK: %[[ACC_BUF:.+]] = memref.alloca() {alignment = 64 : i64} : memref<32x32xf32>
+// CHECK: vector.transfer_write %[[ACC_INIT]], %[[ACC_BUF]][%c0, %c0]
+// CHECK-COUNT-4: x86.amx.tile_load %[[ACC_BUF]]
+
+tt.func public @regr_test_uninitialized_acc_buffer(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %arg2: !tt.ptr<f32>, %arg3: i32, %arg4: i32, %arg5: i32) {
+    %cst = arith.constant 0.000000e+00 : bf16
+    %c0 = arith.constant 0 : index
+    %cst_0 = arith.constant 0.000000e+00 : f32
+    %c31_i32 = arith.constant 31 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c32_i64 = arith.constant 32 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c32_i32 = arith.constant 32 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.addi %arg3, %c31_i32 : i32
+    %2 = arith.divsi %1, %c32_i32 : i32
+    %3 = arith.addi %arg4, %c31_i32 : i32
+    %4 = arith.divsi %3, %c32_i32 : i32
+    %5 = arith.muli %4, %c8_i32 : i32
+    %6 = arith.divsi %0, %5 : i32
+    %7 = arith.muli %6, %c8_i32 : i32
+    %8 = arith.subi %2, %7 : i32
+    %9 = arith.minsi %8, %c8_i32 : i32
+    %10 = arith.remsi %0, %9 : i32
+    %11 = arith.addi %7, %10 : i32
+    %12 = arith.remsi %0, %5 : i32
+    %13 = arith.divsi %12, %9 : i32
+    %14 = arith.divsi %arg3, %c32_i32 : i32
+    %15 = arith.divsi %arg5, %c32_i32 : i32
+    %16 = arith.muli %arg5, %c32_i32 : i32
+    %17 = arith.muli %arg4, %c32_i32 : i32
+    %18 = arith.extsi %16 : i32 to i64
+    %19 = arith.extsi %arg5 : i32 to i64
+    %20 = tt.make_tensor_descriptor %arg0, [%14, %15, %c32_i32, %c32_i32], [%18, %c32_i64, %19, %c1_i64] : <bf16>, <1x1x32x32xbf16>
+    %21 = arith.divsi %arg4, %c32_i32 : i32
+    %22 = arith.extsi %17 : i32 to i64
+    %23 = arith.extsi %arg4 : i32 to i64
+    %24 = tt.make_tensor_descriptor %arg1, [%15, %21, %c32_i32, %c32_i32], [%22, %c32_i64, %23, %c1_i64] : <bf16>, <1x1x32x32xbf16>
+    %25 = tt.make_tensor_descriptor %arg2, [%arg3, %arg4], [%23, %c1_i64] : <f32>, <32x32xf32>
+    %26 = arith.muli %11, %c32_i32 : i32
+    %27 = arith.muli %13, %c32_i32 : i32
+    %28 = triton_cpu.extract_memref %25 : <32x32xf32> -> memref<?x?xf32, strided<[?, 1]>>
+    %29 = arith.index_cast %26 : i32 to index
+    %30 = arith.index_cast %27 : i32 to index
+    %31 = vector.transfer_read %28[%29, %30], %cst_0 : memref<?x?xf32, strided<[?, 1]>>, vector<32x32xf32>
+    %32 = arith.addi %arg5, %c31_i32 : i32
+    %33 = arith.divsi %32, %c32_i32 : i32
+    %34 = scf.for %arg6 = %c0_i32 to %33 step %c1_i32 iter_args(%arg7 = %31) -> (vector<32x32xf32>)  : i32 {
+      %35 = triton_cpu.extract_memref %20 : <1x1x32x32xbf16> -> memref<?x?x32x32xbf16, strided<[?, 32, ?, 1]>>
+      %36 = arith.index_cast %11 : i32 to index
+      %37 = arith.index_cast %arg6 : i32 to index
+      %38 = vector.transfer_read %35[%36, %37, %c0, %c0], %cst {in_bounds = [false, false, true, true]} : memref<?x?x32x32xbf16, strided<[?, 32, ?, 1]>>, vector<1x1x32x32xbf16>
+      %39 = vector.shape_cast %38 : vector<1x1x32x32xbf16> to vector<32x32xbf16>
+      %40 = triton_cpu.extract_memref %24 : <1x1x32x32xbf16> -> memref<?x?x32x32xbf16, strided<[?, 32, ?, 1]>>
+      %41 = arith.index_cast %13 : i32 to index
+      %42 = vector.transfer_read %40[%37, %41, %c0, %c0], %cst {in_bounds = [false, false, true, true]} : memref<?x?x32x32xbf16, strided<[?, 32, ?, 1]>>, vector<1x1x32x32xbf16>
+      %43 = vector.shape_cast %42 : vector<1x1x32x32xbf16> to vector<32x32xbf16>
+      %44 = triton_cpu.dot %39, %43, %arg7, inputPrecision = tf32 : vector<32x32xbf16> * vector<32x32xbf16> -> vector<32x32xf32>
+      scf.yield %44 : vector<32x32xf32>
+    }
+    vector.transfer_write %34, %28[%29, %30] : vector<32x32xf32>, memref<?x?xf32, strided<[?, 1]>>
+    tt.return
+  }

--- a/test/TritonCPU/tensor-desc.mlir
+++ b/test/TritonCPU/tensor-desc.mlir
@@ -7,7 +7,7 @@
 // ALL-LABEL: copy_trans
 tt.func public @copy_trans(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32) {
   // ALL: %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
-  
+
   %c1_i64 = arith.constant 1 : i64
   %c8_i32 = arith.constant 8 : i32
   %0 = tt.get_program_id x : i32
@@ -18,13 +18,13 @@ tt.func public @copy_trans(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32,
   %5 = tt.make_tensor_descriptor %arg0, [%arg2, %arg3], [%4, %c1_i64] : <f32>, <8x8xf32>
   %6 = arith.extsi %arg5 : i32 to i64
   %7 = tt.make_tensor_descriptor %arg1, [%arg4, %arg5], [%6, %c1_i64] : <f32>, <8x8xf32>
-  
+
   // CHECK: %[[READ:.+]] = vector.transfer_read %{{.+}}[%{{.+}}, %{{.+}}], %[[ZERO]] :  memref<?x?xf32, strided<[?, 1]>>, vector<8x8xf32>
   // ASSUMEINBOUNDS: %[[READ:.+]] = vector.transfer_read %{{.+}}[%{{.+}}, %{{.+}}], %[[ZERO]] {in_bounds = [true, true]} :  memref<?x?xf32, strided<[?, 1]>>, vector<8x8xf32>
   %8 = tt.descriptor_load %5[%1, %3] : !tt.tensordesc<8x8xf32> -> tensor<8x8xf32>
-  
+
   %9 = tt.trans %8 {order = array<i32: 1, 0>} : tensor<8x8xf32> -> tensor<8x8xf32>
-  
+
   // CHECK: vector.transfer_write %{{.+}}, %{{.+}}[%{{.+}}, %{{.+}}]  : vector<8x8xf32>,  memref<?x?xf32, strided<[?, 1]>>
   // ASSUMEINBOUNDS: vector.transfer_write %{{.+}}, %{{.+}}[%{{.+}}, %{{.+}}] {in_bounds = [true, true]} : vector<8x8xf32>,  memref<?x?xf32, strided<[?, 1]>>
   tt.descriptor_store %7[%1, %3], %9 : !tt.tensordesc<8x8xf32>, tensor<8x8xf32>
@@ -41,7 +41,7 @@ tt.func public @copy_trans(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32,
 // ALL-LABEL: copy_trans_blocked
 tt.func public @copy_trans_blocked(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32) {
   // ALL: %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
-  
+
   %c0_i32 = arith.constant 0 : i32
   %c1_i64 = arith.constant 1 : i64
   %c8_i64 = arith.constant 8 : i64
@@ -60,15 +60,15 @@ tt.func public @copy_trans_blocked(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %ar
   %11 = arith.extsi %10 : i32 to i64
   %12 = arith.extsi %arg5 : i32 to i64
   %13 = tt.make_tensor_descriptor %arg1, [%8, %9, %c8_i32, %c8_i32], [%11, %c8_i64, %12, %c1_i64] : <f32>, <1x1x8x8xf32>
-  
+
   // CHECK: %[[READ:.+]] = vector.transfer_read %{{.+}}[%{{.+}}, %{{.+}}, %c0, %c0], %[[ZERO]] {in_bounds = [false, false, true, true]} : memref<?x?x8x8xf32, strided<[?, 8, ?, 1]>>, vector<1x1x8x8xf32>
   // CHECK: vector.shape_cast %[[READ]] : vector<1x1x8x8xf32> to vector<8x8xf32>
   // ASSUMEINBOUNDS: %[[READ:.+]] = vector.transfer_read %{{.+}}[%{{.+}}, %{{.+}}, %c0, %c0], %[[ZERO]] {in_bounds = [true, true]} : memref<?x?x8x8xf32, strided<[?, 8, ?, 1]>>, vector<8x8xf32>
   %14 = tt.descriptor_load %7[%0, %1, %c0_i32, %c0_i32] : !tt.tensordesc<1x1x8x8xf32> -> tensor<8x8xf32>
-  
+
   %15 = tt.trans %14 {order = array<i32: 1, 0>} : tensor<8x8xf32> -> tensor<8x8xf32>
   %16 = tt.reshape %15 : tensor<8x8xf32> -> tensor<1x1x8x8xf32>
-  
+
   // CHECK: vector.transfer_write %{{.+}}, %{{.+}}[%{{.+}}, %{{.+}}, %c0, %c0] {in_bounds = [false, false, true, true]} : vector<1x1x8x8xf32>, memref<?x?x8x8xf32, strided<[?, 8, ?, 1]>>
   // ASSUMEINBOUNDS: vector.transfer_write %{{.+}}, %{{.+}}[%{{.+}}, %{{.+}}, %c0, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x8x8xf32>, memref<?x?x8x8xf32, strided<[?, 8, ?, 1]>>
   tt.descriptor_store %13[%0, %1, %c0_i32, %c0_i32], %16 : !tt.tensordesc<1x1x8x8xf32>, tensor<1x1x8x8xf32>
@@ -81,7 +81,7 @@ tt.func public @copy_trans_blocked(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %ar
 
 tt.func public @copy_nan(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32) {
   // ALL: %[[NAN:.+]] = arith.constant 0x7FC00000 : f32
-  
+
   %c1_i64 = arith.constant 1 : i64
   %c8_i32 = arith.constant 8 : i32
   %0 = tt.get_program_id x : i32
@@ -92,10 +92,10 @@ tt.func public @copy_nan(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %
   %5 = tt.make_tensor_descriptor %arg0, [%arg2, %arg3], [%4, %c1_i64] {padding = 2 : i32} : <f32>, <8x8xf32>
   %6 = arith.extsi %arg5 : i32 to i64
   %7 = tt.make_tensor_descriptor %arg1, [%arg4, %arg5], [%6, %c1_i64] : <f32>, <8x8xf32>
-  
+
   // ALL: vector.transfer_read %{{.+}}[%{{.+}}, %{{.+}}], %[[NAN]]
   %8 = tt.descriptor_load %5[%1, %3] : !tt.tensordesc<8x8xf32> -> tensor<8x8xf32>
-  
+
   tt.descriptor_store %7[%1, %3], %8 : !tt.tensordesc<8x8xf32>, tensor<8x8xf32>
   tt.return
 }

--- a/test/TritonCPU/tensor-desc.mlir
+++ b/test/TritonCPU/tensor-desc.mlir
@@ -1,0 +1,101 @@
+// RUN: triton-opt %s -split-input-file -triton-cpu-convert-memory-ops -canonicalize | FileCheck %s --check-prefixes=ALL,CHECK
+// RUN: triton-opt %s -split-input-file -triton-cpu-convert-memory-ops="assume-in-bounds=true" -canonicalize | FileCheck %s --check-prefixes=ALL,ASSUMEINBOUNDS
+
+// Check that bounds checking semantics of tensor descriptor loads/stores are
+// correctly propagated to the generated vector.transfer_read/write ops.
+
+// ALL-LABEL: copy_trans
+tt.func public @copy_trans(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32) {
+  // ALL: %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
+  
+  %c1_i64 = arith.constant 1 : i64
+  %c8_i32 = arith.constant 8 : i32
+  %0 = tt.get_program_id x : i32
+  %1 = arith.muli %0, %c8_i32 : i32
+  %2 = tt.get_program_id y : i32
+  %3 = arith.muli %2, %c8_i32 : i32
+  %4 = arith.extsi %arg3 : i32 to i64
+  %5 = tt.make_tensor_descriptor %arg0, [%arg2, %arg3], [%4, %c1_i64] : <f32>, <8x8xf32>
+  %6 = arith.extsi %arg5 : i32 to i64
+  %7 = tt.make_tensor_descriptor %arg1, [%arg4, %arg5], [%6, %c1_i64] : <f32>, <8x8xf32>
+  
+  // CHECK: %[[READ:.+]] = vector.transfer_read %{{.+}}[%{{.+}}, %{{.+}}], %[[ZERO]] :  memref<?x?xf32, strided<[?, 1]>>, vector<8x8xf32>
+  // ASSUMEINBOUNDS: %[[READ:.+]] = vector.transfer_read %{{.+}}[%{{.+}}, %{{.+}}], %[[ZERO]] {in_bounds = [true, true]} :  memref<?x?xf32, strided<[?, 1]>>, vector<8x8xf32>
+  %8 = tt.descriptor_load %5[%1, %3] : !tt.tensordesc<8x8xf32> -> tensor<8x8xf32>
+  
+  %9 = tt.trans %8 {order = array<i32: 1, 0>} : tensor<8x8xf32> -> tensor<8x8xf32>
+  
+  // CHECK: vector.transfer_write %{{.+}}, %{{.+}}[%{{.+}}, %{{.+}}]  : vector<8x8xf32>,  memref<?x?xf32, strided<[?, 1]>>
+  // ASSUMEINBOUNDS: vector.transfer_write %{{.+}}, %{{.+}}[%{{.+}}, %{{.+}}] {in_bounds = [true, true]} : vector<8x8xf32>,  memref<?x?xf32, strided<[?, 1]>>
+  tt.descriptor_store %7[%1, %3], %9 : !tt.tensordesc<8x8xf32>, tensor<8x8xf32>
+  tt.return
+}
+
+// -----
+
+// Same check for a 4D tensor descriptor; here, the rank reduction on the
+// descriptor load needs to be reversed through an explicit vector.shape_cast,
+// as vector.transfer_read doesn't do bounds checking on the leading/non-vector
+// dimensions.
+
+// ALL-LABEL: copy_trans_blocked
+tt.func public @copy_trans_blocked(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32) {
+  // ALL: %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
+  
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i64 = arith.constant 1 : i64
+  %c8_i64 = arith.constant 8 : i64
+  %c8_i32 = arith.constant 8 : i32
+  %0 = tt.get_program_id x : i32
+  %1 = tt.get_program_id y : i32
+  %2 = arith.divsi %arg2, %c8_i32 : i32
+  %3 = arith.divsi %arg3, %c8_i32 : i32
+  %4 = arith.muli %arg3, %c8_i32 : i32
+  %5 = arith.extsi %4 : i32 to i64
+  %6 = arith.extsi %arg3 : i32 to i64
+  %7 = tt.make_tensor_descriptor %arg0, [%2, %3, %c8_i32, %c8_i32], [%5, %c8_i64, %6, %c1_i64] : <f32>, <1x1x8x8xf32>
+  %8 = arith.divsi %arg4, %c8_i32 : i32
+  %9 = arith.divsi %arg5, %c8_i32 : i32
+  %10 = arith.muli %arg5, %c8_i32 : i32
+  %11 = arith.extsi %10 : i32 to i64
+  %12 = arith.extsi %arg5 : i32 to i64
+  %13 = tt.make_tensor_descriptor %arg1, [%8, %9, %c8_i32, %c8_i32], [%11, %c8_i64, %12, %c1_i64] : <f32>, <1x1x8x8xf32>
+  
+  // CHECK: %[[READ:.+]] = vector.transfer_read %{{.+}}[%{{.+}}, %{{.+}}, %c0, %c0], %[[ZERO]] {in_bounds = [false, false, true, true]} : memref<?x?x8x8xf32, strided<[?, 8, ?, 1]>>, vector<1x1x8x8xf32>
+  // CHECK: vector.shape_cast %[[READ]] : vector<1x1x8x8xf32> to vector<8x8xf32>
+  // ASSUMEINBOUNDS: %[[READ:.+]] = vector.transfer_read %{{.+}}[%{{.+}}, %{{.+}}, %c0, %c0], %[[ZERO]] {in_bounds = [true, true]} : memref<?x?x8x8xf32, strided<[?, 8, ?, 1]>>, vector<8x8xf32>
+  %14 = tt.descriptor_load %7[%0, %1, %c0_i32, %c0_i32] : !tt.tensordesc<1x1x8x8xf32> -> tensor<8x8xf32>
+  
+  %15 = tt.trans %14 {order = array<i32: 1, 0>} : tensor<8x8xf32> -> tensor<8x8xf32>
+  %16 = tt.reshape %15 : tensor<8x8xf32> -> tensor<1x1x8x8xf32>
+  
+  // CHECK: vector.transfer_write %{{.+}}, %{{.+}}[%{{.+}}, %{{.+}}, %c0, %c0] {in_bounds = [false, false, true, true]} : vector<1x1x8x8xf32>, memref<?x?x8x8xf32, strided<[?, 8, ?, 1]>>
+  // ASSUMEINBOUNDS: vector.transfer_write %{{.+}}, %{{.+}}[%{{.+}}, %{{.+}}, %c0, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x8x8xf32>, memref<?x?x8x8xf32, strided<[?, 8, ?, 1]>>
+  tt.descriptor_store %13[%0, %1, %c0_i32, %c0_i32], %16 : !tt.tensordesc<1x1x8x8xf32>, tensor<1x1x8x8xf32>
+  tt.return
+}
+
+// -----
+
+// Check NaN padding.
+
+tt.func public @copy_nan(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32) {
+  // ALL: %[[NAN:.+]] = arith.constant 0x7FC00000 : f32
+  
+  %c1_i64 = arith.constant 1 : i64
+  %c8_i32 = arith.constant 8 : i32
+  %0 = tt.get_program_id x : i32
+  %1 = arith.muli %0, %c8_i32 : i32
+  %2 = tt.get_program_id y : i32
+  %3 = arith.muli %2, %c8_i32 : i32
+  %4 = arith.extsi %arg3 : i32 to i64
+  %5 = tt.make_tensor_descriptor %arg0, [%arg2, %arg3], [%4, %c1_i64] {padding = 2 : i32} : <f32>, <8x8xf32>
+  %6 = arith.extsi %arg5 : i32 to i64
+  %7 = tt.make_tensor_descriptor %arg1, [%arg4, %arg5], [%6, %c1_i64] : <f32>, <8x8xf32>
+  
+  // ALL: vector.transfer_read %{{.+}}[%{{.+}}, %{{.+}}], %[[NAN]]
+  %8 = tt.descriptor_load %5[%1, %3] : !tt.tensordesc<8x8xf32> -> tensor<8x8xf32>
+  
+  tt.descriptor_store %7[%1, %3], %8 : !tt.tensordesc<8x8xf32>, tensor<8x8xf32>
+  tt.return
+}

--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -173,7 +173,8 @@ class CPUBackend(BaseBackend):
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
         cpu.passes.ttcpuir.add_scalarize(pm, True)
-        cpu.passes.ttcpuir.add_convert_memory_ops(pm, True)
+        assumeInBounds = os.getenv("TRITON_CPU_ASSUME_IN_BOUNDS", "0") == "1"
+        cpu.passes.ttcpuir.add_convert_memory_ops(pm, True, assumeInBounds)
         cpu.passes.ttcpuir.add_convert_ptr_ops(pm)
         cpu.passes.ttcpuir.add_convert_elementwise_ops(pm)
         cpu.passes.ttcpuir.add_convert_elem_manip_ops(pm)

--- a/third_party/cpu/include/TritonToTritonCPU/Passes.h
+++ b/third_party/cpu/include/TritonToTritonCPU/Passes.h
@@ -25,7 +25,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createConvertElementwiseOps();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertElemManipOps();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertMemoryOps();
 std::unique_ptr<OperationPass<ModuleOp>>
-createConvertMemoryOps(bool useGatherScatter);
+createConvertMemoryOps(bool useGatherScatter, bool assumeInBounds);
 std::unique_ptr<OperationPass<ModuleOp>> createConvertPtrOps();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertDotOp();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertControlFlowOps();

--- a/third_party/cpu/include/TritonToTritonCPU/Passes.td
+++ b/third_party/cpu/include/TritonToTritonCPU/Passes.td
@@ -13,6 +13,9 @@ def ConvertMemoryOps : Pass<"triton-cpu-convert-memory-ops", "mlir::ModuleOp"> {
         Option<"useGatherScatter", "use-gather-scatter",
                "bool", /*default*/"false",
                "Use Gather or Scatter to lower memory ops.">,
+        Option<"assumeInBounds", "assume-in-bounds",
+               "bool", /*default*/"false",
+               "Assume all tensor descriptor memory accesses are in bounds.">
     ];
 
     let constructor = "mlir::triton::cpu::createConvertMemoryOps()";

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToAMX.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToAMX.cpp
@@ -639,7 +639,7 @@ LogicalResult convertCandidate(AmxDotOpCandidate &candidate,
     // If accumulator is bufferized then we should move initial values before
     // the loop.
     OpBuilder::InsertionGuard g(rewriter);
-    if (candidate.keepAccInBuf)
+    if (candidate.keepAccInBuf || candidate.keepAccOnTiles)
       rewriter.setInsertionPoint(forOp);
     accBuf =
         prepareTensorBuffer(loc, accToStore, false, !candidate.keepAccInBuf,

--- a/third_party/cpu/lib/TritonToTritonCPU/ConvertMemoryOps.cpp
+++ b/third_party/cpu/lib/TritonToTritonCPU/ConvertMemoryOps.cpp
@@ -45,10 +45,11 @@ struct MemoryOpConversion : public OpConversionPattern<OpT> {
 
   MemoryOpConversion(ModuleAxisInfoAnalysis &axisInfoAnalysis,
                      TypeConverter &typeConverter, MLIRContext *context,
-                     bool useGatherScatter)
+                     bool useGatherScatter, bool assumeInBounds)
       : OpConversionPattern<OpT>(typeConverter, context),
         axisAnalysis(axisInfoAnalysis) {
     this->useGatherScatter = useGatherScatter;
+    this->assumeInBounds = assumeInBounds;
   }
 
   Value extractScalarPointer(Location loc, Value ptrs,
@@ -150,6 +151,7 @@ struct MemoryOpConversion : public OpConversionPattern<OpT> {
 protected:
   ModuleAxisInfoAnalysis &axisAnalysis;
   bool useGatherScatter;
+  bool assumeInBounds;
 };
 
 struct LoadOpConversion : public MemoryOpConversion<triton::LoadOp> {
@@ -535,29 +537,50 @@ struct DescriptorLoadOpConversion
     if (!makeDescOp)
       return rewriter.notifyMatchFailure(
           descLoadOp, "Host-side tensor descriptors are unsupported");
-    if (makeDescOp.getPadding() != PaddingOption::PAD_ZERO)
-      return rewriter.notifyMatchFailure(
-          descLoadOp, "Non-default padding mode not yet supported");
 
     auto loc = descLoadOp.getLoc();
 
     auto vectorTy =
         cast<VectorType>(getTypeConverter()->convertType(descLoadOp.getType()));
+    auto readVectorTy = vectorTy;
 
     Value memRef = extractMemRef(makeDescOp, rewriter);
+    auto memRefTy = cast<MemRefType>(memRef.getType());
+
+    if (!assumeInBounds && vectorTy.getRank() < memRefTy.getRank()) {
+      // Enforce equals ranks, because a ranked-reduced vector.transfer_read
+      // doesn't model out-of-bounds checks for the leading/non-vector
+      // dimensions.
+      SmallVector<int64_t> extShape(memRefTy.getRank(), 1);
+      llvm::copy(vectorTy.getShape(),
+                 extShape.begin() + (memRefTy.getRank() - vectorTy.getRank()));
+      readVectorTy = VectorType::get(extShape, vectorTy.getElementType());
+    }
 
     SmallVector<Value> indices;
     castToIndex(adaptor.getIndices(), indices, rewriter, loc);
 
-    auto paddingVal = arith::ConstantOp::create(
-        rewriter, loc, rewriter.getZeroAttr(vectorTy.getElementType()));
+    Value paddingVal;
+    switch (makeDescOp.getPadding()) {
+    case PaddingOption::PAD_ZERO:
+      paddingVal = arith::ConstantOp::create(
+          rewriter, loc, rewriter.getZeroAttr(vectorTy.getElementType()));
+      break;
+    case PaddingOption::PAD_NAN:
+      auto elemTy = cast<FloatType>(vectorTy.getElementType());
+      paddingVal = arith::ConstantFloatOp::create(
+          rewriter, loc, elemTy,
+          llvm::APFloat::getNaN(elemTy.getFloatSemantics()));
+      break;
+    }
 
-    // TODO: The descriptor-load op doesn't give any in-bounds guarantees
-    // (instead expects hardware support), so the transfer_read op needs to do
-    // bounds checking.
-    rewriter.replaceOpWithNewOp<vector::TransferReadOp>(
-        descLoadOp, vectorTy, memRef, indices, paddingVal);
+    SmallVector<bool> inBounds(readVectorTy.getRank(), assumeInBounds);
+    Value res = vector::TransferReadOp::create(
+        rewriter, loc, readVectorTy, memRef, indices, paddingVal, inBounds);
+    if (readVectorTy != vectorTy)
+      res = vector::ShapeCastOp::create(rewriter, loc, vectorTy, res);
 
+    rewriter.replaceOp(descLoadOp, res);
     return success();
   }
 };
@@ -576,16 +599,25 @@ struct DescriptorStoreOpConversion
 
     auto loc = descStoreOp.getLoc();
 
+    Value vecToStore = adaptor.getSrc();
     Value memRef = extractMemRef(makeDescOp, rewriter);
+
+    auto vectorTy = cast<VectorType>(vecToStore.getType());
+    auto memRefTy = cast<MemRefType>(memRef.getType());
+    if (vectorTy.getRank() != memRefTy.getRank()) {
+      // The frontend doesn't rank-reduce descriptor stores currently, but if it
+      // does in the future, we could handle that case similarly to loads.
+      return rewriter.notifyMatchFailure(
+          descStoreOp, "Rank of the value to store must match rank of the "
+                       "memref extracted from the descriptor");
+    }
 
     SmallVector<Value> indices;
     castToIndex(adaptor.getIndices(), indices, rewriter, loc);
 
-    // TODO: The descriptor-store op doesn't give any in-bounds guarantees
-    // (instead expects hardware support), so the transfer_write op needs to do
-    // bounds checking.
+    SmallVector<bool> inBounds(vectorTy.getRank(), assumeInBounds);
     rewriter.replaceOpWithNewOp<vector::TransferWriteOp>(
-        descStoreOp, adaptor.getSrc(), memRef, indices);
+        descStoreOp, vecToStore, memRef, indices, inBounds);
 
     return success();
   }
@@ -620,8 +652,9 @@ struct ConvertMemoryOps
     : public triton::cpu::impl::ConvertMemoryOpsBase<ConvertMemoryOps> {
   ConvertMemoryOps() = default;
 
-  ConvertMemoryOps(bool useGatherScatter) {
+  ConvertMemoryOps(bool useGatherScatter, bool assumeInBounds) {
     this->useGatherScatter = useGatherScatter;
+    this->assumeInBounds = assumeInBounds;
   }
 
   void runOnOperation() override {
@@ -634,8 +667,9 @@ struct ConvertMemoryOps
     RewritePatternSet patterns(context);
     patterns.add<LoadOpConversion, StoreOpConversion, CpuStoreOpConversion,
                  CpuLoadOpConversion, DescriptorLoadOpConversion,
-                 DescriptorStoreOpConversion>(
-        axisInfoAnalysis, pointerConverter, context, useGatherScatter);
+                 DescriptorStoreOpConversion>(axisInfoAnalysis,
+                                              pointerConverter, context,
+                                              useGatherScatter, assumeInBounds);
 
     if (failed(applyPartialConversion(mod, convTarget, std::move(patterns))))
       return signalPassFailure();
@@ -653,8 +687,8 @@ std::unique_ptr<OperationPass<ModuleOp>> createConvertMemoryOps() {
 }
 
 std::unique_ptr<OperationPass<ModuleOp>>
-createConvertMemoryOps(bool useGatherScatter) {
-  return std::make_unique<ConvertMemoryOps>(useGatherScatter);
+createConvertMemoryOps(bool useGatherScatter, bool assumeInBounds) {
+  return std::make_unique<ConvertMemoryOps>(useGatherScatter, assumeInBounds);
 }
 
 } // namespace cpu

--- a/third_party/cpu/lib/TritonToTritonCPU/ConvertMemoryOps.cpp
+++ b/third_party/cpu/lib/TritonToTritonCPU/ConvertMemoryOps.cpp
@@ -566,12 +566,16 @@ struct DescriptorLoadOpConversion
       paddingVal = arith::ConstantOp::create(
           rewriter, loc, rewriter.getZeroAttr(vectorTy.getElementType()));
       break;
-    case PaddingOption::PAD_NAN:
+    case PaddingOption::PAD_NAN: {
       auto elemTy = cast<FloatType>(vectorTy.getElementType());
       paddingVal = arith::ConstantFloatOp::create(
           rewriter, loc, elemTy,
           llvm::APFloat::getNaN(elemTy.getFloatSemantics()));
       break;
+    }
+    default:
+      return rewriter.notifyMatchFailure(
+          descLoadOp, "Unsupported padding option in tensor descriptor");
     }
 
     SmallVector<bool> inBounds(readVectorTy.getRank(), assumeInBounds);

--- a/third_party/cpu/triton_cpu.cc
+++ b/third_party/cpu/triton_cpu.cc
@@ -64,8 +64,10 @@ void init_triton_cpu_passes_ttcpuir(py::module &&m) {
         mlir::triton::cpu::createScalarizeUsingForOpPass(skip_gather_scatter));
   });
   m.def("add_convert_memory_ops", [](mlir::PassManager &pm,
-                                     bool use_gather_scatter) {
-    pm.addPass(mlir::triton::cpu::createConvertMemoryOps(use_gather_scatter));
+                                     bool use_gather_scatter,
+                                     bool assume_in_bounds) {
+    pm.addPass(mlir::triton::cpu::createConvertMemoryOps(use_gather_scatter,
+                                                         assume_in_bounds));
   });
   m.def("add_convert_ptr_ops", [](mlir::PassManager &pm) {
     pm.addPass(mlir::triton::cpu::createConvertPtrOps());


### PR DESCRIPTION
The out-of-bounds handling for tensor descriptor load/store already aligns with `vector.transfer_read/write` semantics, however we have to ensure that the read/write ops are not rank-reducing, because bounds checks are only performed for the vector dimensions.

This PR also introduces an environment variable `TRITON_CPU_ASSUME_IN_BOUNDS` to assess performance without any bounds checks. We should add an analysis pass to eliminate bounds checks (and make this user intervention unnecessary) in the future.