### PR TITLE
[DotToNanokernel] Drop AMX exemption for presence of transfer_write

### DIFF
--- a/test/TritonCPU/dot-to-nanokernel.mlir
+++ b/test/TritonCPU/dot-to-nanokernel.mlir
@@ -717,9 +717,11 @@ tt.func public @gemm_avxneconvert_bf16_vnni(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr
 
 // AMX-COUNT-3: vector.transfer_read %[[BUFFER2]]
 // AMX:         %[[LAST_READ:.+]] = vector.transfer_read %[[BUFFER2]][%c16, %c16]
-// AMX-COUNT-3: vector.insert_strided_slice
-// AMX:         %[[REMAT:.+]] = vector.insert_strided_slice %[[LAST_READ]], %{{.+}}
-// AMX:         vector.transfer_write %[[REMAT]], %[[ORIG_MEMREF]]
+// AMX-COUNT-3: vector.transfer_write %{{.+}}, %[[BUFFER]]
+// AMX:         vector.transfer_write %[[LAST_READ]], %[[BUFFER]][%c16, %c16]
+// AMX:         %[[COPY:.+]] = vector.transfer_read %[[BUFFER]]
+// AMX-SAME:      memref<32x32xf32>, vector<32x32xf32>
+// AMX:         vector.transfer_write %[[COPY]], %[[ORIG_MEMREF]]
 
 tt.func public @gemm_amx_bf16_const_init(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %arg2: !tt.ptr<f32>, %arg3: i32, %arg4: i32, %arg5: i32) {
   %cst = arith.constant 0.000000e+00 : bf16

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
@@ -241,17 +241,11 @@ bool isNanokernelCandidate(triton::cpu::DotOp op, DotOpCandidate &candidate,
           : op.getC().getDefiningOp<vector::TransferReadOp>();
 
   vector::TransferWriteOp accWrite;
-  // AMX loop lowering always materializes the accumulator as a vector value, so
-  // it doesn't impose constraints on the vector.transfer_write.
-  bool isAMXLoop =
-      candidate.target & (AMX_BF16 | AMX_INT8) && candidate.isAccumulationLoop;
-  if (!isAMXLoop) {
-    OpResult accRes = candidate.isAccumulationLoop
-                          ? accLoop.getTiedLoopResult(accIterArg)
-                          : op->getOpResult(0);
-    if (accRes.hasOneUse())
-      accWrite = dyn_cast<vector::TransferWriteOp>(*accRes.getUsers().begin());
-  }
+  OpResult accRes = candidate.isAccumulationLoop
+                        ? accLoop.getTiedLoopResult(accIterArg)
+                        : op->getOpResult(0);
+  if (accRes.hasOneUse())
+    accWrite = dyn_cast<vector::TransferWriteOp>(*accRes.getUsers().begin());
 
   // Quirk in the patterns: they assume that the accumulator read and
   // write are from/to the same memref with the same indices. If not, we can't
@@ -357,9 +351,7 @@ bool isNanokernelCandidate(triton::cpu::DotOp op, DotOpCandidate &candidate,
 }
 
 void makeAccBuffer(DotOpCandidate &candidate, PatternRewriter &rewriter) {
-  bool isAMXLoop =
-      candidate.target & (AMX_BF16 | AMX_INT8) && candidate.isAccumulationLoop;
-  if (candidate.accRead && (isAMXLoop || candidate.accWrite))
+  if (candidate.accRead && candidate.accWrite)
     return; // Nothing to do.
 
   auto accTy = cast<VectorType>(candidate.dot.getC().getType());
@@ -394,9 +386,6 @@ void makeAccBuffer(DotOpCandidate &candidate, PatternRewriter &rewriter) {
   candidate.accRead = vector::TransferReadOp::create(
       rewriter, loc, accTy, candidate.accBuffer, zeroIndices, padding);
   operand->set(candidate.accRead);
-
-  if (isAMXLoop)
-    return;
 
   // After dot or loop...
   rewriter.setInsertionPointAfter(candidate.accLoop ? candidate.accLoop


### PR DESCRIPTION
Observed in KernelBench level 2: If the post op is a DAG (e.g. due to a residual add), the upstream pattern bails out even if a `vector.transfer_write` is present. To guarantee that the pattern always matches after preparations, I'm dropping the exemption for the AMX case again, so an intermediate buffer will be allocated unless the accumulator value comes from a `vector.transfer_read` and is written to the same location directly after the loop with a `vector.transfer_write`. My plan is to investigate if constraints can be relaxed upstream, or develop a clean-up pass to elide redundant copies.