### PR TITLE
[TTTCIR] Preserve original order when unrolling elementwise ops

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -221,11 +221,13 @@ jobs:
           DTYPE=float32 python  python/tutorials/cpu-blocked-matmul.py
           DTYPE=float16 python  python/tutorials/cpu-blocked-matmul.py
 
-          export TRITON_ALWAYS_COMPILE=1 TRITON_LLVM_DEBUG_ONLY=triton-cpu-dot-conversion
+          export TRITON_ALWAYS_COMPILE=1 \
+                 TRITON_CPU_UNROLL_AND_REORDER_ELEMENTWISE_OPS=1 \
+                 TRITON_LLVM_DEBUG_ONLY=triton-cpu-dot-conversion,triton-cpu-unroll-and-reorder-elementwise-ops
           python python/tutorials/cpu-sfc-matmul.py --dtype bfloat16 --target amx
           python python/tutorials/cpu-sfc-matmul.py --dtype int8     --target amx
           python python/tutorials/cpu-sfc-matmul.py --dtype bfloat16 --target avx512
-          unset TRITON_ALWAYS_COMPILE TRITON_LLVM_DEBUG_ONLY
+          unset TRITON_ALWAYS_COMPILE TRITON_CPU_UNROLL_AND_REORDER_ELEMENTWISE_OPS TRITON_LLVM_DEBUG_ONLY
 
       - name: OneDNN Run python unit tests on GNR
         env:

--- a/test/TritonCPU/unroll-and-reorder-eltwise.mlir
+++ b/test/TritonCPU/unroll-and-reorder-eltwise.mlir
@@ -164,3 +164,69 @@ tt.func public @negative_eltwise_kernel4(%arg0: !tt.ptr<bf16>, %arg2: !tt.ptr<bf
   vector.transfer_write %16, %21[%9, %10] {in_bounds = [true, true]} : vector<32x32xbf16>, memref<?x?xbf16, strided<[?, 1]>>
   tt.return
 }
+
+// -----
+
+// Check reordering in the presence of multiple vector.transfer_read ops.
+
+// CHECK-LABEL: eltwise_kernel5
+// CHECK:         vector.transfer_read
+// AVX512-SAME:   vector<8x32xbf16>
+// AVX2-SAME:     vector<2x32xbf16>
+// CHECK:         arith.extf
+// AVX512-SAME:   vector<8x32xf32>
+// AVX2-SAME:     vector<2x32xf32>
+// CHECK:         vector.transfer_read
+// AVX512-SAME:   vector<8x32xbf16>
+// AVX2-SAME:     vector<2x32xbf16>
+// CHECK:         arith.extf
+// AVX512-SAME:   vector<8x32xf32>
+// AVX2-SAME:     vector<2x32xf32>
+// CHECK:         arith.addf
+// AVX512-SAME:   vector<8x32xf32>
+// AVX2-SAME:     vector<2x32xf32>
+// CHECK:         arith.truncf
+// AVX512-SAME:   vector<8x32xf32> to vector<8x32xbf16>
+// AVX2-SAME:     vector<2x32xf32> to vector<2x32xbf16>
+// CHECK:         vector.transfer_write
+// AVX512-SAME:   vector<8x32xbf16>
+// AVX2-SAME:     vector<2x32xbf16>
+
+// Pattern shall repeat.
+
+// CHECK:         vector.transfer_read
+// CHECK:         arith.extf
+// CHECK:         vector.transfer_read
+// CHECK:         arith.extf
+// CHECK:         arith.addf
+// CHECK:         arith.truncf
+// CHECK:         vector.transfer_write
+
+tt.func public @eltwise_kernel5(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %arg2: !tt.ptr<bf16>, %arg3: i32, %arg4: i32) {
+  %cst = arith.constant 0.000000e+00 : bf16
+  %cst_0 = arith.constant dense<2.000000e+00> : vector<32x32xf32>
+  %cst_1 = arith.constant dense<1.500000e+00> : vector<32x32xf32>
+  %c1_i64 = arith.constant 1 : i64
+  %c32_i32 = arith.constant 32 : i32
+  %0 = tt.get_program_id x : i32
+  %1 = arith.muli %0, %c32_i32 : i32
+  %2 = tt.get_program_id y : i32
+  %3 = arith.muli %2, %c32_i32 : i32
+  %4 = arith.extsi %arg4 : i32 to i64
+  %5 = tt.make_tensor_descriptor %arg0, [%arg3, %arg4], [%4, %c1_i64] : <bf16>, <32x32xbf16>
+  %6 = tt.make_tensor_descriptor %arg1, [%arg3, %arg4], [%4, %c1_i64] : <bf16>, <32x32xbf16>
+  %7 = tt.make_tensor_descriptor %arg2, [%arg3, %arg4], [%4, %c1_i64] : <bf16>, <32x32xbf16>
+  %8 = triton_cpu.extract_memref %5 : <32x32xbf16> -> memref<?x?xbf16, strided<[?, 1]>>
+  %9 = arith.index_cast %1 : i32 to index
+  %10 = arith.index_cast %3 : i32 to index
+  %11 = vector.transfer_read %8[%9, %10], %cst {in_bounds = [true, true]} : memref<?x?xbf16, strided<[?, 1]>>, vector<32x32xbf16>
+  %12 = arith.extf %11 : vector<32x32xbf16> to vector<32x32xf32>
+  %13 = triton_cpu.extract_memref %6 : <32x32xbf16> -> memref<?x?xbf16, strided<[?, 1]>>
+  %14 = vector.transfer_read %13[%9, %10], %cst {in_bounds = [true, true]} : memref<?x?xbf16, strided<[?, 1]>>, vector<32x32xbf16>
+  %15 = arith.extf %14 : vector<32x32xbf16> to vector<32x32xf32>
+  %17 = arith.addf %12, %15 : vector<32x32xf32>
+  %20 = arith.truncf %17 : vector<32x32xf32> to vector<32x32xbf16>
+  %21 = triton_cpu.extract_memref %7 : <32x32xbf16> -> memref<?x?xbf16, strided<[?, 1]>>
+  vector.transfer_write %20, %21[%9, %10] {in_bounds = [true, true]} : vector<32x32xbf16>, memref<?x?xbf16, strided<[?, 1]>>
+  tt.return
+}

