### PR TITLE
[CPU] Exclude runtime-only fields from autotune cache key

### DIFF
--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -61,8 +61,12 @@ class CPUOptions:
     def __post_init__(self):
         pass
 
+    # Launch/GPU-only knobs that don't affect the generated x86 code; excluding
+    # them from the cache key avoids redundant recompiles during autotuning.
+    _RUNTIME_ONLY_FIELDS = frozenset({"num_warps", "num_stages", "num_ctas", "num_cpu_threads"})
+
     def hash(self):
-        hash_dict = dict(self.__dict__)
+        hash_dict = {k: v for k, v in self.__dict__.items() if k not in self._RUNTIME_ONLY_FIELDS}
         key = "_".join([f"{name}-{val}" for name, val in sorted(hash_dict.items())])
         return hashlib.sha256(key.encode("utf-8")).hexdigest()
 
@@ -110,6 +114,11 @@ class CPUOptions:
 
 
 class CPUBackend(BaseBackend):
+
+    # Implements the generic BaseBackend.autotune_option_names hook: on CPU the
+    # GPU parallelism knobs (num_warps/num_ctas/num_stages/maxnreg) are ignored,
+    # and the only tunable launch option is the OpenMP thread count.
+    autotune_option_names = ("num_cpu_threads", )
 
     @staticmethod
     def supports_target(target: GPUTarget):


### PR DESCRIPTION
On the CPU backend, num_warps/num_stages/num_ctas are GPU-only and
num_cpu_threads is a launch-time-only OpenMP knob; none affect the generated
x86 code. Including them in CPUOptions.hash() caused configs that share the
same block sizes to trigger separate, redundant LLVM compilations during
autotuning, dominating first-run warmup.

- CPUOptions.hash(): drop num_warps/num_stages/num_ctas/num_cpu_threads from
  the compilation cache key so identical .so are reused.
- CPUBackend.autotune_option_names: implement the generic backend hook proposed
  upstream in triton-lang/triton#10894, declaring num_cpu_threads as the only
  CPU-relevant autotune option — so the shared autotuner forwards/displays the
  right knobs without CPU-specific code in shared files.

No change to generated code or GPU behavior.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it only changes the CPU compilation cache key and which autotune options are forwarded/displayed — no change to generated code or numerics.

- Select one of the following.
  - [x] I have not added any `lit` tests.
