### PR TITLE
[DotToNanokernel] Add support for pre-packed versions of patterns

### DIFF
--- a/python/tutorials/cpu-sfc-matmul.py
+++ b/python/tutorials/cpu-sfc-matmul.py
@@ -15,28 +15,68 @@ import sys
 from gilbert_d2xy import gilbert_d2xy
 
 
-# Transforms the B matrix into a tensor of shape:
+# Transforms the A matrix into a tensor of shape:
+#
+#  (BLOCKS_M, BLOCKS_K, BLOCK_SIZE_M, BLOCK_SIZE_K)
+#
+# and the B matrix into a tensor of shape:
 #
 #  (BLOCKS_N, BLOCKS_K, BLOCK_SIZE_K, BLOCK_SIZE_N)
 #
-# Data is blocked into contiguous chunks of memory. Neighboring blocks in the K
-# dimension will also be neighboring in memory.
+# Data is block-packed into contiguous chunks of memory. Neighboring blocks in
+# the K dimension will also be neighboring in memory. In addition, the B matrix
+# is also packed in VNNI format.
 @triton.jit
-def block_transpose_pack_kernel(in_ptr, out_ptr, sfc_map_ptr, N, K, BLOCK_SIZE_N: tl.constexpr,
-                                BLOCK_SIZE_K: tl.constexpr):
+def block_transpose_pack_kernel(a_in_ptr, a_out_ptr, a_sfc_map_ptr, b_in_ptr, b_out_ptr, b_sfc_map_ptr, M, N, K,
+                                BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr):
+    VNNI: tl.constexpr = 32 // b_in_ptr.type.element_ty.primitive_bitwidth
+
     pid = tl.program_id(axis=0)
-    block_k = tl.load(sfc_map_ptr + 2 * pid)
-    block_n = tl.load(sfc_map_ptr + 2 * pid + 1)
 