--- a/third_party/cpu/lib/TritonCPUTransforms/UnrollAndReorderElementwiseOps.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/UnrollAndReorderElementwiseOps.cpp
@@ -322,8 +322,8 @@ static LogicalResult rewriteElementwiseDAG(vector::TransferWriteOp writeOp,
     }
 
     auto orderAttr = op.getAttrOfType<IntegerAttr>(unrollOrderAttrName);
-    unsigned order = orderAttr ? orderAttr.getInt() + 1 : 0;
-    buckets[order].push_back(&op);
+    unsigned bucketIdx = orderAttr ? orderAttr.getInt() + 1 : 0;
+    buckets[bucketIdx].push_back(&op);
   }
 
   // We'll bring ops in the desired order by subsequently moving them before the

--- a/third_party/cpu/lib/TritonCPUTransforms/UnrollAndReorderElementwiseOps.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/UnrollAndReorderElementwiseOps.cpp
@@ -91,6 +91,9 @@ static SmallVector<int64_t> getUnrollingShape(VectorType vecTy,
   return unrollShape;
 }
 
+// Attempts to find a common unrolling shape for all ops in the DAG. The suffix
+// of the common shape divides the shape of each op's vector type. Returns
+// failure() if no common shape can be found.
 static FailureOr<SmallVector<int64_t>>
 getUnrollingShape(ArrayRef<Operation *> ops, VRFInfo &vrfInfo) {
   SmallVector<int64_t> unrollShape;
@@ -209,6 +212,8 @@ struct PropagateOrderAttrListener : public virtual RewriterBase::Listener {
 };
 } // namespace
 
+// Apply the upstream vector unroll patterns for ops that have the unroll_shape
+// attribute and are contained in the given scf.execute_region.
 static LogicalResult unrollOpsIn(scf::ExecuteRegionOp exec) {
   vector::UnrollVectorOptions unrollOptions;
   // Op has attribute and is contained in the execute_region.
@@ -236,15 +241,23 @@ static LogicalResult unrollOpsIn(scf::ExecuteRegionOp exec) {
                                std::move(patterns), config);
 }
 
