### PR TITLE
fix macos CI timeout

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -81,6 +81,9 @@ jobs:
           pip install torch matplotlib
 
       - name: Install Triton
+        env:
+          #macos-latest has 3 cores and 7gb ram, cap
+          MAX_JOBS: ${{ matrix.config.target-os == 'macos' && '3' || '' }}
         run: |
           echo "PATH is '$PATH'"
           python3 -m pip install --no-build-isolation -vvv '.[tests]'
@@ -103,9 +106,9 @@ jobs:
           # We are generating bfcvt for bfloat16 tests when converting to fp32.
           # This is only for Clang15, works OK for Clang16
           # TODO - fix this using driver flags.
-          python -m pytest -s -n 32 --device cpu \
+          python -m pytest -s -n 3 --device cpu \
             python/test/unit/language/test_core.py -m cpu -k "not bfloat16"
-          python -m pytest -s -n 32 --device cpu \
+          python -m pytest -s -n 3 --device cpu \
             python/test/unit/cpu/test_math.py \
             python/test/unit/cpu/test_opt.py \
             python/test/unit/language/test_annotations.py \


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it fixes testing process.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
    
    
    The Macos CI run would timeout because it would creat 32 parallel threads on a 3 core system, I believe this led to a large part of the computation being taken up by context switching. Matching the thread count to the number of cores seems to allow the CI run to pass within the time limit.
