### PR TITLE
fix -lgcc linker error on macOS with clang

### DIFF
--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -32,10 +32,10 @@ def quiet():
         sys.stdout, sys.stderr = old_stdout, old_stderr
 
 
-def _is_apple_clang():
+def _is_apple_clang(compiler):
     if platform.system() != "Darwin":
         return False
-    res = subprocess.run(["clang", "--version"], capture_output=True, text=True)
+    res = subprocess.run([compiler, "--version"], capture_output=True, text=True)
     if res.returncode != 0:
         return False
     return "Apple clang" in res.stdout
@@ -105,7 +105,7 @@ def _build(name: str, src: str, srcdir: str, library_dirs: list[str], include_di
     if system == "Darwin":
         cc_cmd += ["-undefined", "dynamic_lookup"]
         # Don't use libgcc on clang + macos
-        if "clang" in cc:
+        if _is_apple_clang(cc):
             libraries.remove("gcc")
 
     if language == "c++":
@@ -120,7 +120,7 @@ def _build(name: str, src: str, srcdir: str, library_dirs: list[str], include_di
         cc_cmd += ["-std=c++17"]
         if not os.environ.get("TRITON_DISABLE_OPENMP", None):
             libomp_path = os.environ.get("TRITON_LOCAL_LIBOMP_PATH", None)
-            if _is_apple_clang():
+            if _is_apple_clang(cc):
                 if libomp_path:
                     cc_cmd += ["-Xclang"]
                     cc_cmd += ["-fopenmp"]


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it is in _build(), any test that JIT compiles a kernel will test it

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)


On macOS, `/usr/bin/gcc` is Clang pretending to be gcc. The
`_find_compiler()` helper picks it up before `clang`, so the build
command ends up as `/usr/bin/gcc ... -lgcc ...`. macOS has no `libgcc`,
so linking the kernel `.so` fails with:

    ld: library 'gcc' not found

`_is_apple_clang()` already exists in the same file and works correctly so we can reuse it here.

### Reproduction:
 Run TRITON_CPU_BACKEND=1 python python/test/unit/cpu/test_opt.py::test_vec_cdiv on macOS without CC=clang.
 
 It will throw an error without the change

I understand macos is not directly supported by this project. This is my first PR, but I would like to work more on macOS support if the maintainers are open to it.