-static void rewriteElementwiseDAG(vector::TransferWriteOp writeOp,
-                                  VRFInfo &vrfInfo, PatternRewriter &rewriter) {
+// Main driver. Checks whether the DAG rooted in `writeOp` is amenable for
+// unrolling and reordering, and if so, performs the transformation.
+//
+// Return value is success() if the transformation was either not applicable or
+// succeeded, and failure() if the transformation failed mid-way.
+static LogicalResult rewriteElementwiseDAG(vector::TransferWriteOp writeOp,
+                                           VRFInfo &vrfInfo,
+                                           PatternRewriter &rewriter) {
   LDBG("Attempt to rewrite elementwise DAG rooted in " << writeOp);
   SetVector<Operation *> dag;
   buildElementwiseDAG(writeOp, vrfInfo, dag);
 
   LDBG("  Discovered DAG of size " << dag.size() << ".");
-  if (dag.size() <= 1)
-    return;
+  if (dag.size() <= 1) {
+    LDBG("  No suitable elementwise DAG detected, giving up.");
+    return success();
+  }
 
   bool allUsersInDAG = llvm::all_of(dag, [&dag](Operation *node) {
     return isa<arith::ConstantOp, vector::TransferWriteOp>(node) ||
@@ -252,15 +265,15 @@ static void rewriteElementwiseDAG(vector::TransferWriteOp writeOp,
                         [&dag](Operation *user) { return dag.contains(user); });
   });
   if (!allUsersInDAG) {
-    LDBG("  Elementwise DAG has external users, aborting.");
-    return;
+    LDBG("  Elementwise DAG has external users, giving up.");
+    return success();
   }
 
   // Determine an unrolling shape that is suitable for all ops.
   SmallVector<Operation *> ops = dag.takeVector();
   auto maybeUnrollShape = getUnrollingShape(ops, vrfInfo);
   if (failed(maybeUnrollShape))
-    return;
+    return success();
   ArrayRef<int64_t> unrollShape = *maybeUnrollShape;
 
   rewriter.setInsertionPoint(writeOp);
@@ -288,8 +301,10 @@ static void rewriteElementwiseDAG(vector::TransferWriteOp writeOp,
   rewriter.replaceOp(writeOp, exec.getResults());
 
   // Unroll the ops in the execute_region.
-  [[maybe_unused]] auto res = unrollOpsIn(exec);
-  assert(succeeded(res));
+  if (failed(unrollOpsIn(exec))) {
+    LDBG("  Error: Failed to unroll ops in execute_region.");
+    return failure();
+  }
 
   // Sort the ops into buckets, according to their unroll_order attribute:
   // 0:    Ops that don't have an order attribute and are not
@@ -323,11 +338,20 @@ static void rewriteElementwiseDAG(vector::TransferWriteOp writeOp,
                                [](auto &bucket) { return bucket.empty(); }),
                 buckets.end());
 
+  if (buckets.empty()) {
+    LDBG("  Error: All buckets were empty.");
+    return failure();
+  }
+
   // All remaining buckets should contain the same number of ops, equivalent to
   // the unroll factor.
   unsigned unrollFactor = buckets.back().size();
-  assert(llvm::all_of(
-      buckets, [&](auto &bucket) { return bucket.size() == unrollFactor; }));
+  if (unrollFactor == 0 || !llvm::all_of(buckets, [&](auto &bucket) {
+        return bucket.size() == unrollFactor;
+      })) {
+    LDBG("  Error: Unexpected number of ops in buckets.");
+    return failure();
+  }
 
   for (unsigned u = 0; u < unrollFactor; ++u)
     for (unsigned b = 0; b < buckets.size(); ++b) {
@@ -338,6 +362,7 @@ static void rewriteElementwiseDAG(vector::TransferWriteOp writeOp,
     }
 
   LDBG("  Success.");
+  return success();
 }
 
 namespace {
@@ -358,9 +383,13 @@ struct UnrollAndReorderElementwiseOps
          << vrfInfo.nRegisters << "x" << vrfInfo.registerWidthBits);
 
     PatternRewriter rewriter(context);
-    mod->walk([&](vector::TransferWriteOp write) {
-      rewriteElementwiseDAG(write, vrfInfo, rewriter);
+    auto res = mod->walk([&](vector::TransferWriteOp write) {
+      if (failed(rewriteElementwiseDAG(write, vrfInfo, rewriter)))
+        return WalkResult::interrupt();
+      return WalkResult::advance();
     });
+    if (res.wasInterrupted())
+      signalPassFailure();
   }
 };
 

--- a/third_party/cpu/lib/TritonCPUTransforms/UnrollAndReorderElementwiseOps.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/UnrollAndReorderElementwiseOps.cpp
@@ -322,8 +322,9 @@ static void rewriteElementwiseDAG(vector::TransferWriteOp writeOp,
   buckets.erase(std::remove_if(buckets.begin(), buckets.end(),
                                [](auto &bucket) { return bucket.empty(); }),
                 buckets.end());
-  
-  // All remaining buckets should contain the same number of ops, equivalent to the unroll factor.
+
+  // All remaining buckets should contain the same number of ops, equivalent to
+  // the unroll factor.
   unsigned unrollFactor = buckets.back().size();
   assert(llvm::all_of(
       buckets, [&](auto &bucket) { return bucket.size() == unrollFactor; }));

--- a/third_party/cpu/lib/TritonCPUTransforms/UnrollAndReorderElementwiseOps.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/UnrollAndReorderElementwiseOps.cpp
@@ -253,11 +253,11 @@ static LogicalResult rewriteElementwiseDAG(vector::TransferWriteOp writeOp,
   SetVector<Operation *> dag;
   buildElementwiseDAG(writeOp, vrfInfo, dag);
 
-  LDBG("  Discovered DAG of size " << dag.size() << ".");
   if (dag.size() <= 1) {
     LDBG("  No suitable elementwise DAG detected, giving up.");
     return success();
   }
+  LDBG("  Discovered DAG of size " << dag.size() << ".");
 
   bool allUsersInDAG = llvm::all_of(dag, [&dag](Operation *node) {
     return isa<arith::ConstantOp, vector::TransferWriteOp>(node) ||

--- a/third_party/cpu/lib/TritonCPUTransforms/UnrollAndReorderElementwiseOps.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/UnrollAndReorderElementwiseOps.cpp
@@ -173,6 +173,41 @@ static void buildElementwiseDAG(Operation *op, VRFInfo &vrfInfo,
 }
 
 static constexpr auto *unrollShapeAttrName = "unroll_shape";
+static constexpr auto *unrollOrderAttrName = "unroll_order";
+
+namespace {
+// The upstream vector unroll patterns don't always propagate discardable
+// attributes to the unrolled ops. This should be fixed upstream, but until
+// then, this listener looks for the canonical chain of insert_strided_slice ops
+// and propagates the unroll_order attribute to the clones.
+struct PropagateOrderAttrListener : public virtual RewriterBase::Listener {
+  template <typename OpTy>
+  void propagateAttrToUnrolledOps(Operation *op, IntegerAttr attr,
+                                  Value newValue) {
+    if (auto oldOp = dyn_cast<OpTy>(op)) {
+      Value it = newValue;
+      vector::InsertStridedSliceOp insertOp;
+      OpTy newOp;
+      while ((insertOp = it.getDefiningOp<vector::InsertStridedSliceOp>()) &&
+             (newOp = insertOp.getValueToStore().getDefiningOp<OpTy>())) {
+        newOp->setAttr(unrollOrderAttrName, attr);
+        it = insertOp.getDest();
+      }
+    }
+  }
+
+  void notifyOperationReplaced(Operation *op, ValueRange newValues) override {
+    auto unrollOrderAttr = op->getAttrOfType<IntegerAttr>(unrollOrderAttrName);
+    if (!unrollOrderAttr || newValues.size() != 1)
+      return;
+    Value newValue = newValues.front();
+    propagateAttrToUnrolledOps<vector::TransferReadOp>(op, unrollOrderAttr,
+                                                       newValue);
+    propagateAttrToUnrolledOps<vector::ShapeCastOp>(op, unrollOrderAttr,
+                                                    newValue);
+  }
+};
+} // namespace
 
 static LogicalResult unrollOpsIn(scf::ExecuteRegionOp exec) {
   vector::UnrollVectorOptions unrollOptions;
@@ -194,8 +229,11 @@ static LogicalResult unrollOpsIn(scf::ExecuteRegionOp exec) {
 
   RewritePatternSet patterns(exec.getContext());
   vector::populateVectorUnrollPatterns(patterns, unrollOptions);
+  GreedyRewriteConfig config;
+  PropagateOrderAttrListener listener;
+  config.setListener(&listener);
   return applyPatternsGreedily(exec->getParentOfType<triton::FuncOp>(),
-                               std::move(patterns));
+                               std::move(patterns), config);
 }
 
 static void rewriteElementwiseDAG(vector::TransferWriteOp writeOp,
@@ -233,13 +271,15 @@ static void rewriteElementwiseDAG(vector::TransferWriteOp writeOp,
   Block *execBlock = rewriter.createBlock(&exec.getRegion());
   rewriter.setInsertionPointToStart(execBlock);
 
-  // Clone ops into the execute_region and determine unrolling shape.
+  // Clone ops into the execute_region.
   IRMapping mapping;
+  unsigned order = 0;
   for (auto *op : ops) {
     Operation *cloned = rewriter.clone(*op, mapping);
     auto rank = getVectorType(cloned).getRank();
     cloned->setAttr(unrollShapeAttrName,
                     rewriter.getI64ArrayAttr(unrollShape.take_back(rank)));
+    cloned->setAttr(unrollOrderAttrName, rewriter.getI64IntegerAttr(order++));
   }
 
   // Insert terminator and replace the original write op with the
@@ -251,39 +291,51 @@ static void rewriteElementwiseDAG(vector::TransferWriteOp writeOp,
   [[maybe_unused]] auto res = unrollOpsIn(exec);
   assert(succeeded(res));
 
-  // Remove the unroll_shape attribute and reorder ops in the execute_region.
-  // The idea is to produce chains from sources to the sinks (= unrolled
-  // transfer_write ops) that do not exceed the VRF's capacity.
-  SmallVector<Operation *> unrolledOps;
-  llvm::transform(execBlock->getOperations(), std::back_inserter(unrolledOps),
-                  [](Operation &op) { return &op; });
-  Operation *lastInvOp = nullptr;
-  for (auto *unrOp : unrolledOps) {
-    if (unrOp == execBlock->getTerminator())
+  // Sort the ops into buckets, according to their unroll_order attribute:
+  // 0:    Ops that don't have an order attribute and are not
+  //       vector.transfer.write ops.
+  // 1..N: Ops that have an order attribute.
+  // N+1:  vector.transfer.write ops.
+  SmallVector<SmallVector<Operation *>> buckets(order + 2);
+  Operation *terminator = execBlock->getTerminator();
+  for (Operation &op : execBlock->getOperations()) {
+    if (&op == terminator)
       continue;
-
-    unrOp->removeAttr(unrollShapeAttrName);
-
-    Operation *lastOperandOp = nullptr;
-    for (Value operand : unrOp->getOperands()) {
-      Operation *operandOp = operand.getDefiningOp();
-      if (!operandOp || operandOp->getBlock() != execBlock)
-        continue;
-      if (!lastOperandOp || lastOperandOp->isBeforeInBlock(operandOp))
-        lastOperandOp = operandOp;
+    if (isa<vector::TransferWriteOp>(op)) {
+      buckets.back().push_back(&op);
+      continue;
     }
-    if (lastOperandOp)
-      unrOp->moveAfter(lastOperandOp);
-    else {
-      // Make sure invariant ops moved to the top remain in their original
-      // order.
-      if (lastInvOp)
-        unrOp->moveAfter(lastInvOp);
-      else
-        unrOp->moveBefore(&execBlock->front());
-      lastInvOp = unrOp;
-    }
+
+    auto orderAttr = op.getAttrOfType<IntegerAttr>(unrollOrderAttrName);
+    unsigned order = orderAttr ? orderAttr.getInt() + 1 : 0;
+    buckets[order].push_back(&op);
   }
+
+  // We'll bring ops in the desired order by subsequently moving them before the
+  // terminator.
+  for (auto *op : buckets.front())
+    op->moveBefore(terminator);
+
+  // Remove special buckets: The first one we just handled, and any empty
+  // buckets (that corresponded to constants or folded operations).
+  buckets.erase(buckets.begin());
+  buckets.erase(std::remove_if(buckets.begin(), buckets.end(),
+                               [](auto &bucket) { return bucket.empty(); }),
+                buckets.end());
+  
+  // All remaining buckets should contain the same number of ops, equivalent to the unroll factor.
+  unsigned unrollFactor = buckets.back().size();
+  assert(llvm::all_of(
+      buckets, [&](auto &bucket) { return bucket.size() == unrollFactor; }));
+
+  for (unsigned u = 0; u < unrollFactor; ++u)
+    for (unsigned b = 0; b < buckets.size(); ++b) {
+      Operation *op = buckets[b][u];
+      op->moveBefore(terminator);
+      op->removeAttr(unrollShapeAttrName);
+      op->removeAttr(unrollOrderAttrName);
+    }
+
   LDBG("  Success.");
 }
 


### PR DESCRIPTION
This PR changes the reordering approach to recording the order of operations before unrolling, and then sorting the unrolled ops into buckets, from which the final instruction lists is serialized.

Before, we were moving ops closer to their operand's producers, but I observed this is problematic when ops have more than one operand without dependencies inside the `scf.execute_region`. Consider an `arith.addf` whose operands both are `vector.transfer_read` ops. There wasn't a mechanism to move the first clone of the second read before the last clone of the first read, so we couldn't move the addition (and any trailing ops) to a position where not the entire original vector value was live.