-    in_desc = tl.make_tensor_descriptor(base=in_ptr, shape=(K, N), strides=(N, 1),
-                                        block_shape=(BLOCK_SIZE_K, BLOCK_SIZE_N))
-    out_desc = tl.make_tensor_descriptor(base=out_ptr,
-                                         shape=(N // BLOCK_SIZE_N, K // BLOCK_SIZE_K, BLOCK_SIZE_K, BLOCK_SIZE_N),
-                                         strides=(BLOCK_SIZE_N * K, BLOCK_SIZE_K * BLOCK_SIZE_N, BLOCK_SIZE_N, 1),
-                                         block_shape=(1, 1, BLOCK_SIZE_K, BLOCK_SIZE_N))
+    BLOCKS_M = M // BLOCK_SIZE_M
+    BLOCKS_N = N // BLOCK_SIZE_N
+    BLOCKS_K = K // BLOCK_SIZE_K
 
-    block = in_desc.load((block_k * BLOCK_SIZE_K, block_n * BLOCK_SIZE_N)).reshape((1, 1, BLOCK_SIZE_K, BLOCK_SIZE_N))
-    out_desc.store((block_n, block_k, 0, 0), block)
+    # Block-pack A
+    if pid < BLOCKS_M * BLOCKS_K:
+        block_m = tl.load(a_sfc_map_ptr + 2 * pid)
+        block_k = tl.load(a_sfc_map_ptr + 2 * pid + 1)
+
+        a_in_desc = tl.make_tensor_descriptor(base=a_in_ptr, shape=(M, K), strides=(K, 1),
+                                              block_shape=(BLOCK_SIZE_M, BLOCK_SIZE_K))
+        a_out_desc = tl.make_tensor_descriptor(base=a_out_ptr, shape=(BLOCKS_M, BLOCKS_K, BLOCK_SIZE_M, BLOCK_SIZE_K),
+                                               strides=(BLOCK_SIZE_M * K, BLOCK_SIZE_M * BLOCK_SIZE_K, BLOCK_SIZE_K, 1),
+                                               block_shape=(1, 1, BLOCK_SIZE_M, BLOCK_SIZE_K))
+
+        block = a_in_desc.load((block_m * BLOCK_SIZE_M, block_k * BLOCK_SIZE_K)).reshape(
+            (1, 1, BLOCK_SIZE_M, BLOCK_SIZE_K))
+        a_out_desc.store((block_m, block_k, 0, 0), block)
+
+    # Block-and-VNNI-pack B
+    if pid < BLOCKS_K * BLOCKS_N:
+        block_k = tl.load(b_sfc_map_ptr + 2 * pid)
+        block_n = tl.load(b_sfc_map_ptr + 2 * pid + 1)
+
+        b_in_desc = tl.make_tensor_descriptor(base=b_in_ptr, shape=(K, N), strides=(N, 1),
+                                              block_shape=(1, BLOCK_SIZE_N))
+        b_out_desc = tl.make_tensor_descriptor(
+            base=b_out_ptr, shape=(BLOCKS_N, BLOCKS_K, BLOCK_SIZE_K // VNNI, BLOCK_SIZE_N * VNNI),
+            strides=(BLOCK_SIZE_N * K, BLOCK_SIZE_K * BLOCK_SIZE_N, BLOCK_SIZE_N * VNNI, 1),
+            block_shape=(1, 1, 1, BLOCK_SIZE_N * VNNI))
+        for i in tl.range(0, BLOCK_SIZE_K // VNNI):
+            row1 = b_in_desc.load((block_k * BLOCK_SIZE_K + i * VNNI, block_n * BLOCK_SIZE_N)).reshape((BLOCK_SIZE_N, ))
+            if VNNI > 1:
+                row2 = b_in_desc.load((block_k * BLOCK_SIZE_K + i * VNNI + 1, block_n * BLOCK_SIZE_N)).reshape(
+                    (BLOCK_SIZE_N, ))
+                if VNNI > 2:
+                    row3 = b_in_desc.load((block_k * BLOCK_SIZE_K + i * VNNI + 2, block_n * BLOCK_SIZE_N)).reshape(
+                        (BLOCK_SIZE_N, ))
+                    row4 = b_in_desc.load((block_k * BLOCK_SIZE_K + i * VNNI + 3, block_n * BLOCK_SIZE_N)).reshape(
+                        (BLOCK_SIZE_N, ))
+                    row1 = tl.ravel(tl.join(row1, row3))
+                    row2 = tl.ravel(tl.join(row2, row4))
+                row1 = tl.ravel(tl.join(row1, row2))
+            b_out_desc.store((block_n, block_k, i, 0), row1.reshape((1, 1, 1, BLOCK_SIZE_N * VNNI)))
 
 
 # Matmul kernel using the space curve filling approach in https://arxiv.org/abs/2601.16294v1,
@@ -51,22 +91,26 @@ def block_transpose_pack_kernel(in_ptr, out_ptr, sfc_map_ptr, N, K, BLOCK_SIZE_N
 def sfc_kernel(a_ptr, b_ptr, c_ptr, sfc_map_ptr, M, N, K, ik, BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr,
                BLOCK_SIZE_K: tl.constexpr, DTYPE: tl.constexpr, ACC_DTYPE: tl.constexpr,
                BLOCKING_FACTOR_K: tl.constexpr):
+    VNNI: tl.constexpr = 32 // b_ptr.type.element_ty.primitive_bitwidth
+
     BLOCKS_M = M // BLOCK_SIZE_M
     BLOCKS_N = N // BLOCK_SIZE_N
     BLOCKS_K = K // BLOCK_SIZE_K
     BLOCKS_K_PER_PROG = BLOCKS_K // BLOCKING_FACTOR_K
+
     pid = tl.program_id(axis=0)
     block_m = tl.load(sfc_map_ptr + 2 * pid)
     block_n = tl.load(sfc_map_ptr + 2 * pid + 1)
     block_k = ik * BLOCKS_K_PER_PROG
 
     a_desc = tl.make_tensor_descriptor(base=a_ptr, shape=(BLOCKS_M, BLOCKS_K, BLOCK_SIZE_M, BLOCK_SIZE_K),
-                                       strides=(BLOCK_SIZE_M * K, BLOCK_SIZE_K, K, 1),
+                                       strides=(BLOCK_SIZE_M * K, BLOCK_SIZE_M * BLOCK_SIZE_K, BLOCK_SIZE_K, 1),
                                        block_shape=(1, 1, BLOCK_SIZE_M, BLOCK_SIZE_K))
 
-    b_desc = tl.make_tensor_descriptor(base=b_ptr, shape=(BLOCKS_N, BLOCKS_K, BLOCK_SIZE_K, BLOCK_SIZE_N),
-                                       strides=(BLOCK_SIZE_N * K, BLOCK_SIZE_K * BLOCK_SIZE_N, BLOCK_SIZE_N, 1),
-                                       block_shape=(1, 1, BLOCK_SIZE_K, BLOCK_SIZE_N))
+    b_desc = tl.make_tensor_descriptor(base=b_ptr,
+                                       shape=(BLOCKS_N, BLOCKS_K, BLOCK_SIZE_K // VNNI, BLOCK_SIZE_N * VNNI),
+                                       strides=(BLOCK_SIZE_N * K, BLOCK_SIZE_K * BLOCK_SIZE_N, BLOCK_SIZE_N * VNNI, 1),
+                                       block_shape=(1, 1, BLOCK_SIZE_K // VNNI, BLOCK_SIZE_N * VNNI))
 
     c_desc = tl.make_tensor_descriptor(base=c_ptr, shape=(BLOCKS_M, BLOCKS_N, BLOCK_SIZE_M, BLOCK_SIZE_N),
                                        strides=(BLOCK_SIZE_M * N, BLOCK_SIZE_N, N, 1),
@@ -80,7 +124,9 @@ def sfc_kernel(a_ptr, b_ptr, c_ptr, sfc_map_ptr, M, N, K, ik, BLOCK_SIZE_M: tl.c
 
     for block_ki in range(block_k, block_k + BLOCKS_K_PER_PROG):
         a = a_desc.load([block_m, block_ki, 0, 0]).reshape((BLOCK_SIZE_M, BLOCK_SIZE_K))
-        b = b_desc.load([block_n, block_ki, 0, 0]).reshape((BLOCK_SIZE_K, BLOCK_SIZE_N))
+        b = b_desc.load([block_n, block_ki, 0, 0]).reshape((BLOCK_SIZE_K // VNNI, BLOCK_SIZE_N * VNNI))
+
+        b = tl.extra.cpu.vnni_decode(b)
 
         c = tl.dot(a, b, acc=c, out_dtype=ACC_DTYPE)
 
@@ -94,26 +140,29 @@ def make_sfc_tensor(x, y, dtype=torch.int32, device='cpu'):
     return torch.tensor([c for xy in gilbert for c in xy], dtype=dtype, device=device)
 
 
-def matmul(a: torch.Tensor, b: torch.Tensor, M, N, K, blocking_factor_k=1):
+def matmul(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor, ap: torch.Tensor, bp: torch.Tensor, M, N, K,
+           blocking_factor_k=1):
     assert (M % BLOCK_SIZE_M == 0) and (N % BLOCK_SIZE_N == 0) and (K % BLOCK_SIZE_K == 0), \
            "Masking currently not supported, matrix dimensions must be multiples of block size"
 
-    sfc_map_mn = make_sfc_tensor(M // BLOCK_SIZE_M, N // BLOCK_SIZE_N)
-    sfc_map_kn = make_sfc_tensor(K // BLOCK_SIZE_K, N // BLOCK_SIZE_N)
+    BLOCKS_M = M // BLOCK_SIZE_M
+    BLOCKS_N = N // BLOCK_SIZE_N
+    BLOCKS_K = K // BLOCK_SIZE_K
 
-    bp = torch.empty((N // BLOCK_SIZE_N, K // BLOCK_SIZE_K, BLOCK_SIZE_K, BLOCK_SIZE_N), device=b.device, dtype=b.dtype)
-    c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    sfc_map_mn = make_sfc_tensor(BLOCKS_M, BLOCKS_N)
+    sfc_map_mk = make_sfc_tensor(BLOCKS_M, BLOCKS_K)
+    sfc_map_kn = make_sfc_tensor(BLOCKS_K, BLOCKS_N)
 
     tt_dtype = tl.bfloat16 if a.dtype == torch.bfloat16 else tl.int8
     tt_acc_dtype = tl.float32 if a.dtype == torch.bfloat16 else tl.int32
 
-    block_transpose_pack_kernel[((K // BLOCK_SIZE_K) * (N // BLOCK_SIZE_N), )](b, bp, sfc_map_kn, N, K,
-                                                                               BLOCK_SIZE_N=BLOCK_SIZE_N,
-                                                                               BLOCK_SIZE_K=BLOCK_SIZE_K,
-                                                                               assume_in_bounds=True)
+    num_blocks = max(BLOCKS_M * BLOCKS_K, BLOCKS_K * BLOCKS_N)
+    block_transpose_pack_kernel[(num_blocks, )](a, ap, sfc_map_mk, b, bp, sfc_map_kn, M, N, K,
+                                                BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N,
+                                                BLOCK_SIZE_K=BLOCK_SIZE_K, assume_in_bounds=True)
 
     for ik in range(blocking_factor_k):
-        sfc_kernel[((M // BLOCK_SIZE_M) * (N // BLOCK_SIZE_N), )](a, bp, c, sfc_map_mn, M, N, K, ik,
+        sfc_kernel[((M // BLOCK_SIZE_M) * (N // BLOCK_SIZE_N), )](ap, bp, c, sfc_map_mn, M, N, K, ik,
                                                                   BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N,
                                                                   BLOCK_SIZE_K=BLOCK_SIZE_K, DTYPE=tt_dtype,
                                                                   ACC_DTYPE=tt_acc_dtype,
@@ -182,12 +231,13 @@ print(f"Running unit test with "
       f"M={M}, N={N}, K={K} dtype={dtype_str} "
       f"BLOCK_SIZE_M={BLOCK_SIZE_M}, BLOCK_SIZE_N={BLOCK_SIZE_N}, BLOCK_SIZE_K={BLOCK_SIZE_K}...")
 
-torch_output = torch.matmul(a, b)
+torch_output = torch.empty((M, N), device='cpu', dtype=dtype)
+torch.matmul(a, b, out=torch_output)
 sfc_map_mn = make_sfc_tensor(M // BLOCK_SIZE_M, N // BLOCK_SIZE_N)
 sfc_map_kn = make_sfc_tensor(K // BLOCK_SIZE_K, N // BLOCK_SIZE_N)
 
-triton_output = matmul(a, b, M=M, N=N, K=K, blocking_factor_k=1)
-# print(triton_output)
+triton_output = torch.empty((M, N), device='cpu', dtype=dtype)
+matmul(a, b, triton_output, torch.empty_like(a), torch.empty_like(b), M=M, N=N, K=K, blocking_factor_k=1)
 
 if torch.allclose(triton_output, torch_output, atol=1e-5, rtol=1e-2):
     print("✅ TritonCPU pre-packed SFC and TorchCPU match")
@@ -276,20 +326,23 @@ def benchmark(M, N, K, provider):
     n_layers = calculate_layers(M, N, K, dtype)
     a = rand_a[:n_layers * M * K].reshape(n_layers, M, K)
     b = rand_b[:n_layers * K * N].reshape(n_layers, K, N)
+    c = torch.empty((n_layers, M, N), device='cpu', dtype=dtype)
 
     quantiles = [0.5, 0.2, 0.8]
     if backend == 'torch-cpu-native':
 
         def doit():
             for i in range(n_layers):
-                torch.matmul(a[i % n_layers], b[i % n_layers])
+                torch.matmul(a[i % n_layers], b[i % n_layers], out=c[i % n_layers])
 
         ms, min_ms, max_ms = triton.testing.do_bench(doit, quantiles=quantiles, rep=10000)  # run for 10 seconds
     elif backend == 'triton-cpu':
+        ap = torch.empty((M, K), device=a.device, dtype=a.dtype)
+        bp = torch.empty((K, N), device=b.device, dtype=b.dtype)
 
         def doit():
             for i in range(n_layers):
-                matmul(a[i % n_layers], b[i % n_layers], M, N, K, blocking_factor_k=sfc_bfk)
+                matmul(a[i % n_layers], b[i % n_layers], c[i % n_layers], ap, bp, M, N, K, blocking_factor_k=sfc_bfk)
 
         ms, min_ms, max_ms = triton.testing.do_bench(
             doit, quantiles=quantiles, measure_time_with_hooks=False,  # also capture potential Python loop overhead

--- a/python/tutorials/cpu-sfc-matmul.py
+++ b/python/tutorials/cpu-sfc-matmul.py
@@ -203,7 +203,7 @@ elif args.target == 'avx_ne_convert':
         parser.error("AVX-NE-CONVERT target only supports bfloat16 data type")
     BLOCK_SIZE_M = 2
     BLOCK_SIZE_N = 32
-    BLOCK_SIZE_K = 1
+    BLOCK_SIZE_K = 2
 
 torch.manual_seed(0)
 torch.set_printoptions(

--- a/python/tutorials/cpu-sfc-matmul.py
+++ b/python/tutorials/cpu-sfc-matmul.py
@@ -233,8 +233,6 @@ print(f"Running unit test with "
 
 torch_output = torch.empty((M, N), device='cpu', dtype=dtype)
 torch.matmul(a, b, out=torch_output)
-sfc_map_mn = make_sfc_tensor(M // BLOCK_SIZE_M, N // BLOCK_SIZE_N)
-sfc_map_kn = make_sfc_tensor(K // BLOCK_SIZE_K, N // BLOCK_SIZE_N)
 
 triton_output = torch.empty((M, N), device='cpu', dtype=dtype)
 matmul(a, b, triton_output, torch.empty_like(a), torch.empty_like(b), M=M, N=N, K=K, blocking_factor_k=1)

--- a/test/TritonCPU/dot-to-nanokernel.mlir
+++ b/test/TritonCPU/dot-to-nanokernel.mlir
@@ -617,6 +617,86 @@ tt.func public @gemm_avxneconvert_bf16(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16
 
 // -----
 
+// AVX_NE_CONVERT bf16 pre-packed vector.contract inside of an accumulator loop
+
+// ALL-LABEL: @gemm_avxneconvert_bf16_vnni
+
+// No shuffles
+// AVX_NE_CONVERT-NOT:       vector.shuffle
+
+// Main loop (using 8 accumulators (1x8xf32))
+// AVX_NE_CONVERT:           %{{.+}}:8 = scf.for %arg{{.+}} = %{{.+}} to %{{.+}} step %c1
+
+// Code sequence of interest
+// AVX_NE_CONVERT:             x86.avx.bcst_to_f32.packed
+// AVX_NE_CONVERT:             x86.avx.cvt.packed.even.indexed_to_f32
+// AVX_NE_CONVERT:             vector.fma
+// AVX_NE_CONVERT:             x86.avx.cvt.packed.odd.indexed_to_f32
+// AVX_NE_CONVERT:             vector.fma
+
+// AVX_NE_CONVERT:             scf.yield
+
+// No shuffle before storing to memory
+// AVX_NE_CONVERT-NOT:         vector.shuffle
+// AVX_NE_CONVERT:             arith.truncf
+// AVX_NE_CONVERT:             vector.transfer_write
+
+tt.func public @gemm_avxneconvert_bf16_vnni(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %arg2: !tt.ptr<bf16>, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32) {
+  %cst = arith.constant 0.000000e+00 : bf16
+  %c0 = arith.constant 0 : index
+  %c2_i32 = arith.constant 2 : i32
+  %c32_i32 = arith.constant 32 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c4_i64 = arith.constant 4 : i64
+  %c2_i64 = arith.constant 2 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %c64_i32 = arith.constant 64 : i32
+  %c64_i64 = arith.constant 64 : i64
+  %c32_i64 = arith.constant 32 : i64
+  %0 = arith.divsi %arg4, %c2_i32 : i32
+  %1 = arith.divsi %arg5, %c32_i32 : i32
+  %2 = arith.divsi %arg6, %c2_i32 : i32
+  %m = tt.get_program_id x : i32
+  %n = tt.get_program_id y : i32
+  %9 = arith.muli %arg7, %2 : i32
+  %10 = arith.muli %arg6, %c2_i32 : i32
+  %11 = arith.extsi %10 : i32 to i64
+  %12 = tt.make_tensor_descriptor %arg0, [%0, %2, %c2_i32, %c2_i32], [%11, %c4_i64, %c2_i64, %c1_i64] : <bf16>, <1x1x2x2xbf16>
+  %13 = arith.muli %arg6, %c32_i32 : i32
+  %14 = arith.extsi %13 : i32 to i64
+  %15 = tt.make_tensor_descriptor %arg1, [%1, %2, %c1_i32, %c64_i32], [%14, %c64_i64, %c64_i64, %c1_i64] : <bf16>, <1x1x1x64xbf16>
+  %16 = arith.muli %arg5, %c2_i32 : i32
+  %17 = arith.extsi %16 : i32 to i64
+  %18 = arith.extsi %arg5 : i32 to i64
+  %19 = tt.make_tensor_descriptor %arg2, [%0, %1, %c2_i32, %c32_i32], [%17, %c32_i64, %18, %c1_i64] : <bf16>, <1x1x2x32xbf16>
+  %21 = triton_cpu.extract_memref %19 : <1x1x2x32xbf16> -> memref<?x?x2x32xbf16, strided<[?, 32, ?, 1]>>
+  %22 = arith.index_cast %m : i32 to index
+  %23 = arith.index_cast %n : i32 to index
+  %24 = vector.transfer_read %21[%22, %23, %c0, %c0], %cst {in_bounds = [true, true]} : memref<?x?x2x32xbf16, strided<[?, 32, ?, 1]>>, vector<2x32xbf16>
+  %25 = arith.extf %24 : vector<2x32xbf16> to vector<2x32xf32>
+  %26 = arith.addi %9, %2 : i32
+  %27 = scf.for %arg8 = %9 to %26 step %c1_i32 iter_args(%arg9 = %25) -> (vector<2x32xf32>)  : i32 {
+    %30 = triton_cpu.extract_memref %12 : <1x1x2x2xbf16> -> memref<?x?x2x2xbf16, strided<[?, 4, 2, 1]>>
+    %31 = arith.index_cast %arg8 : i32 to index
+    %32 = vector.transfer_read %30[%22, %31, %c0, %c0], %cst {in_bounds = [true, true]} : memref<?x?x2x2xbf16, strided<[?, 4, 2, 1]>>, vector<2x2xbf16>
+    %33 = triton_cpu.extract_memref %15 : <1x1x1x64xbf16> -> memref<?x?x1x64xbf16, strided<[?, 64, 64, 1]>>
+    %34 = vector.transfer_read %33[%23, %31, %c0, %c0], %cst {in_bounds = [true, true]} : memref<?x?x1x64xbf16, strided<[?, 64, 64, 1]>>, vector<1x64xbf16>
+    %res1, %res2 = vector.deinterleave %34 : vector<1x64xbf16> -> vector<1x32xbf16>
+    %35 = vector.transpose %res1, [1, 0] : vector<1x32xbf16> to vector<32x1xbf16>
+    %36 = vector.transpose %res2, [1, 0] : vector<1x32xbf16> to vector<32x1xbf16>
+    %37 = vector.interleave %35, %36 : vector<32x1xbf16> -> vector<32x2xbf16>
+    %38 = vector.transpose %37, [1, 0] : vector<32x2xbf16> to vector<2x32xbf16>
+    %39 = triton_cpu.dot %32, %38, %arg9, inputPrecision = tf32 : vector<2x2xbf16> * vector<2x32xbf16> -> vector<2x32xf32>
+    scf.yield %39 : vector<2x32xf32>
+  }
+  %28 = arith.truncf %27 : vector<2x32xf32> to vector<2x32xbf16>
+  %29 = vector.shape_cast %28 : vector<2x32xbf16> to vector<1x1x2x32xbf16>
+  vector.transfer_write %29, %21[%22, %23, %c0, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x32xbf16>, memref<?x?x2x32xbf16, strided<[?, 32, ?, 1]>>
+  tt.return
+}
+
+// -----
+
 // Temporary buffer needed: accumulator is initialized from constant
 
 // ALL-LABEL: @gemm_amx_bf16_const_init

--- a/test/TritonCPU/dot-to-nanokernel.mlir
+++ b/test/TritonCPU/dot-to-nanokernel.mlir
@@ -64,6 +64,82 @@ tt.func public @gemm_amx_bf16(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %arg2:
 
 // -----
 
+// AMX bf16 pre-packed vector.contract inside of an accumulator loop
+
+// ALL-LABEL: @gemm_amx_bf16_vnni
+
+// Reshaped memrefs for packed inputs
+// AMX:         %[[A_VNNI:.+]] = memref.expand_shape %{{.+}} {{\[\[0\], \[1\], \[2\], \[3, 4\]\]}} output_shape [%{{.+}}, %{{.+}}, 32, 16, 2] : memref<?x?x32x32xbf16, strided<[?, 1024, 32, 1]>> into memref<?x?x32x16x2xbf16, strided<[?, 1024, 32, 2, 1]>>
+// AMX:         %[[B_VNNI:.+]] = memref.expand_shape %{{.+}} {{\[\[0\], \[1\], \[2\], \[3, 4\]\]}} output_shape [%{{.+}}, %{{.+}}, 16, 32, 2] : memref<?x?x16x64xbf16, strided<[?, 1024, 64, 1]>> into memref<?x?x16x32x2xbf16, strided<[?, 1024, 64, 2, 1]>>
+
+// Tile registers for accumulation
+// AMX-COUNT-4: x86.amx.tile_zero : !x86.amx.tile<16x16xf32>
+
+// AMX-NOT:     vector.shuffle
+
+// Main pipeline
+// AMX:         %{{.+}}:4 = scf.for %arg{{.+}} = %{{.+}} to %{{.+}} step %c1 iter_args(%arg{{.+}} = %{{.+}}, %arg{{.+}} = %{{.+}}, %arg{{.+}} = %{{.+}}, %arg{{.+}} = %{{.+}}) ->
+// AMX-SAME:      (!x86.amx.tile<16x16xf32>, !x86.amx.tile<16x16xf32>, !x86.amx.tile<16x16xf32>, !x86.amx.tile<16x16xf32>)
+// AMX-COUNT-4:   x86.amx.tile_mulf
+
+// Store results back to a temp buffer, and then to memory
+// AMX-COUNT-4: x86.amx.tile_store
+// AMX-NOT:     vector.shuffle
+// AMX:         vector.transfer_write
+
+tt.func public @gemm_amx_bf16_vnni(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %arg2: !tt.ptr<bf16>, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32) {
+  %cst = arith.constant 0.000000e+00 : bf16
+  %c0 = arith.constant 0 : index
+  %c32_i32 = arith.constant 32 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c1024_i64 = arith.constant 1024 : i64
+  %c32_i64 = arith.constant 32 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %c16_i32 = arith.constant 16 : i32
+  %c64_i32 = arith.constant 64 : i32
+  %c64_i64 = arith.constant 64 : i64
+  %0 = arith.divsi %arg4, %c32_i32 : i32
+  %1 = arith.divsi %arg5, %c32_i32 : i32
+  %2 = arith.divsi %arg6, %c32_i32 : i32
+  %m = tt.get_program_id x : i32
+  %n = tt.get_program_id y : i32
+  %9 = arith.muli %arg7, %2 : i32
+  %10 = arith.muli %arg6, %c32_i32 : i32
+  %11 = arith.extsi %10 : i32 to i64
+  %12 = tt.make_tensor_descriptor %arg0, [%0, %2, %c32_i32, %c32_i32], [%11, %c1024_i64, %c32_i64, %c1_i64] : <bf16>, <1x1x32x32xbf16>
+  %13 = tt.make_tensor_descriptor %arg1, [%1, %2, %c16_i32, %c64_i32], [%11, %c1024_i64, %c64_i64, %c1_i64] : <bf16>, <1x1x16x64xbf16>
+  %14 = arith.muli %arg5, %c32_i32 : i32
+  %15 = arith.extsi %14 : i32 to i64
+  %16 = arith.extsi %arg5 : i32 to i64
+  %17 = tt.make_tensor_descriptor %arg2, [%0, %1, %c32_i32, %c32_i32], [%15, %c32_i64, %16, %c1_i64] : <bf16>, <1x1x32x32xbf16>
+  %19 = triton_cpu.extract_memref %17 : <1x1x32x32xbf16> -> memref<?x?x32x32xbf16, strided<[?, 32, ?, 1]>>
+  %20 = arith.index_cast %m : i32 to index
+  %21 = arith.index_cast %n : i32 to index
+  %22 = vector.transfer_read %19[%20, %21, %c0, %c0], %cst {in_bounds = [true, true]} : memref<?x?x32x32xbf16, strided<[?, 32, ?, 1]>>, vector<32x32xbf16>
+  %23 = arith.extf %22 : vector<32x32xbf16> to vector<32x32xf32>
+  %24 = arith.addi %9, %2 : i32
+  %25 = scf.for %arg8 = %9 to %24 step %c1_i32 iter_args(%arg9 = %23) -> (vector<32x32xf32>)  : i32 {
+    %28 = triton_cpu.extract_memref %12 : <1x1x32x32xbf16> -> memref<?x?x32x32xbf16, strided<[?, 1024, 32, 1]>>
+    %29 = arith.index_cast %arg8 : i32 to index
+    %30 = vector.transfer_read %28[%20, %29, %c0, %c0], %cst {in_bounds = [true, true]} : memref<?x?x32x32xbf16, strided<[?, 1024, 32, 1]>>, vector<32x32xbf16>
+    %31 = triton_cpu.extract_memref %13 : <1x1x16x64xbf16> -> memref<?x?x16x64xbf16, strided<[?, 1024, 64, 1]>>
+    %32 = vector.transfer_read %31[%21, %29, %c0, %c0], %cst {in_bounds = [true, true]} : memref<?x?x16x64xbf16, strided<[?, 1024, 64, 1]>>, vector<16x64xbf16>
+    %res1, %res2 = vector.deinterleave %32 : vector<16x64xbf16> -> vector<16x32xbf16>
+    %33 = vector.transpose %res1, [1, 0] : vector<16x32xbf16> to vector<32x16xbf16>
+    %34 = vector.transpose %res2, [1, 0] : vector<16x32xbf16> to vector<32x16xbf16>
+    %35 = vector.interleave %33, %34 : vector<32x16xbf16> -> vector<32x32xbf16>
+    %36 = vector.transpose %35, [1, 0] : vector<32x32xbf16> to vector<32x32xbf16>
+    %37 = triton_cpu.dot %30, %36, %arg9, inputPrecision = tf32 : vector<32x32xbf16> * vector<32x32xbf16> -> vector<32x32xf32>
+    scf.yield %37 : vector<32x32xf32>
+  }
+  %26 = arith.truncf %25 : vector<32x32xf32> to vector<32x32xbf16>
+  %27 = vector.shape_cast %26 : vector<32x32xbf16> to vector<1x1x32x32xbf16>
+  vector.transfer_write %27, %19[%20, %21, %c0, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x32x32xbf16>, memref<?x?x32x32xbf16, strided<[?, 32, ?, 1]>>
+  tt.return
+}
+
+// -----
+
 // AMX int8 flat/online-packing vector.contract inside of an accumulator loop
 
 // ALL-LABEL: @gemm_amx_int8
@@ -125,6 +201,90 @@ tt.func public @gemm_amx_int8(%arg0: !tt.ptr<i8>, %arg1: !tt.ptr<i8>, %arg2: !tt
 
 // -----
 
+// AMX int8 pre-packed vector.contract inside of an accumulator loop
+
+// ALL-LABEL: @gemm_amx_int8_vnni
+
+// Reshaped memrefs for packed inputs
+// AMX:         %[[A_VNNI:.+]] = memref.expand_shape %{{.+}} {{\[\[0\], \[1\], \[2\], \[3, 4\]\]}} output_shape [%{{.+}}, %{{.+}}, 32, 16, 4] : memref<?x?x32x64xi8, strided<[?, 2048, 64, 1]>> into memref<?x?x32x16x4xi8, strided<[?, 2048, 64, 4, 1]>>
+// AMX:         %[[B_VNNI:.+]] = memref.expand_shape %{{.+}} {{\[\[0\], \[1\], \[2\], \[3, 4\]\]}} output_shape [%{{.+}}, %{{.+}}, 16, 32, 4] : memref<?x?x16x128xi8, strided<[?, 2048, 128, 1]>> into memref<?x?x16x32x4xi8, strided<[?, 2048, 128, 4, 1]>>
+
+// Tile registers for accumulation
+// AMX-COUNT-4: x86.amx.tile_zero : !x86.amx.tile<16x16xi32>
+
+// AMX-NOT:     vector.shuffle
+
+// Main pipeline
+// AMX:         %{{.+}}:4 = scf.for %arg{{.+}} = %{{.+}} to %{{.+}} step %c1 iter_args(%arg{{.+}} = %{{.+}}, %arg{{.+}} = %{{.+}}, %arg{{.+}} = %{{.+}}, %arg{{.+}} = %{{.+}}) ->
+// AMX-SAME:      (!x86.amx.tile<16x16xi32>, !x86.amx.tile<16x16xi32>, !x86.amx.tile<16x16xi32>, !x86.amx.tile<16x16xi32>)
+// AMX-COUNT-4:   x86.amx.tile_muli
+
+// Store results back to a temp buffer, and then to memory
+// AMX-COUNT-4: x86.amx.tile_store
+// AMX-NOT:     vector.shuffle
+// AMX:         vector.transfer_write
+
+tt.func public @gemm_amx_int8_vnni(%arg0: !tt.ptr<i8>, %arg1: !tt.ptr<i8>, %arg2: !tt.ptr<i8>, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32) {
+  %c0_i8 = arith.constant 0 : i8
+  %c0 = arith.constant 0 : index
+  %c0_i32 = arith.constant 0 : i32
+  %c32_i32 = arith.constant 32 : i32
+  %c64_i32 = arith.constant 64 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c2048_i64 = arith.constant 2048 : i64
+  %c32_i64 = arith.constant 32 : i64
+  %c64_i64 = arith.constant 64 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %c16_i32 = arith.constant 16 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c128_i64 = arith.constant 128 : i64
+  %0 = arith.divsi %arg4, %c32_i32 : i32
+  %1 = arith.divsi %arg5, %c32_i32 : i32
+  %2 = arith.divsi %arg6, %c64_i32 : i32
+  %m = tt.get_program_id x : i32
+  %n = tt.get_program_id y : i32
+  %9 = arith.muli %arg7, %2 : i32
+  %10 = arith.muli %arg6, %c32_i32 : i32
+  %11 = arith.extsi %10 : i32 to i64
+  %12 = tt.make_tensor_descriptor %arg0, [%0, %2, %c32_i32, %c64_i32], [%11, %c2048_i64, %c64_i64, %c1_i64] : <i8>, <1x1x32x64xsi8>
+  %13 = tt.make_tensor_descriptor %arg1, [%1, %2, %c16_i32, %c128_i32], [%11, %c2048_i64, %c128_i64, %c1_i64] : <i8>, <1x1x16x128xsi8>
+  %14 = arith.muli %arg5, %c32_i32 : i32
+  %15 = arith.extsi %14 : i32 to i64
+  %16 = arith.extsi %arg5 : i32 to i64
+  %17 = tt.make_tensor_descriptor %arg2, [%0, %1, %c32_i32, %c32_i32], [%15, %c32_i64, %16, %c1_i64] : <i8>, <1x1x32x32xsi8>
+  %19 = triton_cpu.extract_memref %17 : <1x1x32x32xsi8> -> memref<?x?x32x32xi8, strided<[?, 32, ?, 1]>>
+  %20 = arith.index_cast %m : i32 to index
+  %21 = arith.index_cast %n : i32 to index
+  %22 = vector.transfer_read %19[%20, %21, %c0, %c0], %c0_i8 {in_bounds = [true, true]} : memref<?x?x32x32xi8, strided<[?, 32, ?, 1]>>, vector<32x32xi8>
+  %23 = arith.extsi %22 : vector<32x32xi8> to vector<32x32xi32>
+  %24 = arith.addi %9, %2 : i32
+  %25 = scf.for %arg8 = %9 to %24 step %c1_i32 iter_args(%arg9 = %23) -> (vector<32x32xi32>)  : i32 {
+    %28 = triton_cpu.extract_memref %12 : <1x1x32x64xsi8> -> memref<?x?x32x64xi8, strided<[?, 2048, 64, 1]>>
+    %29 = arith.index_cast %arg8 : i32 to index
+    %30 = vector.transfer_read %28[%20, %29, %c0, %c0], %c0_i8 {in_bounds = [true, true]} : memref<?x?x32x64xi8, strided<[?, 2048, 64, 1]>>, vector<32x64xi8>
+    %31 = triton_cpu.extract_memref %13 : <1x1x16x128xsi8> -> memref<?x?x16x128xi8, strided<[?, 2048, 128, 1]>>
+    %32 = vector.transfer_read %31[%21, %29, %c0, %c0], %c0_i8 {in_bounds = [true, true]} : memref<?x?x16x128xi8, strided<[?, 2048, 128, 1]>>, vector<16x128xi8>
+    %res1, %res2 = vector.deinterleave %32 : vector<16x128xi8> -> vector<16x64xi8>
+    %33 = vector.transpose %res1, [1, 0] : vector<16x64xi8> to vector<64x16xi8>
+    %34 = vector.transpose %res2, [1, 0] : vector<16x64xi8> to vector<64x16xi8>
+    %35 = vector.interleave %33, %34 : vector<64x16xi8> -> vector<64x32xi8>
+    %36 = vector.transpose %35, [1, 0] : vector<64x32xi8> to vector<32x64xi8>
+    %res1_0, %res2_1 = vector.deinterleave %36 : vector<32x64xi8> -> vector<32x32xi8>
+    %37 = vector.transpose %res1_0, [1, 0] : vector<32x32xi8> to vector<32x32xi8>
+    %38 = vector.transpose %res2_1, [1, 0] : vector<32x32xi8> to vector<32x32xi8>
+    %39 = vector.interleave %37, %38 : vector<32x32xi8> -> vector<32x64xi8>
+    %40 = vector.transpose %39, [1, 0] : vector<32x64xi8> to vector<64x32xi8>
+    %41 = triton_cpu.dot %30, %40, %arg9, inputPrecision = tf32 : vector<32x64xi8> * vector<64x32xi8> -> vector<32x32xi32>
+    scf.yield %41 : vector<32x32xi32>
+  }
+  %26 = arith.trunci %25 : vector<32x32xi32> to vector<32x32xi8>
+  %27 = vector.shape_cast %26 : vector<32x32xi8> to vector<1x1x32x32xi8>
+  vector.transfer_write %27, %19[%20, %21, %c0, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x32x32xi8>, memref<?x?x32x32xi8, strided<[?, 32, ?, 1]>>
+  tt.return
+}
+
+// -----
+
 // AVX-512 bf16 flat/online-packing vector.contract inside of an accumulator loop
 
 // ALL-LABEL: @gemm_avx512_bf16
@@ -179,6 +339,87 @@ tt.func public @gemm_avx512_bf16(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %ar
 
 // -----
 
+// AVX-512 bf16 pre-packed vector.contract inside of an accumulator loop
+
+// ALL-LABEL: @gemm_avx512_bf16_vnni
+
+// No shuffles
+// AVX512-NOT:       vector.shuffle
+
+// Reshaped memrefs for packed inputs
+// AVX512:           %[[A_VNNI:.+]] = memref.expand_shape %{{.+}} {{\[\[0\], \[1\], \[2\], \[3, 4\]\]}} output_shape [%{{.+}}, %{{.+}}, 4, 1, 2] : memref<?x?x4x2xbf16, strided<[?, 8, 2, 1]>> into memref<?x?x4x1x2xbf16, strided<[?, 8, 2, 2, 1]>>
+// AVX512:           %[[B_VNNI:.+]] = memref.expand_shape %{{.+}} {{\[\[0\], \[1\], \[2\], \[3, 4\]\]}} output_shape [%{{.+}}, %{{.+}}, 1, 64, 2] : memref<?x?x1x128xbf16, strided<[?, 128, 128, 1]>> into memref<?x?x1x64x2xbf16, strided<[?, 128, 128, 2, 1]>>
+
+// Main loop (using 16 accumulators (1x16xf32))
+// AVX512:           %{{.+}}:16 = scf.for %arg{{.+}} = %{{.+}} to %{{.+}} step %c1
+
+// AVX512-NOT:         vector.shuffle
+// AVX512-COUNT-16:    x86.avx512.dot
+
+// AVX512:             scf.yield
+
+// No shuffles before storing to memory
+// AVX512-NOT:       vector.shuffle
+// AVX512:           arith.truncf
+// AVX512:           vector.transfer_write
+
+tt.func public @gemm_avx512_bf16_vnni(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %arg2: !tt.ptr<bf16>, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32) {
+  %cst = arith.constant 0.000000e+00 : bf16
+  %c0 = arith.constant 0 : index
+  %c4_i32 = arith.constant 4 : i32
+  %c64_i32 = arith.constant 64 : i32
+  %c2_i32 = arith.constant 2 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c8_i64 = arith.constant 8 : i64
+  %c2_i64 = arith.constant 2 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %c128_i32 = arith.constant 128 : i32
+  %c128_i64 = arith.constant 128 : i64
+  %c64_i64 = arith.constant 64 : i64
+  %0 = arith.divsi %arg4, %c4_i32 : i32
+  %1 = arith.divsi %arg5, %c64_i32 : i32
+  %2 = arith.divsi %arg6, %c2_i32 : i32
+  %m = tt.get_program_id x : i32
+  %n = tt.get_program_id y : i32
+  %9 = arith.muli %arg7, %2 : i32
+  %10 = arith.muli %arg6, %c4_i32 : i32
+  %11 = arith.extsi %10 : i32 to i64
+  %12 = tt.make_tensor_descriptor %arg0, [%0, %2, %c4_i32, %c2_i32], [%11, %c8_i64, %c2_i64, %c1_i64] : <bf16>, <1x1x4x2xbf16>
+  %13 = arith.muli %arg6, %c64_i32 : i32
+  %14 = arith.extsi %13 : i32 to i64
+  %15 = tt.make_tensor_descriptor %arg1, [%1, %2, %c1_i32, %c128_i32], [%14, %c128_i64, %c128_i64, %c1_i64] : <bf16>, <1x1x1x128xbf16>
+  %16 = arith.muli %arg5, %c4_i32 : i32
+  %17 = arith.extsi %16 : i32 to i64
+  %18 = arith.extsi %arg5 : i32 to i64
+  %19 = tt.make_tensor_descriptor %arg2, [%0, %1, %c4_i32, %c64_i32], [%17, %c64_i64, %18, %c1_i64] : <bf16>, <1x1x4x64xbf16>
+  %21 = triton_cpu.extract_memref %19 : <1x1x4x64xbf16> -> memref<?x?x4x64xbf16, strided<[?, 64, ?, 1]>>
+  %22 = arith.index_cast %m : i32 to index
+  %23 = arith.index_cast %n : i32 to index
+  %24 = vector.transfer_read %21[%22, %23, %c0, %c0], %cst {in_bounds = [true, true]} : memref<?x?x4x64xbf16, strided<[?, 64, ?, 1]>>, vector<4x64xbf16>
+  %25 = arith.extf %24 : vector<4x64xbf16> to vector<4x64xf32>
+  %26 = arith.addi %9, %2 : i32
+  %27 = scf.for %arg8 = %9 to %26 step %c1_i32 iter_args(%arg9 = %25) -> (vector<4x64xf32>)  : i32 {
+    %30 = triton_cpu.extract_memref %12 : <1x1x4x2xbf16> -> memref<?x?x4x2xbf16, strided<[?, 8, 2, 1]>>
+    %31 = arith.index_cast %arg8 : i32 to index
+    %32 = vector.transfer_read %30[%22, %31, %c0, %c0], %cst {in_bounds = [true, true]} : memref<?x?x4x2xbf16, strided<[?, 8, 2, 1]>>, vector<4x2xbf16>
+    %33 = triton_cpu.extract_memref %15 : <1x1x1x128xbf16> -> memref<?x?x1x128xbf16, strided<[?, 128, 128, 1]>>
+    %34 = vector.transfer_read %33[%23, %31, %c0, %c0], %cst {in_bounds = [true, true]} : memref<?x?x1x128xbf16, strided<[?, 128, 128, 1]>>, vector<1x128xbf16>
+    %res1, %res2 = vector.deinterleave %34 : vector<1x128xbf16> -> vector<1x64xbf16>
+    %35 = vector.transpose %res1, [1, 0] : vector<1x64xbf16> to vector<64x1xbf16>
+    %36 = vector.transpose %res2, [1, 0] : vector<1x64xbf16> to vector<64x1xbf16>
+    %37 = vector.interleave %35, %36 : vector<64x1xbf16> -> vector<64x2xbf16>
+    %38 = vector.transpose %37, [1, 0] : vector<64x2xbf16> to vector<2x64xbf16>
+    %39 = triton_cpu.dot %32, %38, %arg9, inputPrecision = tf32 : vector<4x2xbf16> * vector<2x64xbf16> -> vector<4x64xf32>
+    scf.yield %39 : vector<4x64xf32>
+  }
+  %28 = arith.truncf %27 : vector<4x64xf32> to vector<4x64xbf16>
+  %29 = vector.shape_cast %28 : vector<4x64xbf16> to vector<1x1x4x64xbf16>
+  vector.transfer_write %29, %21[%22, %23, %c0, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x4x64xbf16>, memref<?x?x4x64xbf16, strided<[?, 64, ?, 1]>>
+  tt.return
+}
+
+// -----
+
 // AVX10.2 int8 flat/online-packing vector.contract inside of an accumulator loop
 
 // ALL-LABEL: @gemm_avx10_2_int8
@@ -226,6 +467,93 @@ tt.func public @gemm_avx10_2_int8(%arg0: !tt.ptr<i8>, %arg1: !tt.ptr<i8>, %arg2:
     scf.yield %19 : vector<4x64xi32>
   }
   vector.transfer_write %13, %9[%10, %11] {in_bounds = [true, true]} : vector<4x64xi32>, memref<?x?xi32, strided<[?, 1]>>
+  tt.return
+}
+
+// -----
+
+// AVX10.2 int8 pre-packed vector.contract inside of an accumulator loop
+
+// ALL-LABEL: @gemm_avx10_2_int8_vnni
+
+// No shuffles
+// AVX10_2-NOT:       vector.shuffle
+
+// Reshaped memrefs for packed inputs
+// AVX10_2:           %[[A_VNNI:.+]] = memref.expand_shape %{{.+}} {{\[\[0\], \[1\], \[2\], \[3, 4\]\]}} output_shape [%{{.+}}, %{{.+}}, 4, 1, 4] : memref<?x?x4x4xi8, strided<[?, 16, 4, 1]>> into memref<?x?x4x1x4xi8, strided<[?, 16, 4, 4, 1]>>
+// AVX10_2:           %[[B_VNNI:.+]] = memref.expand_shape %{{.+}} {{\[\[0\], \[1\], \[2\], \[3, 4\]\]}} output_shape [%{{.+}}, %{{.+}}, 1, 64, 4] : memref<?x?x1x256xi8, strided<[?, 256, 256, 1]>> into memref<?x?x1x64x4xi8, strided<[?, 256, 256, 4, 1]>>
+
+// Main loop (using 16 accumulators (1x16xi32))
+// AVX10_2:           %{{.+}}:16 = scf.for %arg{{.+}} = %{{.+}} to %{{.+}} step %c1
+
+// AVX10_2-NOT:         vector.shuffle
+// AVX10_2-COUNT-16:    x86.avx10.dot.i8
+
+// AVX10_2:             scf.yield
+
+// No shuffles before storing to memory
+// AVX10_2-NOT:       vector.shuffle
+// AVX10_2:           arith.trunci
+// AVX10_2:           vector.transfer_write
+
+tt.func public @gemm_avx10_2_int8_vnni(%arg0: !tt.ptr<i8>, %arg1: !tt.ptr<i8>, %arg2: !tt.ptr<i8>, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32) {
+  %c0_i8 = arith.constant 0 : i8
+  %c0 = arith.constant 0 : index
+  %c4_i32 = arith.constant 4 : i32
+  %c64_i32 = arith.constant 64 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c16_i64 = arith.constant 16 : i64
+  %c4_i64 = arith.constant 4 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %c256_i32 = arith.constant 256 : i32
+  %c256_i64 = arith.constant 256 : i64
+  %c64_i64 = arith.constant 64 : i64
+  %c0_i32 = arith.constant 0 : i32
+  %0 = arith.divsi %arg4, %c4_i32 : i32
+  %1 = arith.divsi %arg5, %c64_i32 : i32
+  %2 = arith.divsi %arg6, %c4_i32 : i32
+  %m = tt.get_program_id x : i32
+  %n = tt.get_program_id y : i32
+  %9 = arith.muli %arg7, %2 : i32
+  %10 = arith.muli %arg6, %c4_i32 : i32
+  %11 = arith.extsi %10 : i32 to i64
+  %12 = tt.make_tensor_descriptor %arg0, [%0, %2, %c4_i32, %c4_i32], [%11, %c16_i64, %c4_i64, %c1_i64] : <i8>, <1x1x4x4xsi8>
+  %13 = arith.muli %arg6, %c64_i32 : i32
+  %14 = arith.extsi %13 : i32 to i64
+  %15 = tt.make_tensor_descriptor %arg1, [%1, %2, %c1_i32, %c256_i32], [%14, %c256_i64, %c256_i64, %c1_i64] : <i8>, <1x1x1x256xsi8>
+  %16 = arith.muli %arg5, %c4_i32 : i32
+  %17 = arith.extsi %16 : i32 to i64
+  %18 = arith.extsi %arg5 : i32 to i64
+  %19 = tt.make_tensor_descriptor %arg2, [%0, %1, %c4_i32, %c64_i32], [%17, %c64_i64, %18, %c1_i64] : <i8>, <1x1x4x64xsi8>
+  %20 = arith.cmpi eq, %arg7, %c0_i32 : i32
+  %21 = triton_cpu.extract_memref %19 : <1x1x4x64xsi8> -> memref<?x?x4x64xi8, strided<[?, 64, ?, 1]>>
+  %22 = arith.index_cast %m : i32 to index
+  %23 = arith.index_cast %n : i32 to index
+  %24 = vector.transfer_read %21[%22, %23, %c0, %c0], %c0_i8 {in_bounds = [true, true]} : memref<?x?x4x64xi8, strided<[?, 64, ?, 1]>>, vector<4x64xi8>
+  %25 = arith.extsi %24 : vector<4x64xi8> to vector<4x64xi32>
+  %26 = arith.addi %9, %2 : i32
+  %27 = scf.for %arg8 = %9 to %26 step %c1_i32 iter_args(%arg9 = %25) -> (vector<4x64xi32>)  : i32 {
+    %30 = triton_cpu.extract_memref %12 : <1x1x4x4xsi8> -> memref<?x?x4x4xi8, strided<[?, 16, 4, 1]>>
+    %31 = arith.index_cast %arg8 : i32 to index
+    %32 = vector.transfer_read %30[%22, %31, %c0, %c0], %c0_i8 {in_bounds = [true, true]} : memref<?x?x4x4xi8, strided<[?, 16, 4, 1]>>, vector<4x4xi8>
+    %33 = triton_cpu.extract_memref %15 : <1x1x1x256xsi8> -> memref<?x?x1x256xi8, strided<[?, 256, 256, 1]>>
+    %34 = vector.transfer_read %33[%23, %31, %c0, %c0], %c0_i8 {in_bounds = [true, true]} : memref<?x?x1x256xi8, strided<[?, 256, 256, 1]>>, vector<1x256xi8>
+    %res1, %res2 = vector.deinterleave %34 : vector<1x256xi8> -> vector<1x128xi8>
+    %35 = vector.transpose %res1, [1, 0] : vector<1x128xi8> to vector<128x1xi8>
+    %36 = vector.transpose %res2, [1, 0] : vector<1x128xi8> to vector<128x1xi8>
+    %37 = vector.interleave %35, %36 : vector<128x1xi8> -> vector<128x2xi8>
+    %38 = vector.transpose %37, [1, 0] : vector<128x2xi8> to vector<2x128xi8>
+    %res1_0, %res2_1 = vector.deinterleave %38 : vector<2x128xi8> -> vector<2x64xi8>
+    %39 = vector.transpose %res1_0, [1, 0] : vector<2x64xi8> to vector<64x2xi8>
+    %40 = vector.transpose %res2_1, [1, 0] : vector<2x64xi8> to vector<64x2xi8>
+    %41 = vector.interleave %39, %40 : vector<64x2xi8> -> vector<64x4xi8>
+    %42 = vector.transpose %41, [1, 0] : vector<64x4xi8> to vector<4x64xi8>
+    %43 = triton_cpu.dot %32, %42, %arg9, inputPrecision = tf32 : vector<4x4xi8> * vector<4x64xi8> -> vector<4x64xi32>
+    scf.yield %43 : vector<4x64xi32>
+  }
+  %28 = arith.trunci %27 : vector<4x64xi32> to vector<4x64xi8>
+  %29 = vector.shape_cast %28 : vector<4x64xi8> to vector<1x1x4x64xi8>
+  vector.transfer_write %29, %21[%22, %23, %c0, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x4x64xi8>, memref<?x?x4x64xi8, strided<[?, 64, ?, 1]>>
   tt.return
 }
 

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
@@ -136,16 +136,31 @@ unsigned checkInputShapes(VectorType lhsTy, VectorType resTy,
            candidate.blockK == k;
   };
 
-  if (shapeUnrollsTo(1, 8, 1, 12))
+  // Check for twice the size in the N dimension, so that at least one eligble
+  // pair of contracts will be generated, which is a requirement for the flat
+  // operand version of the patterns. The VNNI-packed version would work with a
+  // single contraction, but this way we can handle both cases uniformly.
+
+  // AVX_NE_CONVERT lowers to an FMA, so the flat version expects K=1, whereas
+  // the pre-packed version expects K=2 (actually, 1x2).
+  if (shapeUnrollsTo(1, 16, 1, 12))
+    return mask & AVX_NE_CONVERT;
+  if (candidate.isVnniPacked && !(mask & AVX512_BF16) &&
+      shapeUnrollsTo(1, 16, 2, 12))
     return mask & AVX_NE_CONVERT;
 
-  if (shapeUnrollsTo(1, 16, 2, 24))
+  // For AVX512 and AVX10.2, we have proper dot product instructions, and K
+  // must equal the VNNI factor. We don't have to distingush between flat and
+  // pre-packed versions for shape check.
+  if (shapeUnrollsTo(1, 32, 2, 24))
     return mask & AVX512_BF16;
 
-  if (shapeUnrollsTo(1, 16, 4, 24))
+  if (shapeUnrollsTo(1, 32, 4, 24))
     return mask & AVX10_2;
 
-  // AMX lowering currently matches only the 2x2 register tiling.
+  // AMX lowering currently matches only the 2x2 register tiling. K must equal
+  // 16xVNNI factor; again no need to distinguish between flat and pre-packed
+  // versions for the shape check.
   if (shapeEquals(32, 32, 32))
     return mask & AMX_BF16;
 
@@ -176,34 +191,27 @@ bool isNanokernelCandidate(triton::cpu::DotOp op, DotOpCandidate &candidate,
 
   mask = checkElemTypes(lhsTy.getElementType(), rhsTy.getElementType(),
                         accTy.getElementType(), resTy.getElementType(), mask);
+  candidate.isVnniPacked = getVnniSrc(op.getB()) != nullptr;
   mask = checkInputShapes(lhsTy, resTy, candidate, mask);
   if (llvm::isPowerOf2_32(mask) != 1) {
     LDBG("  Drop candidate. No uniquely matching ISA extension for the op's "
          "types and shapes.");
     return false;
   }
+  candidate.target = static_cast<ISAExt>(mask);
 
   if (!isLoopCarriedAcc(op.getC())) {
     LDBG("  Drop candidate. Only loop-carried accumulator case is supported.");
     return false;
   }
 
-  bool isAMX = mask & (AMX_BF16 | AMX_INT8);
-
   auto accLoop = cast<scf::ForOp>(op->getParentOp());
 
   auto lhsRead = op.getA().getDefiningOp<vector::TransferReadOp>();
-  auto rhsRead = op.getB().getDefiningOp<vector::TransferReadOp>();
-
-  bool isVnniPacked = false;
-  // TODO: Handle VNNI encoding for AVX_NE_CONVERT as well.
-  if (!rhsRead && !(mask & AVX_NE_CONVERT)) {
-    Value vnniSrc = getVnniSrc(op.getB());
-    if (vnniSrc) {
-      rhsRead = vnniSrc.getDefiningOp<vector::TransferReadOp>();
-      isVnniPacked = true;
-    }
-  }
+  auto rhsRead =
+      candidate.isVnniPacked
+          ? getVnniSrc(op.getB()).getDefiningOp<vector::TransferReadOp>()
+          : op.getB().getDefiningOp<vector::TransferReadOp>();
 
   if (!lhsRead || !rhsRead) {
     LDBG("  Drop candidate. Expected vector.transfer_read ops feeding the dot, "
@@ -217,6 +225,7 @@ bool isNanokernelCandidate(triton::cpu::DotOp op, DotOpCandidate &candidate,
                      .getDefiningOp<vector::TransferReadOp>();
 
   // AMX lowering doesn't care about the write-back of the accumulator anymore.
+  bool isAMX = candidate.target & (AMX_BF16 | AMX_INT8);
   auto accWrite = !isAMX && accLoop.getResults().front().hasOneUse()
                       ? dyn_cast<vector::TransferWriteOp>(
                             *accLoop.getResults().front().getUsers().begin())
@@ -239,12 +248,7 @@ bool isNanokernelCandidate(triton::cpu::DotOp op, DotOpCandidate &candidate,
     bool hasNonIdentityPermutation =
         !transferOp.getPermutationMap().isMinorIdentity();
     bool hasMask = transferOp.getMask() != nullptr;
-
-    ArrayAttr inBounds = transferOp.getInBounds();
-    bool hasBoundsCheck =
-        std::any_of(inBounds.begin(), inBounds.end(), [](Attribute attr) {
-          return !cast<mlir::BoolAttr>(attr).getValue();
-        });
+    bool hasBoundsCheck = transferOp.hasOutOfBoundsDim();
 
     if (hasNonIdentityPermutation || hasMask || hasBoundsCheck) {
       LDBG("  Drop candidate. Transfer op has a permutation map, mask or needs "
@@ -298,19 +302,17 @@ bool isNanokernelCandidate(triton::cpu::DotOp op, DotOpCandidate &candidate,
   // TODO: Otherwise, the k-index for the A load would have to be multiplied by
   // the VNNI factor, which we don't support yet during the conversion of the
   // loop to use an index-typed induction variable.
-  if (!checkTransferOp(lhsRead, isVnniPacked) ||
-      !checkTransferOp(rhsRead, isVnniPacked) || !checkTransferOp(accRead) ||
-      !checkTransferOp(accWrite))
+  if (!checkTransferOp(lhsRead, candidate.isVnniPacked) ||
+      !checkTransferOp(rhsRead, candidate.isVnniPacked) ||
+      !checkTransferOp(accRead) || !checkTransferOp(accWrite))
     return false;
 
-  candidate.target = static_cast<ISAExt>(mask);
   candidate.dot = op;
   candidate.accLoop = accLoop;
   candidate.lhsRead = lhsRead;
   candidate.rhsRead = rhsRead;
   candidate.accRead = accRead;
   candidate.accWrite = accWrite;
-  candidate.isVnniPacked = isVnniPacked;
 
   return true;
 }
@@ -553,8 +555,8 @@ void performRegisterTiling(DotOpCandidate &candidate,
   };
 
   if (candidate.target & AVX_NE_CONVERT) {
-    assert(!candidate.isVnniPacked);
-    vnniFactor = 1; // TODO: Why is NE_CONVERT different?
+    if (!candidate.isVnniPacked)
+      vnniFactor = 1;
     setContractShape(1, 8, 1);
     setLhsShape(1, 1);
     setRhsShape(1, 8);
@@ -609,6 +611,10 @@ void spliceAccumulatorAndConvertToIndex(DotOpCandidate &candidate,
   llvm::SmallDenseMap<ArrayAttr, vector::InsertStridedSliceOp> insertOps;
 
   for (auto user : iterArg.getUsers()) {
+    // See above: Flat operands require a pair of contractions, so the following
+    // assertion holds.
+    // TODO: If we want to handle the no-unroll-single-VNNI-packed contraction
+    // case, then the we have to make the splicing optional in this method.
     auto extractSliceOp = cast<vector::ExtractStridedSliceOp>(user);
     extractOps[extractSliceOp.getOffsets()] = extractSliceOp;
   }
@@ -831,6 +837,7 @@ struct ConvertDotToNanokernel
           LDBG("  blockM: " << candidate.blockM);
           LDBG("  blockN: " << candidate.blockN);
           LDBG("  blockK: " << candidate.blockK);
+          LDBG("  VNNI-packed: " << candidate.isVnniPacked);
           LDBG("  LHS read: " << candidate.lhsRead);
           LDBG("  RHS read: " << candidate.rhsRead);
           if (candidate.accRead)

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
@@ -136,8 +136,8 @@ unsigned checkInputShapes(VectorType lhsTy, VectorType resTy,
            candidate.blockK == k;
   };
 
-  // Check for twice the size in the N dimension, so that at least one eligble
-  // pair of contracts will be generated, which is a requirement for the flat
+  // Check for twice the size in the N dimension, so that at least one eligible
+  // pair of contractions will be generated, which is a requirement for the flat
   // operand version of the patterns. The VNNI-packed version would work with a
   // single contraction, but this way we can handle both cases uniformly.
 
@@ -150,7 +150,7 @@ unsigned checkInputShapes(VectorType lhsTy, VectorType resTy,
     return mask & AVX_NE_CONVERT;
 
   // For AVX512 and AVX10.2, we have proper dot product instructions, and K
-  // must equal the VNNI factor. We don't have to distingush between flat and
+  // must equal the VNNI factor. We don't have to distinguish between flat and
   // pre-packed versions for shape check.
   if (shapeUnrollsTo(1, 32, 2, 24))
     return mask & AVX512_BF16;
@@ -392,6 +392,9 @@ void makeVnniRead(vector::TransferReadOp &op, PatternRewriter &rewriter) {
 
   auto vecTy = op.getVectorType();
   SmallVector<int64_t> newVecShape{vecTy.getShape()};
+  assert(newVecShape.back() % vnniFactor == 0 &&
+         "Expected the last dimension of the vector to be divisible by the "
+         "VNNI factor");
   newVecShape.back() /= vnniFactor;
   newVecShape.push_back(vnniFactor);
   auto newVecTy = VectorType::get(newVecShape, vecTy.getElementType());
@@ -482,7 +485,7 @@ void convertToContract(DotOpCandidate &candidate, PatternRewriter &rewriter) {
   rewriter.setInsertionPoint(op);
 
   // Use the (potentially modified to encode VNNI packing) transfer reads as
-  // operands of the new contractation op.
+  // operands of the new contraction op.
   Value a = candidate.lhsRead;
   Value b = candidate.rhsRead;
   Value c = op.getC();
@@ -614,7 +617,7 @@ void spliceAccumulatorAndConvertToIndex(DotOpCandidate &candidate,
     // See above: Flat operands require a pair of contractions, so the following
     // assertion holds.
     // TODO: If we want to handle the no-unroll-single-VNNI-packed contraction
-    // case, then the we have to make the splicing optional in this method.
+    // case, we have to make the splicing optional in this method.
     auto extractSliceOp = cast<vector::ExtractStridedSliceOp>(user);
     extractOps[extractSliceOp.getOffsets()] = extractSliceOp;
   }

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
@@ -91,6 +91,9 @@ struct DotOpCandidate {
 
   // Temporary buffer for accumulator.
   memref::AllocaOp accBuffer;
+
+  // Keep track of whether the operands are already VNNI-packed.
+  bool isVnniPacked;
 };
 
 unsigned checkElemTypes(Type lhsElemTy, Type rhsElemTy, Type accElemTy,
@@ -191,6 +194,17 @@ bool isNanokernelCandidate(triton::cpu::DotOp op, DotOpCandidate &candidate,
 
   auto lhsRead = op.getA().getDefiningOp<vector::TransferReadOp>();
   auto rhsRead = op.getB().getDefiningOp<vector::TransferReadOp>();
+
+  bool isVnniPacked = false;
+  // TODO: Handle VNNI encoding for AVX_NE_CONVERT as well.
+  if (!rhsRead && !(mask & AVX_NE_CONVERT)) {
+    Value vnniSrc = getVnniSrc(op.getB());
+    if (vnniSrc) {
+      rhsRead = vnniSrc.getDefiningOp<vector::TransferReadOp>();
+      isVnniPacked = true;
+    }
+  }
+
   if (!lhsRead || !rhsRead) {
     LDBG("  Drop candidate. Expected vector.transfer_read ops feeding the dot, "
          "but got: "
@@ -217,7 +231,8 @@ bool isNanokernelCandidate(triton::cpu::DotOp op, DotOpCandidate &candidate,
     accWrite = nullptr;
   }
 
-  auto checkTransferOp = [&](auto transferOp) {
+  auto checkTransferOp = [&](auto transferOp,
+                             bool expectBlockBasedIndexing = false) {
     if (!transferOp)
       return true; // No op to check, so no reason to drop the candidate.
 
@@ -249,6 +264,9 @@ bool isNanokernelCandidate(triton::cpu::DotOp op, DotOpCandidate &candidate,
 
     auto memrefTy = cast<MemRefType>(transferOp.getBase().getType());
     auto memrefRank = memrefTy.getRank();
+    // If the memref has more than 2 dimensions, we expect to find block-based
+    // indexing where the last two dimensions of the memref match the vector
+    // shape.
     if (memrefRank > 2) {
       auto memrefShape = memrefTy.getShape();
       auto vecShape = vecTy.getShape();
@@ -265,11 +283,24 @@ bool isNanokernelCandidate(triton::cpu::DotOp op, DotOpCandidate &candidate,
       }
     }
 
+    if (expectBlockBasedIndexing && memrefRank <= 2) {
+      LDBG("  Drop candidate. Expected block-based indexing, but got: "
+           << transferOp);
+      return false;
+    }
+
     return true;
   };
 
-  if (!checkTransferOp(lhsRead) || !checkTransferOp(rhsRead) ||
-      !checkTransferOp(accRead) || !checkTransferOp(accWrite))
+  // Conservatively enforce block-based indexing for the VNNI-packed case, so
+  // that the k-index is the same for the A and B loads, i.e. the induction
+  // variable with step == 1.
+  // TODO: Otherwise, the k-index for the A load would have to be multiplied by
+  // the VNNI factor, which we don't support yet during the conversion of the
+  // loop to use an index-typed induction variable.
+  if (!checkTransferOp(lhsRead, isVnniPacked) ||
+      !checkTransferOp(rhsRead, isVnniPacked) || !checkTransferOp(accRead) ||
+      !checkTransferOp(accWrite))
     return false;
 
   candidate.target = static_cast<ISAExt>(mask);
@@ -279,6 +310,7 @@ bool isNanokernelCandidate(triton::cpu::DotOp op, DotOpCandidate &candidate,
   candidate.rhsRead = rhsRead;
   candidate.accRead = accRead;
   candidate.accWrite = accWrite;
+  candidate.isVnniPacked = isVnniPacked;
 
   return true;
 }
@@ -327,6 +359,64 @@ void makeAccBuffer(DotOpCandidate &candidate, PatternRewriter &rewriter) {
   rewriter.replaceAllUsesExcept(result, remat, candidate.accWrite);
 }
 
+void makeVnniRead(vector::TransferReadOp &op, PatternRewriter &rewriter) {
+  Location loc = op.getLoc();
+  rewriter.setInsertionPoint(op);
+
+  auto memrefTy = cast<MemRefType>(op.getBase().getType());
+  auto memrefRank = memrefTy.getRank();
+
+  unsigned vnniFactor = 32 / memrefTy.getElementTypeBitWidth();
+
+  SmallVector<int64_t> newMemrefShape{memrefTy.getShape()};
+  if (newMemrefShape.back() != ShapedType::kDynamic) {
+    assert(newMemrefShape.back() % vnniFactor == 0 &&
+           "Expected the last dimension of the memref to be divisible by the "
+           "VNNI factor");
+    newMemrefShape.back() /= vnniFactor;
+  }
+  newMemrefShape.push_back(vnniFactor);
+
+  // Split last dimension.
+  SmallVector<ReassociationIndices> reassoc;
+  for (int d = 0; d < memrefRank - 1; ++d)
+    reassoc.push_back({d});
+  reassoc.push_back({memrefRank - 1, memrefRank});
+
+  auto newMemref = memref::ExpandShapeOp::create(rewriter, loc, newMemrefShape,
+                                                 op.getBase(), reassoc);
+
+  LDBG("  Transformed type: " << memrefTy << " -> " << newMemref.getType());
+
+  auto vecTy = op.getVectorType();
+  SmallVector<int64_t> newVecShape{vecTy.getShape()};
+  newVecShape.back() /= vnniFactor;
+  newVecShape.push_back(vnniFactor);
+  auto newVecTy = VectorType::get(newVecShape, vecTy.getElementType());
+
+  SmallVector<Value> newIndices{op.getIndices()};
+  newIndices.push_back(arith::ConstantIndexOp::create(rewriter, loc, 0));
+
+  SmallVector<bool> newInBounds{op.getInBoundsValues()};
+  newInBounds.push_back(newInBounds.back());
+
+  auto newRead =
+      vector::TransferReadOp::create(rewriter, loc, newVecTy, newMemref,
+                                     newIndices, op.getPadding(), newInBounds);
+
+  // Only needed to keep IR legal.
+  rewriter.replaceOpWithNewOp<vector::ShapeCastOp>(op, vecTy, newRead);
+
+  op = newRead;
+}
+
+void encodeVnniPacking(DotOpCandidate &candidate, PatternRewriter &rewriter) {
+  if (!candidate.isVnniPacked)
+    return;
+  makeVnniRead(candidate.lhsRead, rewriter);
+  makeVnniRead(candidate.rhsRead, rewriter);
+}
+
 template <typename TransferOp>
 void moveIndicesToSubview(TransferOp op, PatternRewriter &rewriter) {
   if (llvm::all_of(op.getIndices(), isZeroInteger))
@@ -349,15 +439,12 @@ void moveIndicesToSubview(TransferOp op, PatternRewriter &rewriter) {
   for (int64_t i = 0; i < vecTy.getRank(); ++i)
     sizes[startDim + i] = vecTy.getShape()[i];
 
-  // We checked during candidate selection that if the memref rank is greater
-  // than 2, then the last two dimensions match the vector shape and the indices
-  // are zero.
   auto layout = cast<StridedLayoutAttr>(memrefTy.getLayout());
-  auto resultMemrefTy =
-      MemRefType::get(vecTy.getShape(), vecTy.getElementType(),
-                      StridedLayoutAttr::get(ctx, ShapedType::kDynamic,
-                                             layout.getStrides().take_back(2)),
-                      memrefTy.getMemorySpace());
+  auto resultMemrefTy = MemRefType::get(
+      vecTy.getShape(), vecTy.getElementType(),
+      StridedLayoutAttr::get(ctx, ShapedType::kDynamic,
+                             layout.getStrides().take_back(vecTy.getRank())),
+      memrefTy.getMemorySpace());
 
   Value memrefView = memref::SubViewOp::create(
       rewriter, loc, resultMemrefTy, op.getBase(),
@@ -392,8 +479,10 @@ void convertToContract(DotOpCandidate &candidate, PatternRewriter &rewriter) {
 
   rewriter.setInsertionPoint(op);
 
-  Value a = op.getA();
-  Value b = op.getB();
+  // Use the (potentially modified to encode VNNI packing) transfer reads as
+  // operands of the new contractation op.
+  Value a = candidate.lhsRead;
+  Value b = candidate.rhsRead;
   Value c = op.getC();
   VectorType aType = cast<VectorType>(a.getType());
   VectorType bType = cast<VectorType>(b.getType());
@@ -401,17 +490,32 @@ void convertToContract(DotOpCandidate &candidate, PatternRewriter &rewriter) {
 
   unsigned rank = cType.getRank();
   assert(rank == 2 && "Only 2D case is supported");
-  auto aMap = AffineMap::getMultiDimMapWithTargets(3, {0, 2}, ctx);
-  auto bMap = AffineMap::getMultiDimMapWithTargets(3, {2, 1}, ctx);
-  auto cMap = AffineMap::getMultiDimMapWithTargets(3, {0, 1}, ctx);
-  auto iteratorTypes = rewriter.getArrayAttr(
-      {vector::IteratorTypeAttr::get(ctx, vector::IteratorType::parallel),
-       vector::IteratorTypeAttr::get(ctx, vector::IteratorType::parallel),
-       vector::IteratorTypeAttr::get(ctx, vector::IteratorType::reduction)});
+  ArrayAttr indexingMaps, iteratorTypes;
+  if (!candidate.isVnniPacked) {
+    auto aMap = AffineMap::getMultiDimMapWithTargets(3, {0, 2}, ctx);
+    auto bMap = AffineMap::getMultiDimMapWithTargets(3, {2, 1}, ctx);
+    auto cMap = AffineMap::getMultiDimMapWithTargets(3, {0, 1}, ctx);
+    indexingMaps = rewriter.getAffineMapArrayAttr({aMap, bMap, cMap});
+    iteratorTypes = rewriter.getArrayAttr(
+        {vector::IteratorTypeAttr::get(ctx, vector::IteratorType::parallel),
+         vector::IteratorTypeAttr::get(ctx, vector::IteratorType::parallel),
+         vector::IteratorTypeAttr::get(ctx, vector::IteratorType::reduction)});
+  } else {
+    auto aMap = AffineMap::getMultiDimMapWithTargets(4, {0, 2, 3}, ctx);
+    auto bMap = AffineMap::getMultiDimMapWithTargets(4, {2, 1, 3}, ctx);
+    auto cMap = AffineMap::getMultiDimMapWithTargets(4, {0, 1}, ctx);
+    indexingMaps = rewriter.getAffineMapArrayAttr({aMap, bMap, cMap});
+    iteratorTypes = rewriter.getArrayAttr(
+        {vector::IteratorTypeAttr::get(ctx, vector::IteratorType::parallel),
+         vector::IteratorTypeAttr::get(ctx, vector::IteratorType::parallel),
+         vector::IteratorTypeAttr::get(ctx, vector::IteratorType::reduction),
+         vector::IteratorTypeAttr::get(ctx, vector::IteratorType::reduction)});
+  }
   candidate.contract = rewriter.replaceOpWithNewOp<vector::ContractionOp>(
-      op, a, b, c, rewriter.getAffineMapArrayAttr({aMap, bMap, cMap}),
-      iteratorTypes);
+      op, a, b, c, indexingMaps, iteratorTypes);
   candidate.dot = {};
+
+  LDBG("  Converted to contraction op: " << candidate.contract);
 }
 
 void performRegisterTiling(DotOpCandidate &candidate,
@@ -421,40 +525,50 @@ void performRegisterTiling(DotOpCandidate &candidate,
       32 / candidate.contract.getLhs().getType().getElementTypeBitWidth();
 
   static constexpr auto *unrollShapeAttrName = "unroll_shape";
-
-  if (candidate.target & AVX_NE_CONVERT) {
-    candidate.contract->setAttr(unrollShapeAttrName,
-                                rewriter.getI64ArrayAttr({1, 8, 1}));
-    candidate.lhsRead->setAttr(unrollShapeAttrName,
-                               rewriter.getI64ArrayAttr({1, 1}));
-    candidate.rhsRead->setAttr(unrollShapeAttrName,
-                               rewriter.getI64ArrayAttr({1, 8}));
-    candidate.accRead->setAttr(unrollShapeAttrName,
-                               rewriter.getI64ArrayAttr({1, 8}));
-    candidate.accWrite->setAttr(unrollShapeAttrName,
-                                rewriter.getI64ArrayAttr({1, 8}));
-  } else if (candidate.target & (AVX512_BF16 | AVX10_2)) {
-    candidate.contract->setAttr(unrollShapeAttrName,
-                                rewriter.getI64ArrayAttr({1, 16, vnniFactor}));
-    candidate.lhsRead->setAttr(unrollShapeAttrName,
-                               rewriter.getI64ArrayAttr({1, vnniFactor}));
-    candidate.rhsRead->setAttr(unrollShapeAttrName,
-                               rewriter.getI64ArrayAttr({vnniFactor, 16}));
-    candidate.accRead->setAttr(unrollShapeAttrName,
-                               rewriter.getI64ArrayAttr({1, 16}));
-    candidate.accWrite->setAttr(unrollShapeAttrName,
-                                rewriter.getI64ArrayAttr({1, 16}));
-  } else if (candidate.target & (AMX_BF16 | AMX_INT8)) {
+  auto setContractShape = [&](int64_t m, int64_t n, int64_t k) {
     candidate.contract->setAttr(
         unrollShapeAttrName,
-        rewriter.getI64ArrayAttr({16, 16, 16 * vnniFactor}));
-    candidate.lhsRead->setAttr(unrollShapeAttrName,
-                               rewriter.getI64ArrayAttr({16, 16 * vnniFactor}));
-    candidate.rhsRead->setAttr(unrollShapeAttrName,
-                               rewriter.getI64ArrayAttr({16 * vnniFactor, 16}));
+        candidate.isVnniPacked
+            ? rewriter.getI64ArrayAttr({m, n, k, vnniFactor})
+            : rewriter.getI64ArrayAttr({m, n, k * vnniFactor}));
+  };
+  auto setLhsShape = [&](int64_t m, int64_t k) {
+    candidate.lhsRead->setAttr(
+        unrollShapeAttrName,
+        candidate.isVnniPacked ? rewriter.getI64ArrayAttr({m, k, vnniFactor})
+                               : rewriter.getI64ArrayAttr({m, k * vnniFactor}));
+  };
+  auto setRhsShape = [&](int64_t k, int64_t n) {
+    candidate.rhsRead->setAttr(
+        unrollShapeAttrName,
+        candidate.isVnniPacked ? rewriter.getI64ArrayAttr({k, n, vnniFactor})
+                               : rewriter.getI64ArrayAttr({k * vnniFactor, n}));
+  };
+  auto setAccShape = [&](int64_t m, int64_t n) {
     candidate.accRead->setAttr(unrollShapeAttrName,
-                               rewriter.getI64ArrayAttr({16, 16}));
-    // Don't attempt to unroll the write.
+                               rewriter.getI64ArrayAttr({m, n}));
+    if (candidate.accWrite)
+      candidate.accWrite->setAttr(unrollShapeAttrName,
+                                  rewriter.getI64ArrayAttr({m, n}));
+  };
+
+  if (candidate.target & AVX_NE_CONVERT) {
+    assert(!candidate.isVnniPacked);
+    vnniFactor = 1; // TODO: Why is NE_CONVERT different?
+    setContractShape(1, 8, 1);
+    setLhsShape(1, 1);
+    setRhsShape(1, 8);
+    setAccShape(1, 8);
+  } else if (candidate.target & (AVX512_BF16 | AVX10_2)) {
+    setContractShape(1, 16, 1);
+    setLhsShape(1, 1);
+    setRhsShape(1, 16);
+    setAccShape(1, 16);
+  } else if (candidate.target & (AMX_BF16 | AMX_INT8)) {
+    setContractShape(16, 16, 16);
+    setLhsShape(16, 16);
+    setRhsShape(16, 16);
+    setAccShape(16, 16);
   } else {
     llvm_unreachable("Unsupported ISA extension for register tiling");
   }
@@ -661,6 +775,10 @@ LogicalResult convertCandidate(DotOpCandidate &candidate,
                                PatternRewriter &rewriter) {
   // Introduce temporary buffer if needed.
   makeAccBuffer(candidate, rewriter);
+
+  // If the operands are already VNNI-packed, communicate this to the patterns
+  // by encoding it in the types.
+  encodeVnniPacking(candidate, rewriter);
 
   // Insert memref.subview ops to ensure all transfer ops have zero indices.
   moveIndicesToSubview(candidate, rewriter);


### PR DESCRIPTION
The new support made it possible to port over the more sophisticated blocking and packing kernel from the `cpu-blocked-matmul.py` sample. The A operand is now pre-blocked as well, and I hoisted the intermediate and result buffer allocations out of the timed loop.