### PR TITLE
  [CPU] Isolate CPU-specific tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -111,6 +111,7 @@ jobs:
           python -m pytest -s -n 3 --device cpu \
             python/test/unit/cpu/test_math.py \
             python/test/unit/cpu/test_opt.py \
+            python/test/unit/cpu/test_cpu_subprocess.py \
             python/test/unit/language/test_annotations.py \
             python/test/unit/language/test_block_pointer.py \
             python/test/unit/language/test_compile_errors.py \
@@ -137,6 +138,7 @@ jobs:
           python -m pytest -s -n 32 --device cpu \
             python/test/unit/cpu/test_math.py \
             python/test/unit/cpu/test_opt.py \
+            python/test/unit/cpu/test_cpu_subprocess.py \
             python/test/unit/language/test_annotations.py \
             python/test/unit/language/test_block_pointer.py \
             python/test/unit/language/test_compile_errors.py \

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -131,6 +131,7 @@ jobs:
             python/test/unit/runtime/test_subproc.py \
             python/test/unit/test_debug_dump.py \
             --deselect python/test/unit/language/test_annotations.py::test_float_annotation \
+            --deselect python/test/unit/language/test_compile_errors.py::test_fp8_support \
             --deselect python/test/unit/language/test_conversions.py::test_typeconvert_upcast \
             --deselect python/test/unit/language/test_conversions.py::test_typeconvert_downcast \
             --deselect python/test/unit/language/test_conversions.py::test_typeconvert_downcast_clamping \
@@ -166,6 +167,7 @@ jobs:
             python/test/unit/runtime/test_subproc.py \
             python/test/unit/test_debug_dump.py \
             --deselect python/test/unit/language/test_annotations.py::test_float_annotation \
+            --deselect python/test/unit/language/test_compile_errors.py::test_fp8_support \
             --deselect python/test/unit/language/test_conversions.py::test_typeconvert_upcast \
             --deselect python/test/unit/language/test_conversions.py::test_typeconvert_downcast \
             --deselect python/test/unit/language/test_conversions.py::test_typeconvert_downcast_clamping \

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -111,6 +111,9 @@ jobs:
           python -m pytest -s -n 3 --device cpu \
             python/test/unit/cpu/test_math.py \
             python/test/unit/cpu/test_opt.py \
+            python/test/unit/cpu/test_cpu_annotations.py \
+            python/test/unit/cpu/test_cpu_conversions.py \
+            python/test/unit/cpu/test_cpu_flip.py \
             python/test/unit/cpu/test_cpu_subprocess.py \
             python/test/unit/language/test_annotations.py \
             python/test/unit/language/test_block_pointer.py \
@@ -127,6 +130,11 @@ jobs:
             python/test/unit/runtime/test_launch.py \
             python/test/unit/runtime/test_subproc.py \
             python/test/unit/test_debug_dump.py \
+            --deselect python/test/unit/language/test_annotations.py::test_float_annotation \
+            --deselect python/test/unit/language/test_conversions.py::test_typeconvert_upcast \
+            --deselect python/test/unit/language/test_conversions.py::test_typeconvert_downcast \
+            --deselect python/test/unit/language/test_conversions.py::test_typeconvert_downcast_clamping \
+            --deselect python/test/unit/language/test_standard.py::test_flip \
             -k "not bfloat16"
 
       - name: Run python unit tests for Intel
@@ -134,10 +142,13 @@ jobs:
         run: |
           python -m pytest -s -n 32 --device cpu -m cpu \
             python/test/unit/language/test_core.py \
-            python/test/unit/language/test_tensor_descriptor.py
+            python/test/unit/cpu/test_cpu_tensor_descriptor.py
           python -m pytest -s -n 32 --device cpu \
             python/test/unit/cpu/test_math.py \
             python/test/unit/cpu/test_opt.py \
+            python/test/unit/cpu/test_cpu_annotations.py \
+            python/test/unit/cpu/test_cpu_conversions.py \
+            python/test/unit/cpu/test_cpu_flip.py \
             python/test/unit/cpu/test_cpu_subprocess.py \
             python/test/unit/language/test_annotations.py \
             python/test/unit/language/test_block_pointer.py \
@@ -153,7 +164,12 @@ jobs:
             python/test/unit/runtime/test_driver.py \
             python/test/unit/runtime/test_launch.py \
             python/test/unit/runtime/test_subproc.py \
-            python/test/unit/test_debug_dump.py
+            python/test/unit/test_debug_dump.py \
+            --deselect python/test/unit/language/test_annotations.py::test_float_annotation \
+            --deselect python/test/unit/language/test_conversions.py::test_typeconvert_upcast \
+            --deselect python/test/unit/language/test_conversions.py::test_typeconvert_downcast \
+            --deselect python/test/unit/language/test_conversions.py::test_typeconvert_downcast_clamping \
+            --deselect python/test/unit/language/test_standard.py::test_flip
 
       - name: Run lit tests
         run: |

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
 addopts = --tb=short
-markers = interpreter: indicate whether interpreter supports the test
+markers =
+    interpreter: indicate whether interpreter supports the test
+    cpu: indicate whether test is supported on cpu
 python_files = test_*.py *_test.py tutorials/*.py examples/*.py

--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -3,8 +3,6 @@ import tempfile
 
 
 def pytest_configure(config):
-    config.addinivalue_line("markers", "interpreter: indicate whether interpreter supports the test")
-    config.addinivalue_line("markers", "cpu: indicate whether test is supported on cpu")
     # If pytest-sugar is not active, enable instafail
     if not config.pluginmanager.hasplugin("sugar"):
         config.option.instafail = True

--- a/python/test/unit/cpu/cpu_print_helper.py
+++ b/python/test/unit/cpu/cpu_print_helper.py
@@ -8,10 +8,6 @@ import triton
 import triton.language as tl
 
 
-def get_current_target_warp_size():
-    return triton.runtime.driver.active.get_current_target().warp_size
-
-
 @triton.jit
 def kernel_device_print(X, Y, BLOCK: tl.constexpr):
     x = tl.load(X + tl.arange(0, BLOCK))
@@ -41,10 +37,12 @@ def kernel_print(X, Y, BLOCK: tl.constexpr):
 
 
 @triton.jit
-def kernel_device_print_scalar(SCALAR):
+def kernel_device_print_scalars(SCALAR, INT, FLOAT):
     x = tl.load(SCALAR)
     # Triton should add a space after this prefix.
     print("x:", x)
+    print("int:", INT)
+    print("float:", FLOAT)
 
 
 @triton.jit
@@ -75,7 +73,7 @@ def kernel_device_print_multiple_args(X, Y, BLOCK: tl.constexpr):
 @triton.jit
 def kernel_static_print(X, Y, BLOCK: tl.constexpr, PLACEHOLDER: tl.constexpr):
     # This function takes an extra value as a tl.constexpr so this kernel is not
-    # cached.  This way the static print is run every time.
+    # cached. This way the static print is run every time.
     x = tl.load(X + tl.arange(0, BLOCK))
     tl.static_print("", x)
     tl.store(Y + tl.arange(0, BLOCK), x)
@@ -105,19 +103,22 @@ def kernel_print_2d_tensor(X, Y, BLOCK_SIZE_X: tl.constexpr, BLOCK_SIZE_Y: tl.co
 
 
 def test_print(func: str, data_type: str, device: str):
-    N = 128  # This value should match with test_print in test_subprocess.py.
-    # TODO(antiagainst): Currently the warp count is chosen to make sure we don't have multiple
-    # threads printing duplicated messages due to broadcasting. Improve print op lowering logic
-    # to filter out duplicated data range.
-    num_warps = N // get_current_target_warp_size()
+    if device != "cpu":
+        raise ValueError(f"CPU print helper received unexpected device: {device}")
+
+    N = 128  # This value should match test_cpu_print in test_cpu_subprocess.py.
+    SCALAR = 42
+    # The CPU target has no GPU warp. A logical size of one preserves the
+    # launch geometry used by the CPU print lowering.
+    num_warps = N
 
     x = torch.arange(0, N, dtype=torch.int32, device=device).to(getattr(torch, data_type))
     y = torch.zeros((N, ), dtype=x.dtype, device=device)
     if func == "device_print":
         kernel_device_print[(1, )](x, y, num_warps=num_warps, BLOCK=N)
-    elif func == "device_print_scalar":
-        scalar = torch.tensor(42, dtype=x.dtype, device=device)
-        kernel_device_print_scalar[(1, )](scalar, num_warps=num_warps)
+    elif func == "device_print_scalars":
+        scalar = torch.tensor(SCALAR, dtype=x.dtype, device=device)
+        kernel_device_print_scalars[(1, )](scalar, SCALAR, 3.14, num_warps=num_warps)
     elif func == "device_print_negative":
         x = -x
         kernel_device_print[(1, )](x, y, num_warps=num_warps, BLOCK=N)
@@ -145,24 +146,20 @@ def test_print(func: str, data_type: str, device: str):
     elif func == "device_print_pointer":
         kernel_print_pointer[(1, )](x, y, num_warps=num_warps, BLOCK=N)
     elif func == "device_print_2d_tensor":
-        BLOCK_SIZE_X = num_warps
-        BLOCK_SIZE_Y = get_current_target_warp_size()
-        x_2d_tensor = x.reshape((BLOCK_SIZE_X, BLOCK_SIZE_Y))
-        kernel_print_2d_tensor[(1, )](x_2d_tensor, y, num_warps=num_warps, BLOCK_SIZE_X=BLOCK_SIZE_X,
-                                      BLOCK_SIZE_Y=BLOCK_SIZE_Y)
+        block_size_x = N
+        block_size_y = 1
+        x_2d_tensor = x.reshape((block_size_x, block_size_y))
+        kernel_print_2d_tensor[(1, )](x_2d_tensor, y, num_warps=num_warps, BLOCK_SIZE_X=block_size_x,
+                                      BLOCK_SIZE_Y=block_size_y)
     else:
-        assert f"Unknown kernel: {func}"
+        raise ValueError(f"Unknown kernel: {func}")
 
     excluded_funcs = {
         "print_no_arg", "no_arg_print", "device_print_large", "print_multiple_args", "device_print_multiple_args",
-        "device_print_pointer", "device_print_scalar", "device_print_2d_tensor", "device_print_uint_cast"
+        "device_print_pointer", "device_print_scalars", "device_print_2d_tensor", "device_print_uint_cast"
     }
     if func not in excluded_funcs:
         assert_close(y, x)
-
-    # Wait until driver complete all the jobs for the device_print, especially test_subprocess
-    # require this which captures stdout when child exits.
-    getattr(torch, device).synchronize()
 
 
 if __name__ == "__main__":

--- a/python/test/unit/cpu/test_cpu_annotations.py
+++ b/python/test/unit/cpu/test_cpu_annotations.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+
+
+def annotated_function(return_type=None, **arg_types):
+
+    def decorator(func):
+        func.__annotations__ = {**arg_types, "return": return_type}
+        return func
+
+    return decorator
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("dtype", [
+    pytest.param(tl.float16, id="float16"),
+    pytest.param(tl.bfloat16, id="bfloat16"),
+    pytest.param(tl.float32, id="float32"),
+    pytest.param(tl.float64, id="float64"),
+])
+@pytest.mark.parametrize("test_val", [0.0, 42.0, float("inf"), float("nan")])
+def test_cpu_float_annotation(device, dtype, test_val):
+    if dtype in (tl.float16, tl.bfloat16) and test_val != 0.0:
+        pytest.xfail("Nonzero float16 and bfloat16 scalar annotations are NYI in the CPU backend")
+
+    @triton.jit
+    @annotated_function(val=dtype)
+    def kernel(ptr, val):
+        tl.static_assert(val.dtype == dtype)
+        tl.store(ptr, val)
+
+    ptr = torch.empty(1, device=device, dtype=torch.float32)
+    compiled = kernel[(1, )](ptr, test_val)
+    np.testing.assert_allclose(ptr.cpu().numpy(), [test_val], atol=1e-6)
+
+    if dtype == tl.float16:
+        assert "%val: f16" in compiled.asm["ttir"]
+        assert "arith.extf %val : f16 to f32" in compiled.asm["ttir"]
+    elif dtype == tl.bfloat16:
+        assert "%val: bf16" in compiled.asm["ttir"]
+        assert "arith.extf %val : bf16 to f32" in compiled.asm["ttir"]
+    elif dtype == tl.float32:
+        assert "%val: f32" in compiled.asm["ttir"]
+    elif dtype == tl.float64:
+        assert "%val: f64" in compiled.asm["ttir"]
+        assert "arith.truncf %val : f64 to f32" in compiled.asm["ttir"]

--- a/python/test/unit/cpu/test_cpu_annotations.py
+++ b/python/test/unit/cpu/test_cpu_annotations.py
@@ -17,6 +17,8 @@ def annotated_function(return_type=None, **arg_types):
     return decorator
 
 
+# Keep CPU-specific expected failures local: nonzero fp16 and bf16 scalar
+# annotations remain NYI, while zero and wider floating-point values must pass.
 @pytest.mark.cpu
 @pytest.mark.parametrize("dtype", [
     pytest.param(tl.float16, id="float16"),

--- a/python/test/unit/cpu/test_cpu_conversions.py
+++ b/python/test/unit/cpu/test_cpu_conversions.py
@@ -1,0 +1,67 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+import triton
+import triton.language as tl
+
+shared_test_path = Path(__file__).parents[1] / "language" / "test_conversions.py"
+shared_test_spec = importlib.util.spec_from_file_location("shared_test_conversions", shared_test_path)
+assert shared_test_spec is not None and shared_test_spec.loader is not None
+conversions = importlib.util.module_from_spec(shared_test_spec)
+sys.modules[shared_test_spec.name] = conversions
+shared_test_spec.loader.exec_module(conversions)
+
+
+def require_cpu(device):
+    if device != "cpu":
+        pytest.skip("CPU conversion tests require --device cpu.")
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("src_dtype", ["float8e4b8", "float8e4b15"])
+def test_cpu_unsupported_fp8_upcast(src_dtype, device):
+    require_cpu(device)
+
+    with pytest.raises(triton.CompilationError, match="not supported in this architecture"):
+        conversions.launch_exhaustive_populate(getattr(tl, src_dtype), 0, 65536, False, 8, 0x7f, device=device)
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("src_dtype, dst_dtype, rounding, max_repr", [
+    ("float32", "float8e5", "rtne", 0x47600000),
+    ("float32", "float8e5", "rtz", 0x47600000),
+    ("float32", "float8e4nv", "rtne", 0x43e00000),
+    ("float32", "float8e5b16", "rtne", 0x47600000),
+    ("bfloat16", "float8e5", "rtne", 0x4760),
+    ("bfloat16", "float8e4nv", "rtne", 0x43e0),
+    ("float16", "float8e5", "rtne", 0x7b00),
+    ("float16", "float8e4nv", "rtne", 0x5f00),
+    ("bfloat16", "float8e5b16", "rtne", 0x4760),
+    ("float16", "float8e5b16", "rtne", 0x7b00),
+])
+def test_cpu_typeconvert_downcast(src_dtype, dst_dtype, rounding, max_repr, device):
+    require_cpu(device)
+
+    exponent_bits, mantissa_bits, exponent_bias = {
+        "float8e5": (5, 2, 15),
+        "float8e4nv": (4, 3, 7),
+        "float8e5b16": (5, 2, 16),
+    }[dst_dtype]
+
+    # Exhaustive conversion is expensive on CPU. Sampling 16 high-byte
+    # offsets retains the coverage used by the CPU backend test suite.
+    for offset in range(16):
+        conversions.downcast_test(
+            getattr(tl, src_dtype),
+            getattr(tl, dst_dtype),
+            rounding,
+            exponent_bits,
+            mantissa_bits,
+            exponent_bias,
+            max_repr,
+            offset,
+            device=device,
+        )

--- a/python/test/unit/cpu/test_cpu_conversions.py
+++ b/python/test/unit/cpu/test_cpu_conversions.py
@@ -15,6 +15,10 @@ conversions = importlib.util.module_from_spec(shared_test_spec)
 sys.modules[shared_test_spec.name] = conversions
 shared_test_spec.loader.exec_module(conversions)
 
+# CPU supports a narrower FP8 matrix than GPU backends. Unsupported source
+# formats are checked as compile errors below; downcasts cover e5, e4nv, and
+# e5b16, while FP8 downcast clamping remains NYI and is excluded from CPU CI.
+
 
 def require_cpu(device):
     if device != "cpu":

--- a/python/test/unit/cpu/test_cpu_conversions.py
+++ b/python/test/unit/cpu/test_cpu_conversions.py
@@ -1,3 +1,4 @@
+import contextlib
 import importlib.util
 import sys
 from pathlib import Path
@@ -27,6 +28,31 @@ def test_cpu_unsupported_fp8_upcast(src_dtype, device):
 
     with pytest.raises(triton.CompilationError, match="not supported in this architecture"):
         conversions.launch_exhaustive_populate(getattr(tl, src_dtype), 0, 65536, False, 8, 0x7f, device=device)
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("dtype", [tl.float8e5, tl.float8e5b16, tl.float8e4nv, tl.float8e4b8, tl.float8e4b15])
+def test_cpu_fp8_dot_compile_support(fresh_triton_cache, dtype, device):
+    require_cpu(device)
+
+    supported_dtypes = [tl.float8e5, tl.float8e5b16, tl.float8e4nv]
+
+    @triton.jit
+    def dtype_kernel(dtype: tl.constexpr):
+        a = tl.full((64, 64), 0.0, dtype)
+        tl.dot(a, a)
+
+    if dtype in supported_dtypes:
+        ctx = contextlib.nullcontext()
+    else:
+        ctx = pytest.raises(triton.CompilationError)
+
+    with ctx as exc_info:
+        triton.compile(
+            triton.compiler.ASTSource(fn=dtype_kernel, signature={"dtype": "constexpr"}, constexprs={"dtype": dtype}))
+
+    if dtype not in supported_dtypes:
+        assert "not supported in this architecture" in str(exc_info.value.__cause__)
 
 
 @pytest.mark.cpu

--- a/python/test/unit/cpu/test_cpu_flip.py
+++ b/python/test/unit/cpu/test_cpu_flip.py
@@ -5,6 +5,9 @@ import triton
 import triton.language as tl
 from triton._internal_testing import numpy_random
 
+# This matrix preserves the CPU configurations selected when these tests were
+# isolated: shapes with both M and N non-unit had previously failed. The K=64
+# last-dimension case remains as regression coverage for a former xfail.
 flip_cases = [
     pytest.param(1, 16, 64, 0),
     pytest.param(1, 16, 64, 1),

--- a/python/test/unit/cpu/test_cpu_flip.py
+++ b/python/test/unit/cpu/test_cpu_flip.py
@@ -1,0 +1,39 @@
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+from triton._internal_testing import numpy_random
+
+flip_cases = [
+    pytest.param(1, 16, 64, 0),
+    pytest.param(1, 16, 64, 1),
+    pytest.param(1, 16, 64, 2),
+    pytest.param(1, 16, 64, -2),
+    pytest.param(32, 1, 2, 0),
+    pytest.param(32, 1, 2, 1),
+    pytest.param(32, 1, 2, 2),
+    pytest.param(32, 1, 2, -2),
+]
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("M, N, K, dim", flip_cases)
+@pytest.mark.parametrize("dtype_str", ["int32", "float16", "float32", "bfloat16"])
+def test_cpu_flip(M, N, K, dtype_str, dim, device):
+
+    @triton.jit
+    def flip_kernel(X, Z, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr, dim: tl.constexpr):
+        offx = tl.arange(0, M) * N * K
+        offy = tl.arange(0, N) * K
+        offz = tl.arange(0, K)
+        off3d = offx[:, None, None] + offy[None, :, None] + offz[None, None, :]
+        x = tl.load(X + off3d)
+        x = tl.flip(x, dim)
+        tl.store(Z + off3d, x)
+
+    x = torch.from_numpy(numpy_random((M, N, K), dtype_str=dtype_str)).to(device)
+    expected = torch.flip(x, (dim, ))
+    actual = torch.empty_like(x, device=device)
+    flip_kernel[(1, )](x, actual, M, N, K, dim, num_warps=8)
+    assert (expected == actual).all(), (expected, actual)

--- a/python/test/unit/cpu/test_cpu_subprocess.py
+++ b/python/test/unit/cpu/test_cpu_subprocess.py
@@ -1,0 +1,144 @@
+import os
+import subprocess
+import sys
+
+import pytest
+
+dir_path = os.path.dirname(os.path.realpath(__file__))
+print_path = os.path.join(dir_path, "cpu_print_helper.py")
+torch_types = ["int8", "uint8", "int16", "int32", "long", "float16", "float32", "float64"]
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("func_type, data_type", [(fn, data_type)
+                                                  for fn in ["device_print", "device_print_scalars"]
+                                                  for data_type in torch_types] + [
+                                                      ("print", "int32"),
+                                                      ("static_print", "int32"),
+                                                      ("no_arg_print", "int32"),
+                                                      ("print_no_arg", "int32"),
+                                                      ("device_print_large", "int32"),
+                                                      ("print_multiple_args", "int32"),
+                                                      ("device_print_multiple_args", "int32"),
+                                                      ("device_print_hex", "int16"),
+                                                      ("device_print_hex", "int32"),
+                                                      ("device_print_hex", "int64"),
+                                                      ("device_print_pointer", "int32"),
+                                                      ("device_print_negative", "int32"),
+                                                      ("device_print_uint", "uint32"),
+                                                      ("device_print_uint_cast", "uint8"),
+                                                      ("device_print_2d_tensor", "int32"),
+                                                  ])
+def test_cpu_print(func_type: str, data_type: str, device: str):
+    if device != "cpu":
+        pytest.skip("CPU print tests require --device cpu.")
+    if data_type == "float16" or func_type in ["device_print_pointer", "device_print_large"]:
+        pytest.skip("Printing float16, pointers, and large tensors is not yet supported on CPU.")
+
+    env = os.environ.copy()
+    env.pop("TRITON_CPU_BACKEND", None)
+    env.pop("TRITON_INTERPRET", None)
+    env["TRITON_DEFAULT_BACKEND"] = "cpu"
+    proc = subprocess.run(
+        [sys.executable, print_path, "test_print", func_type, data_type, device],
+        capture_output=True,
+        env=env,
+    )
+    assert proc.returncode == 0, proc.stderr.decode("UTF-8", errors="replace")
+
+    _check_cpu_print(proc.stdout.decode("UTF-8"), func_type, data_type, 128, 42)
+
+
+def _check_cpu_print(actual, func_type, data_type, N, SCALAR_VAL):
+    # An example of tensor printing is:
+    # (0, 0, 0) x: [  0,   1,   2,   3,   4,   5,   6,   7,
+    #                 8,   9,  10,  11,  12,  13,  14,  15,
+    #                 ...
+    #               120, 121, 122, 123, 124, 125, 126, 127]
+    PID_PREFIX = "(0, 0, 0)"
+    NEWLINE_WITH_PADDING = "\n" + " " * len(PID_PREFIX + " x: [")
+    if func_type in ("print", "device_print", "device_print_uint", "device_print_uint_cast"):
+        expected = PID_PREFIX + " x: ["
+        for i in range(N):
+            if func_type == "device_print_uint_cast":
+                offset = 128  # tl.arange(0, BLOCK) + 128
+            elif data_type == "uint32":
+                offset = 1 << 31
+            else:
+                offset = 0
+            expected += f"{i + offset:3}"
+            if data_type.startswith("float"):
+                expected += ".0000"
+            if i == N - 1:
+                continue
+            expected += ","
+            expected += NEWLINE_WITH_PADDING if i % 8 == 7 else " "
+        expected += "]"
+    elif func_type == "device_print_scalars":
+        expected = f"{PID_PREFIX} x: {SCALAR_VAL}"
+        if data_type.startswith("float"):
+            expected += ".000000"
+        expected += f"\n{PID_PREFIX} int: {SCALAR_VAL}"
+        expected += f"\n{PID_PREFIX} float: 3.140000"
+    elif func_type == "device_print_negative":
+        expected = PID_PREFIX + " x: ["
+        for i in range(N):
+            expected += f"{-i:4}"
+            if i == N - 1:
+                continue
+            expected += ","
+            expected += NEWLINE_WITH_PADDING if i % 8 == 7 else " "
+        expected += "]"
+    elif func_type == "device_print_hex":
+        expected = PID_PREFIX + " x: ["
+        for i in range(N):
+            if data_type.endswith("8"):
+                expected += f"0x{i:02x}"
+            elif data_type.endswith("16"):
+                expected += f"0x{i:04x}"
+            elif data_type.endswith("32"):
+                expected += f"0x{i:08x}"
+            elif data_type.endswith("64"):
+                expected += f"0x{i:016x}"
+            if i == N - 1:
+                continue
+            expected += ","
+            expected += NEWLINE_WITH_PADDING if i % 8 == 7 else " "
+        expected += "]"
+    elif func_type == "static_print":
+        expected = f" int32[constexpr[{N}]]"
+    elif func_type == "no_arg_print":
+        expected = f"{PID_PREFIX}: 0"
+    elif func_type == "print_no_arg":
+        expected = f"{PID_PREFIX} no arg"
+    elif func_type in ("print_multiple_args", "device_print_multiple_args"):
+        expected = ""
+        for k in range(2):
+            expected += PID_PREFIX + ": ["
+            for i in range(N):
+                expected += f"{i:3}" if k == 0 else "1"
+                if i == N - 1:
+                    continue
+                expected += ","
+                if i % 8 == 7:
+                    expected += "\n" + " " * len(PID_PREFIX + ": [")
+                else:
+                    expected += " "
+            expected += "]"
+            if k == 0:
+                expected += "\n"
+    elif func_type == "device_print_2d_tensor":
+        # CPU prints a shape-(N, 1) tensor because it has no GPU warp.
+        expected = PID_PREFIX + ": ["
+        for i in range(N):
+            expected += f"[{i:3}]"
+            if i == N - 1:
+                continue
+            expected += ","
+            expected += "\n" + " " * len(PID_PREFIX + ": [")
+        expected += "]"
+    else:
+        raise ValueError(f"Unexpected CPU print test case: {func_type}")
+
+    assert actual.endswith("\n")
+    assert actual[:-1] == expected

--- a/python/test/unit/cpu/test_cpu_tensor_descriptor.py
+++ b/python/test/unit/cpu/test_cpu_tensor_descriptor.py
@@ -1,0 +1,118 @@
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+from triton._internal_testing import tma_dtypes
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+_SHARED_TEST_PATH = pathlib.Path(__file__).parents[1] / "language" / "test_tensor_descriptor.py"
+_SHARED_TEST_SPEC = importlib.util.spec_from_file_location("_shared_tensor_descriptor_tests", _SHARED_TEST_PATH)
+assert _SHARED_TEST_SPEC is not None and _SHARED_TEST_SPEC.loader is not None
+_SHARED_TESTS = importlib.util.module_from_spec(_SHARED_TEST_SPEC)
+sys.modules[_SHARED_TEST_SPEC.name] = _SHARED_TESTS
+_SHARED_TEST_SPEC.loader.exec_module(_SHARED_TESTS)
+
+_test_functional_interface = _SHARED_TESTS.test_tensor_descriptor_functional_interface
+_test_load = _SHARED_TESTS.test_tensor_descriptor_load
+_test_load3d = _SHARED_TESTS.test_tensor_descriptor_load3d
+_test_load_nd = _SHARED_TESTS.test_tensor_descriptor_load_nd
+_test_store = _SHARED_TESTS.test_tensor_descriptor_store
+_test_store3d = _SHARED_TESTS.test_tensor_descriptor_store3d
+_test_store_nd = _SHARED_TESTS.test_tensor_descriptor_store_nd
+
+pytestmark = pytest.mark.cpu
+
+
+@pytest.mark.parametrize("dtype_str", tma_dtypes)
+@pytest.mark.parametrize("M_BLOCK,N_BLOCK", [(2, 16), (8, 16), (8, 32)])
+def test_cpu_tensor_descriptor_load(dtype_str, M_BLOCK, N_BLOCK, device):
+    _test_load(dtype_str, 1, M_BLOCK, N_BLOCK, device)
+
+
+@pytest.mark.parametrize("dtype_str", tma_dtypes)
+@pytest.mark.parametrize("M_BLOCK,N_BLOCK", [(2, 16), (8, 16), (8, 32)])
+def test_cpu_tensor_descriptor_store(dtype_str, M_BLOCK, N_BLOCK, device):
+    _test_store(dtype_str, 1, M_BLOCK, N_BLOCK, device)
+
+
+@pytest.mark.parametrize("dtype_str", tma_dtypes)
+def test_cpu_tensor_descriptor_functional_interface(dtype_str, device):
+    _test_functional_interface(dtype_str, device)
+
+
+@pytest.mark.parametrize("dtype_str", tma_dtypes)
+@pytest.mark.parametrize("K_BLOCK", [16, 32])
+def test_cpu_tensor_descriptor_load3d(dtype_str, K_BLOCK, device):
+    _test_load3d(dtype_str, K_BLOCK, device)
+
+
+@pytest.mark.parametrize("dtype_str", tma_dtypes)
+@pytest.mark.parametrize("K_BLOCK", [16, 32])
+def test_cpu_tensor_descriptor_store3d(dtype_str, K_BLOCK, device):
+    _test_store3d(dtype_str, K_BLOCK, device)
+
+
+@pytest.mark.parametrize("dtype_str", tma_dtypes)
+@pytest.mark.parametrize("ndim", [1, 2, 3, 4, 5])
+@pytest.mark.parametrize("INNER_BLOCK", [16, 32])
+def test_cpu_tensor_descriptor_load_nd(dtype_str, ndim, INNER_BLOCK, device):
+    _test_load_nd(dtype_str, 1, ndim, INNER_BLOCK, device)
+
+
+@pytest.mark.parametrize("dtype_str", tma_dtypes)
+@pytest.mark.parametrize("ndim", [1, 2, 3, 4, 5])
+@pytest.mark.parametrize("INNER_BLOCK", [16, 32])
+def test_cpu_tensor_descriptor_store_nd(dtype_str, ndim, INNER_BLOCK, device):
+    _test_store_nd(dtype_str, 1, ndim, INNER_BLOCK, device)
+
+
+def test_cpu_tensor_descriptor_padding(device):
+
+    @triton.jit
+    def device_descriptor_load(in_ptr, out_ptr, IM, IN, OM, ON, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr,
+                               padding: tl.constexpr):
+        desc = tl.make_tensor_descriptor(
+            in_ptr,
+            shape=[IM, IN],
+            strides=[IN, 1],
+            block_shape=[M_BLOCK, N_BLOCK],
+            padding_option=padding,
+        )
+
+        moffset = tl.program_id(0) * M_BLOCK
+        noffset = tl.program_id(1) * N_BLOCK
+        value = desc.load([moffset, noffset])
+
+        offsets_m = moffset + tl.arange(0, M_BLOCK)
+        offsets_n = noffset + tl.arange(0, N_BLOCK)
+        tl.store(out_ptr + offsets_m[:, None] * ON + offsets_n[None, :], value)
+
+    def alloc_fn(size: int, alignment: float, stream: float):
+        return torch.ones(size, device=device, dtype=torch.float32)
+
+    triton.set_allocator(alloc_fn)
+
+    input_shape = (48, 48)
+    output_shape = (64, 64)
+    block_shape = (32, 32)
+    inp = torch.arange(input_shape[0] * input_shape[1], device=device, dtype=torch.float32)
+    inp = inp.reshape(input_shape)
+    out = torch.zeros(output_shape, device=device, dtype=torch.float32)
+
+    host_descriptor = TensorDescriptor(inp, inp.shape, inp.stride(), list(block_shape), padding="nan")
+    assert tuple(host_descriptor.shape) == input_shape
+    assert tuple(host_descriptor.block_shape) == block_shape
+
+    grid = tuple(triton.cdiv(size, block) for size, block in zip(output_shape, block_shape))
+    device_descriptor_load[grid](inp, out, *input_shape, *output_shape, *block_shape, "nan")
+
+    expected = torch.zeros(output_shape, device=device, dtype=torch.float32)
+    expected[:input_shape[0], :input_shape[1]] = inp
+    expected[:, input_shape[1]:] = float("nan")
+    expected[input_shape[0]:, :] = float("nan")
+    torch.testing.assert_close(expected, out, equal_nan=True)

--- a/python/test/unit/cpu/test_cpu_tensor_descriptor.py
+++ b/python/test/unit/cpu/test_cpu_tensor_descriptor.py
@@ -27,6 +27,10 @@ _test_store_nd = _SHARED_TESTS.test_tensor_descriptor_store_nd
 
 pytestmark = pytest.mark.cpu
 
+# These wrappers preserve the CPU subset selected when the tests were split:
+# one CTA and block dimensions no larger than 32. Larger blocks and multi-CTA
+# configurations had previously been skipped by the shared tests.
+
 
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
 @pytest.mark.parametrize("M_BLOCK,N_BLOCK", [(2, 16), (8, 16), (8, 32)])
@@ -72,6 +76,8 @@ def test_cpu_tensor_descriptor_store_nd(dtype_str, ndim, INNER_BLOCK, device):
 
 
 def test_cpu_tensor_descriptor_padding(device):
+    # The original CPU path exercised only descriptors created in the kernel;
+    # keep padding coverage on that path rather than a host-passed descriptor.
 
     @triton.jit
     def device_descriptor_load(in_ptr, out_ptr, IM, IN, OM, ON, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr,

--- a/python/test/unit/language/test_annotations.py
+++ b/python/test/unit/language/test_annotations.py
@@ -5,8 +5,6 @@ import triton.language as tl
 import pytest
 import numpy as np
 
-from test_core import is_cpu
-
 
 def annotated_function(return_type=None, **arg_types):
     """A decorator to add annotations to a function."""
@@ -62,8 +60,6 @@ def test_unknown_annotation(device):
      for test_val in [0.0, 42.0, float("inf"), float("nan")]],
 )
 def test_float_annotation(device, dtype, test_val):
-    if is_cpu():
-        pytest.xfail("NYI in CPU backend")
 
     @triton.jit
     @annotated_function(val=dtype)

--- a/python/test/unit/language/test_block_pointer.py
+++ b/python/test/unit/language/test_block_pointer.py
@@ -3,7 +3,7 @@ import torch
 
 import triton
 import triton.language as tl
-from test_core import check_type_supported, is_cpu
+from test_core import check_type_supported
 
 
 @triton.jit
@@ -37,9 +37,6 @@ def block_copy_kernel(a_ptr, b_ptr, N, BLOCK_SIZE: tl.constexpr, PADDING_OPTION:
     for boundary_check in (None, "lower", "upper")
 ])
 def test_block_copy(dtypes_str, n, padding_option, boundary_check, device):
-    if is_cpu() and boundary_check == "lower":
-        pytest.skip("Lower boundary check is NYI for CPU")
-
     src_dtype_str = dtypes_str[0]
     dst_dtype_str = dtypes_str[1]
     src_dtype = getattr(torch, src_dtype_str)
@@ -66,24 +63,6 @@ def test_block_copy(dtypes_str, n, padding_option, boundary_check, device):
             assert torch.all(b[n // 2:n] == 0)
         elif padding_option == "nan":
             assert torch.all(torch.isnan(b[n // 2:n]))
-
-
-def test_block_copy2d(device):
-
-    @triton.jit
-    def kernel(in_ptr, out_ptr, M: tl.constexpr, N: tl.constexpr, BLOCK_M: tl.constexpr):
-        block_offset = tl.program_id(0) * BLOCK_M
-        in_block_ptr = tl.make_block_ptr(base=in_ptr, shape=(M, N), strides=(N, 1), offsets=(block_offset, 0),
-                                         block_shape=(BLOCK_M, N), order=(1, 0))
-        out_block_ptr = tl.make_block_ptr(base=out_ptr, shape=(M, N), strides=(N, 1), offsets=(block_offset, 0),
-                                          block_shape=(BLOCK_M, N), order=(1, 0))
-        x = tl.load(in_block_ptr)
-        tl.store(out_block_ptr, x)
-
-    inp = torch.randn((256, 16), device=device, dtype=torch.float32)
-    res = torch.empty_like(inp)
-    kernel[(16, )](inp, res, M=16, N=16, BLOCK_M=16)
-    assert (inp == res).all()
 
 
 @triton.jit
@@ -122,9 +101,6 @@ def matmul_no_scf_with_advance_kernel(  #
 ])
 def test_block_ptr_matmul_no_scf(shape, num_warps, device):
     m, n, k = shape
-    if is_cpu():
-        # FIXME: fix compilation time for bigger shapes on CPU
-        m = n = 16
     a = torch.randn((m, k), device=device, dtype=torch.float16)
     b = torch.randn((k, n), device=device, dtype=torch.float16)
     c = torch.empty((m, n), device=device, dtype=torch.float32)
@@ -138,11 +114,7 @@ def test_block_ptr_matmul_no_scf(shape, num_warps, device):
         stride_cm=c.stride(0), stride_cn=c.stride(1),  #
         BLOCK_M=m, BLOCK_N=n, BLOCK_K=k,  #
         num_warps=num_warps)
-    if is_cpu():
-        # torch.matmul not implemented for Half float (float16) cpu
-        golden = torch.matmul(a.to(torch.float32), b.to(torch.float32))
-    else:
-        golden = torch.matmul(a, b)
+    golden = torch.matmul(a, b)
     torch.testing.assert_close(c, golden, check_dtype=False)
 
 

--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -7,7 +7,7 @@ import triton
 import triton.language as tl
 from triton.compiler.errors import CompilationError, CompileTimeAssertionFailure
 import traceback
-from triton._internal_testing import is_cuda, is_hip, is_hip_cdna4, is_cpu
+from triton._internal_testing import is_cuda, is_hip, is_hip_cdna4
 
 
 def format_exception(type, value, tb):
@@ -364,9 +364,6 @@ def test_fp8_support(fresh_triton_cache, dtype):
         supported_dtypes += [tl.float8e4nv, tl.float8e4b8, tl.float8e5b16]
         if is_hip_cdna4():
             warning_dtypes += [tl.float8e4b8, tl.float8e5b16]
-            supported_dtypes += [tl.float8e4nv]
-    elif is_cpu():
-        supported_dtypes = [tl.float8e5, tl.float8e5b16, tl.float8e4nv]
 
     @triton.jit
     def dtype_kernel(dtype: tl.constexpr):

--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -7,7 +7,7 @@ import pytest
 import triton
 import triton.language as tl
 
-from triton._internal_testing import is_cuda, is_hip, is_hip_cdna2, is_hip_cdna3, is_hip_cdna4, is_hip_rdna3, is_hip_rdna4, is_hip_gfx1250, is_cpu
+from triton._internal_testing import is_cuda, is_hip, is_hip_cdna2, is_hip_cdna3, is_hip_cdna4, is_hip_rdna3, is_hip_rdna4, is_hip_gfx1250
 
 FP8_DTYPES = ('float8e5', 'float8e4b15', 'float8e4nv', 'float8e4b8', 'float8e5b16')
 
@@ -297,12 +297,6 @@ def test_typeconvert_upcast(src_dtype, dst_dtype, device):
             return
         if src_dtype in ('float8e4b8', 'float8e5b16') and is_hip_cdna2():
             pytest.skip(f"{src_dtype} is not supported on current AMD GPU")
-    elif is_cpu():
-        if src_dtype in ('float8e4b8', 'float8e4b15'):
-            # If the dtype should error out in the given device, we assert that and return
-            with pytest.raises(triton.CompilationError, match="not supported in this architecture"):
-                launch_exhaustive_populate(getattr(tl, src_dtype), 0, 65536, False, 8, 0x7f, device=device)
-        return
 
     # dtype : (exponent_bits, mantissa_bits, exponent_bias, max_repr)
     stuff = {
@@ -342,9 +336,6 @@ def test_typeconvert_upcast(src_dtype, dst_dtype, device):
     ('float16', 'float8e4b8', 'rtne', 0x5b80),
 ])
 def test_typeconvert_downcast(src_dtype, dst_dtype, rounding, max_repr, device):
-    if is_cpu() and dst_dtype not in ['float8e5', 'float8e4nv', 'float8e5b16']:
-        # TODO: check if 'float8e4b15' downcast is fine for cpu if it will enable in this test
-        pytest.skip(f"Conversion from {src_dtype} to {dst_dtype} is not supported on CPU")
 
     if is_cuda():
         if src_dtype != 'float32' and torch.cuda.get_device_capability(0) < (9, 0):
@@ -373,8 +364,7 @@ def test_typeconvert_downcast(src_dtype, dst_dtype, rounding, max_repr, device):
         'float8e5b16': (5, 2, 16),
     }[dst_dtype]
 
-    # TODO: On CPU, this is pretty slow. Investigate why it's slow.
-    for i in range(16 if is_cpu() else 256):
+    for i in range(256):
         downcast_test(getattr(tl, src_dtype), getattr(tl, dst_dtype), rounding, *stuff, max_repr, i, device=device)
 
 @pytest.mark.parametrize("mode", [
@@ -389,8 +379,6 @@ def test_typeconvert_downcast_clamping(src_dtype, dst_dtype, mode, device, round
 
         if dst_dtype in ('float8e5', 'float8e4nv') and rounding == 'rtne' and torch.cuda.get_device_capability(0) < (9, 0):
             pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on NVGPU with compute capability 9.0+")
-    if is_cpu():
-        pytest.xfail("NYI in CPU backend")
 
     if dst_dtype in FP8_DTYPES and is_hip_rdna3():
         pytest.skip(f"{dst_dtype} is not supported on AMDGPU RDNA3")

--- a/python/test/unit/language/test_pipeliner.py
+++ b/python/test/unit/language/test_pipeliner.py
@@ -4,7 +4,6 @@ import pytest
 import torch
 import triton
 import triton.language as tl
-from test_core import is_cpu
 
 from triton._internal_testing import is_cuda, is_hopper_or_newer, is_hip_cdna, is_hip_cdna2, is_hip
 
@@ -271,11 +270,7 @@ def test_pipeline_matmul(scale, device):
     if scale:
         ref_out = dot_scale_ref(a, scale_a, b, a_type, b_type)
     else:
-        if is_cpu():
-            ref_out = torch.matmul(a.to(torch.float32), b.to(torch.float32)).to(torch.float16)
-        else:
-            ref_out = torch.matmul(a, b)
-
+        ref_out = torch.matmul(a, b)
     # Bigger tolerance for AMD CDNA2 devices.
     # CDNA2 devices use reduced precision fp16 and bf16 and flush input and
     # output denormal values to zero. Detailed info is at: https://pytorch.org/docs/stable/notes/numerical_accuracy.html#reduced-precision-fp16-and-bf16-gemms-and-convolutions-on-amd-instinct-mi200-devices

--- a/python/test/unit/language/test_standard.py
+++ b/python/test/unit/language/test_standard.py
@@ -3,7 +3,7 @@ import pytest
 import torch
 import triton.language as tl
 
-from test_core import _test_binary, int_dtypes, uint_dtypes, float_dtypes, numpy_random, is_cpu
+from test_core import _test_binary, int_dtypes, uint_dtypes, float_dtypes, numpy_random
 
 # ---------------
 # test maximum/minimum ops
@@ -69,10 +69,6 @@ def test_sort(M, N, k, descending, dtype_str, device):
 @pytest.mark.parametrize("dtype_str", ['int32', 'float16', 'float32', 'bfloat16'])
 @pytest.mark.parametrize("dim", [0, 1, 2, -2])
 def test_flip(M, N, K, dtype_str, dim, device):
-    if is_cpu() and (M != 1 and N != 1):
-        pytest.skip("Flip does not work correctly on CPU if both dimensions are not 1")
-    if is_cpu() and dim == 2 and K > 4:
-        pytest.xfail("last-dimension flip is broken")
 
     @triton.jit
     def flip_kernel(X, Z, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr, dim: tl.constexpr):

--- a/python/test/unit/language/test_subprocess.py
+++ b/python/test/unit/language/test_subprocess.py
@@ -5,7 +5,7 @@ import sys
 from collections import Counter
 
 import triton
-from triton._internal_testing import is_interpreter, is_cpu
+from triton._internal_testing import is_interpreter
 
 import pytest
 
@@ -14,10 +14,9 @@ print_path = os.path.join(dir_path, "print_helper.py")
 torch_types = ["int8", "uint8", "int16", "int32", "long", "float16", "float32", "float64"]
 
 
-@pytest.mark.cpu
 @pytest.mark.interpreter
 @pytest.mark.parametrize("func_type, data_type", [(fn, data_type)
-                                                  for fn in ["device_print", "device_print_scalars"]
+                                                  for fn in ["device_print", "device_print_scalar"]
                                                   for data_type in torch_types] + [
                                                       ("print", "int32"),
                                                       ("static_print", "int32"),
@@ -36,13 +35,9 @@ torch_types = ["int8", "uint8", "int16", "int32", "long", "float16", "float32", 
                                                       ("device_print_2d_tensor", "int32"),
                                                   ])
 def test_print(func_type: str, data_type: str, device: str):
-    if is_cpu() and (data_type == "float16" or func_type in ["device_print_pointer", "device_print_large"]):
-        pytest.skip("test_print for float16/pointer/large are not yet supported on CPU.")
-
     proc = subprocess.run(
         [sys.executable, print_path, "test_print", func_type, data_type, device],
         capture_output=True,
-        env={**os.environ, "TRITON_CPU_BACKEND": "1" if is_cpu() else "0"},
     )
     assert proc.returncode == 0
 
@@ -59,11 +54,6 @@ def test_print(func_type: str, data_type: str, device: str):
     # Constant for testing the printing of scalar values
     SCALAR_VAL = 42
 
-    # TODO: Consider cases for signedness, overflow, and multiple pids (non-determinism).
-    if is_cpu():
-        _check_cpu_print(proc.stdout.decode("UTF-8"), func_type, data_type, N, SCALAR_VAL)
-        return
-
     # Format is
     #   pid (<x>, <y>, <z>) idx (<i1>, <i2>, ...) <prefix> (operand <n>) <elem>
     expected_lines = Counter()
@@ -78,14 +68,10 @@ def test_print(func_type: str, data_type: str, device: str):
             if data_type.startswith("float"):
                 line += ".000000"
             expected_lines[line] = 1
-    elif func_type == "device_print_scalars":
+    elif func_type == "device_print_scalar":
         line = f"pid (0, 0, 0) idx () x: {SCALAR_VAL}"
         if data_type.startswith("float"):
             line += ".000000"
-        expected_lines[line] = N
-        line = f"pid (0, 0, 0) idx () int: {SCALAR_VAL}"
-        expected_lines[line] = N
-        line = "pid (0, 0, 0) idx () float: 3.140000"
         expected_lines[line] = N
     elif func_type == "device_print_negative":
         for i in range(N):
@@ -138,108 +124,3 @@ def test_print(func_type: str, data_type: str, device: str):
             continue
         print(f'Expected line "{line}" {expected_lines[line]} time(s), but saw {actual_lines[line]} time(s)')
     assert all(delta == 0 for delta in diff.values())
-
-
-def _check_cpu_print(actual, func_type, data_type, N, SCALAR_VAL):
-    # An example of a tensor printing is like:
-    # (0, 0, 0) x: [  0,   1,   2,   3,   4,   5,   6,   7,
-    #                 8,   9,  10,  11,  12,  13,  14,  15,
-    #                 ...
-    #               120, 121, 122, 123, 124, 125, 126, 127]
-    PID_PREFIX = "(0, 0, 0)"
-    NEWLINE_WITH_PADDING = "\n" + " " * (len(PID_PREFIX + " x: ["))
-    if func_type in ("print", "device_print", "device_print_uint", "device_print_uint_cast"):
-        expected = PID_PREFIX + " x: ["
-        for i in range(N):
-            if func_type == "device_print_uint_cast":
-                offset = 128  # tl.arange(0, BLOCK) + 128
-            elif data_type == "uint32":
-                offset = 1 << 31
-            else:
-                offset = 0
-            expected += f"{i + offset:3}"
-            if data_type.startswith("float"):
-                expected += ".0000"
-            if i == N - 1:
-                continue
-            expected += ","
-            if i % 8 == 7:
-                expected += NEWLINE_WITH_PADDING
-            else:
-                expected += " "
-        expected += "]"
-    elif func_type == "device_print_scalars":
-        expected = f"{PID_PREFIX} x: {SCALAR_VAL}"
-        if data_type.startswith("float"):
-            expected += ".000000"
-        expected += f"\n{PID_PREFIX} int: {SCALAR_VAL}"
-        expected += f"\n{PID_PREFIX} float: 3.140000"
-    elif func_type == "device_print_negative":
-        expected = PID_PREFIX + " x: ["
-        for i in range(N):
-            expected += f"{-i:4}"
-            if i == N - 1:
-                continue
-            expected += ","
-            if i % 8 == 7:
-                expected += NEWLINE_WITH_PADDING
-            else:
-                expected += " "
-        expected += "]"
-    elif func_type == "device_print_hex":
-        expected = PID_PREFIX + " x: ["
-        for i in range(N):
-            if data_type.endswith("8"):
-                expected += f"0x{i:02x}"
-            elif data_type.endswith("16"):
-                expected += f"0x{i:04x}"
-            elif data_type.endswith("32"):
-                expected += f"0x{i:08x}"
-            elif data_type.endswith("64"):
-                expected += f"0x{i:016x}"
-            if i == N - 1:
-                continue
-            expected += ","
-            if i % 8 == 7:
-                expected += NEWLINE_WITH_PADDING
-            else:
-                expected += " "
-        expected += "]"
-    elif func_type == "static_print":
-        expected = f" int32[constexpr[{N}]]"
-    elif func_type == "no_arg_print":
-        expected = f"{PID_PREFIX}: 0"
-    elif func_type == "print_no_arg":
-        expected = f"{PID_PREFIX} no arg"
-    elif func_type == "print_multiple_args" or func_type == "device_print_multiple_args":
-        expected = ""
-        for k in range(2):
-            expected += PID_PREFIX + ": ["
-            for i in range(N):
-                expected += f"{i:3}" if k == 0 else "1"
-                if i == N - 1:
-                    continue
-                expected += ","
-                if i % 8 == 7:
-                    expected += "\n" + " " * (len(PID_PREFIX + ": ["))
-                else:
-                    expected += " "
-            expected += "]"
-            if k == 0:
-                expected += "\n"
-    elif func_type == "device_print_2d_tensor":
-        # For CPU, the 2D tensor has shape (N, 1) since warp_size is 1
-        expected = PID_PREFIX + ": ["
-        for i in range(N):
-            expected += f"[{i:3}]"
-            if i == N - 1:
-                continue
-            expected += ","
-            if i % 8 == 7:
-                expected += "\n" + " " * (len(PID_PREFIX + ": ["))
-            else:
-                expected += "\n" + " " * (len(PID_PREFIX + ": ["))
-        expected += "]"
-
-    # Ignore the trailing new line.
-    assert actual[:-1] == expected

--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -7,12 +7,11 @@ import triton.language as tl
 from triton._internal_testing import is_hopper, is_sm12x, is_interpreter, numpy_random, to_triton, unwrap_tensor, tma_dtypes, to_numpy
 from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor
 from typing import Optional
-from triton._internal_testing import is_cuda, is_hip, is_hip_cdna3, is_cpu
+from triton._internal_testing import is_cuda, is_hip, is_hip_cdna3
 from triton.tools.tensor_descriptor import TensorDescriptor
 from triton import CompilationError
 
 
-@pytest.mark.cpu
 @pytest.mark.interpreter
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
 @pytest.mark.parametrize("num_ctas", [1, 2])
@@ -20,8 +19,6 @@ from triton import CompilationError
 def test_tensor_descriptor_load(dtype_str, num_ctas, M_BLOCK, N_BLOCK, device):
     if num_ctas == 2 and (not is_cuda() or torch.cuda.get_device_capability(0)[0] not in (9, 10)):
         pytest.skip("CTAs is unsupported for these cards")
-    if is_cpu() and M_BLOCK > 32 or N_BLOCK > 32:
-        pytest.skip("Large loads unsupported on CPU")
 
     @triton.jit
     def kernel(out_ptr, a_ptr, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
@@ -59,7 +56,6 @@ def test_tensor_descriptor_load(dtype_str, num_ctas, M_BLOCK, N_BLOCK, device):
     torch.testing.assert_close(expect, unwrap_tensor(out))
 
 
-@pytest.mark.cpu
 @pytest.mark.interpreter
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
 @pytest.mark.parametrize("num_ctas", [1, 2])
@@ -67,8 +63,6 @@ def test_tensor_descriptor_load(dtype_str, num_ctas, M_BLOCK, N_BLOCK, device):
 def test_tensor_descriptor_store(dtype_str, num_ctas, M_BLOCK, N_BLOCK, device):
     if num_ctas == 2 and (not is_cuda() or torch.cuda.get_device_capability(0)[0] not in (9, 10)):
         pytest.skip("CTAs is unsupported for these cards")
-    if is_cpu() and M_BLOCK > 32 or N_BLOCK > 32:
-        pytest.skip("Large stores unsupported on CPU")
 
     @triton.jit
     def kernel(out_ptr, a_ptr, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
@@ -116,7 +110,6 @@ def test_tensor_descriptor_store(dtype_str, num_ctas, M_BLOCK, N_BLOCK, device):
 
 
 # Exercise the functional load/store builtins once to ensure they map through.
-@pytest.mark.cpu
 @pytest.mark.interpreter
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
 def test_tensor_descriptor_functional_interface(dtype_str, device):
@@ -163,13 +156,10 @@ def test_tensor_descriptor_functional_interface(dtype_str, device):
     torch.testing.assert_close(unwrap_tensor(inp), unwrap_tensor(out))
 
 
-@pytest.mark.cpu
 @pytest.mark.interpreter
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
 @pytest.mark.parametrize("K_BLOCK", [16, 32, 64, 128])
 def test_tensor_descriptor_load3d(dtype_str, K_BLOCK, device):
-    if is_cpu() and K_BLOCK > 32:
-        pytest.skip("Large loads unsupported on CPU")
 
     @triton.jit
     def kernel(out_ptr, a_ptr, M, N, K, stride_m, stride_n, stride_k, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr,
@@ -215,13 +205,10 @@ def test_tensor_descriptor_load3d(dtype_str, K_BLOCK, device):
     torch.testing.assert_close(expect, actual)
 
 
-@pytest.mark.cpu
 @pytest.mark.interpreter
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
 @pytest.mark.parametrize("K_BLOCK", [16, 32, 64, 128])
 def test_tensor_descriptor_store3d(dtype_str, K_BLOCK, device):
-    if is_cpu() and K_BLOCK > 32:
-        pytest.skip("Large stores unsupported on CPU")
 
     @triton.jit
     def kernel(out_ptr, a_ptr, M, N, K, stride_m, stride_n, stride_k, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr,
@@ -266,7 +253,6 @@ def test_tensor_descriptor_store3d(dtype_str, K_BLOCK, device):
     torch.testing.assert_close(expect, actual)
 
 
-@pytest.mark.cpu
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
 @pytest.mark.parametrize("num_ctas", [1, 2])
 @pytest.mark.parametrize("ndim", [1, 2, 3, 4, 5])
@@ -274,8 +260,6 @@ def test_tensor_descriptor_store3d(dtype_str, K_BLOCK, device):
 def test_tensor_descriptor_load_nd(dtype_str, num_ctas, ndim, INNER_BLOCK, device):
     if num_ctas == 2 and (not is_cuda() or torch.cuda.get_device_capability(0)[0] not in (9, 10)):
         pytest.skip("CTAs is unsupported for these cards")
-    if is_cpu() and INNER_BLOCK > 32:
-        pytest.skip("Large block size unsupported on CPU")
 
     @triton.jit
     def kernel(out_ptr, a_ptr, shape, strides, BLOCK_SHAPE):
@@ -334,7 +318,6 @@ def test_tensor_descriptor_load_nd(dtype_str, num_ctas, ndim, INNER_BLOCK, devic
     torch.testing.assert_close(expect, actual)
 
 
-@pytest.mark.cpu
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
 @pytest.mark.parametrize("num_ctas", [1, 2])
 @pytest.mark.parametrize("ndim", [1, 2, 3, 4, 5])
@@ -342,8 +325,6 @@ def test_tensor_descriptor_load_nd(dtype_str, num_ctas, ndim, INNER_BLOCK, devic
 def test_tensor_descriptor_store_nd(dtype_str, num_ctas, ndim, INNER_BLOCK, device):
     if num_ctas == 2 and (not is_cuda() or torch.cuda.get_device_capability(0)[0] not in (9, 10)):
         pytest.skip("CTAs is unsupported for these cards")
-    if is_cpu() and INNER_BLOCK > 32:
-        pytest.skip("Large block size unsupported on CPU")
 
     @triton.jit
     def kernel(out_ptr, a_ptr, shape, strides, BLOCK_SHAPE):
@@ -402,7 +383,6 @@ def test_tensor_descriptor_store_nd(dtype_str, num_ctas, ndim, INNER_BLOCK, devi
     torch.testing.assert_close(expect, actual)
 
 
-@pytest.mark.cpu
 @pytest.mark.interpreter
 def test_tensor_descriptor_padding(device):
 
@@ -452,16 +432,14 @@ def test_tensor_descriptor_padding(device):
     in_desc = TensorDescriptor(input, input.shape, input.stride(), dummy_block, padding=padding)
     grid = (triton.cdiv(OM, M_BLOCK), triton.cdiv(ON, N_BLOCK))
     device_tma_load[grid](input, out_device_tma, IM, IN, OM, ON, M_BLOCK, N_BLOCK, padding)
-    if not is_cpu():
-        host_tma_load[grid](in_desc, out_host_tma, OM, ON, M_BLOCK, N_BLOCK)
+    host_tma_load[grid](in_desc, out_host_tma, OM, ON, M_BLOCK, N_BLOCK)
     expected = torch.zeros((OM, ON), device=device, dtype=torch.float32)
     expected[0:IN, 0:IM] = input
     expected[:, IN:ON] = float('nan')
     expected[IM:OM, :] = float('nan')
 
     torch.testing.assert_close(expected, out_device_tma, equal_nan=True)
-    if not is_cpu():
-        torch.testing.assert_close(expected, out_host_tma, equal_nan=True)
+    torch.testing.assert_close(expected, out_host_tma, equal_nan=True)
 
 
 @triton.jit(noinline=True)

--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -6,7 +6,7 @@ import pytest
 
 import pathlib
 import uuid
-from triton._internal_testing import is_cuda, is_hip_cdna2, is_cpu
+from triton._internal_testing import is_cuda, is_hip, is_hip_cdna2
 
 
 def do_bench(kernel_call, quantiles, use_cuda_graph=False):
@@ -17,10 +17,8 @@ def do_bench(kernel_call, quantiles, use_cuda_graph=False):
 
 @pytest.mark.parametrize('use_cuda_graph', [False, True])
 def test_kwargs(use_cuda_graph: bool, device: str):
-
-    if not is_cuda() and use_cuda_graph:
-        pytest.xfail("CUDA is not available")
-        pytest.skip("Use cuda graph without cuda looks strange")
+    if use_cuda_graph and not (is_cuda() or is_hip()):
+        pytest.xfail("CUDA graphs require a GPU backend")
 
     M, N = 1024, 16
     src = torch.randn(M * N, device=device)
@@ -547,11 +545,8 @@ def test_exceed_tmem(device):
 
 
 def test_exceed_threads(device):
-    if is_cpu():
-        pytest.skip("Not supported on CPU")
-
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA is not available")
+    if not (is_cuda() or is_hip()):
+        pytest.skip("GPU thread limits are not applicable to this backend")
     x = torch.empty(1024, device=device, dtype=torch.float32)
     y = torch.empty_like(x)
     output = torch.empty_like(x)

--- a/python/test/unit/runtime/test_launch.py
+++ b/python/test/unit/runtime/test_launch.py
@@ -12,9 +12,6 @@ from triton._internal_testing import is_cuda, is_hip, is_cpu
 
 
 def test_metadata() -> None:
-    if is_cpu:
-        pytest.xfail("Test is flaky on CPU")
-
     used_hook = False
 
     def _launch_metadata(grid, kernel, args):

--- a/python/test/unit/runtime/test_launch.py
+++ b/python/test/unit/runtime/test_launch.py
@@ -8,10 +8,11 @@ import numpy as np
 import torch
 import triton
 import triton.language as tl
-from triton._internal_testing import is_cuda, is_hip, is_cpu
+from triton._internal_testing import is_cuda, is_hip
 
 
 def test_metadata() -> None:
+
     used_hook = False
 
     def _launch_metadata(grid, kernel, args):
@@ -197,8 +198,7 @@ def test_launch_with_options(options) -> None:
     if option_key == "extern_libs":
         # HIPOptions overwrite the extern_libs option, so we skip the test
         # passing and specializing options still is tested
-        # CPU backend currently ignores `extern_libs`
-        if not is_hip() and not is_cpu():
+        if not is_hip():
             assert compile_info[option_key] == tuple(option_val.items())
     else:
         assert compile_info[option_key] == option_val

--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -314,32 +314,36 @@ def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, return_m
     if measure_time_with_hooks:
         di.enable_hook_timing()
 
-    # compute number of warmup and repeat
-    n_warmup = max(1, int(warmup / estimate_ms))
-    n_repeat = max(1, int(rep / estimate_ms))
-    start_event = [di.Event(enable_timing=True) for i in range(n_repeat)]
-    end_event = [di.Event(enable_timing=True) for i in range(n_repeat)]
-    # Warm-up
-    for _ in range(n_warmup):
-        fn()
-    # Benchmark
-    for i in range(n_repeat):
-        # we don't want `fn` to accumulate gradient values
-        # if it contains a backward pass. So we clear the
-        # provided gradients
-        if grad_to_none is not None:
-            for x in grad_to_none:
-                x.grad = None
-        # we clear the L2 cache before each run
-        runtime.driver.active.clear_cache(cache)
-        # record time of `fn`
-        start_event[i].record()
-        fn()
-        end_event[i].record()
-    # Record clocks
-    di.synchronize()
-    times = [s.elapsed_time(e) for s, e in zip(start_event, end_event)]
-    return _summarize_statistics(times, quantiles, return_mode)
+    try:
+        # compute number of warmup and repeat
+        n_warmup = max(1, int(warmup / estimate_ms))
+        n_repeat = max(1, int(rep / estimate_ms))
+        start_event = [di.Event(enable_timing=True) for i in range(n_repeat)]
+        end_event = [di.Event(enable_timing=True) for i in range(n_repeat)]
+        # Warm-up
+        for _ in range(n_warmup):
+            fn()
+        # Benchmark
+        for i in range(n_repeat):
+            # we don't want `fn` to accumulate gradient values
+            # if it contains a backward pass. So we clear the
+            # provided gradients
+            if grad_to_none is not None:
+                for x in grad_to_none:
+                    x.grad = None
+            # we clear the L2 cache before each run
+            runtime.driver.active.clear_cache(cache)
+            # record time of `fn`
+            start_event[i].record()
+            fn()
+            end_event[i].record()
+        # Record clocks
+        di.synchronize()
+        times = [s.elapsed_time(e) for s, e in zip(start_event, end_event)]
+        return _summarize_statistics(times, quantiles, return_mode)
+    finally:
+        if measure_time_with_hooks:
+            di.disable_hook_timing()
 
 
 def do_bench_proton(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, return_mode="mean"):
@@ -590,7 +594,6 @@ class Mark:
                     y_max = y_max.astype(float)
                     ax.fill_between(df[first_x], y_min, y_max, alpha=0.15, color=col)
             ax.legend()
-
             ax.set_xlabel(bench.xlabel or first_x)
             ax.set_ylabel(bench.ylabel)
             # ax.set_title(bench.plot_name)

--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -58,7 +58,8 @@ class CPUOptions:
     assume_in_bounds: bool = False
 
     def __post_init__(self):
-        pass
+        extern_libs = {} if self.extern_libs is None else dict(self.extern_libs)
+        object.__setattr__(self, "extern_libs", tuple(extern_libs.items()))
 
     # GPU-only knobs do not affect the generated x86 code. num_cpu_threads is
     # launch metadata, so it must remain in the key until launch options are

--- a/third_party/cpu/backend/driver.py
+++ b/third_party/cpu/backend/driver.py
@@ -380,13 +380,21 @@ class CPUDeviceInterface:
         self.kernel_times = []
         self.last_start = 0
         self.use_hooks = False
-        triton.knobs.runtime.launch_enter_hook = None
-        triton.knobs.runtime.launch_exit_hook = None
 
     def enable_hook_timing(self):
+        if self.use_hooks:
+            return
+        self.kernel_times.clear()
         self.use_hooks = True
-        triton.knobs.runtime.launch_enter_hook = lambda arg: self._enter_hook()
-        triton.knobs.runtime.launch_exit_hook = lambda arg: self._exit_hook()
+        triton.knobs.runtime.launch_enter_hook.add(self._launch_enter_hook)
+        triton.knobs.runtime.launch_exit_hook.add(self._launch_exit_hook)
+
+    def disable_hook_timing(self):
+        if not self.use_hooks:
+            return
+        triton.knobs.runtime.launch_enter_hook.remove(self._launch_enter_hook)
+        triton.knobs.runtime.launch_exit_hook.remove(self._launch_exit_hook)
+        self.use_hooks = False
 
     def synchronize(self):
         pass
@@ -396,6 +404,12 @@ class CPUDeviceInterface:
 
     def _exit_hook(self):
         self.kernel_times.append(time.perf_counter() - self.last_start)
+
+    def _launch_enter_hook(self, _metadata):
+        self._enter_hook()
+
+    def _launch_exit_hook(self, _metadata):
+        self._exit_hook()
 
     def Event(self, enable_timing=True):
         if self.use_hooks:
@@ -408,6 +422,7 @@ class CPUDriver(DriverBase):
     def __init__(self):
         self.utils = CPUUtils()
         self.launcher_cls = CPULauncher
+        self.device_interface = CPUDeviceInterface()
         super().__init__()
 
     def get_current_device(self):
@@ -427,7 +442,7 @@ class CPUDriver(DriverBase):
         return GPUTarget("cpu", cpu_arch, 0)
 
     def get_device_interface(self):
-        return CPUDeviceInterface()
+        return self.device_interface
 
     @staticmethod
     def is_active():
@@ -437,8 +452,7 @@ class CPUDriver(DriverBase):
         from triton.testing import do_bench
 
         def do_bench_cpu(*args, **kwargs):
-            if not 'measure_time_with_hooks' in kwargs:
-                kwargs['measure_time_with_hooks'] = True
+            kwargs.setdefault('measure_time_with_hooks', True)
             return do_bench(*args, **kwargs)
 
         return do_bench_cpu

--- a/third_party/cpu/lib/TritonCPUToLLVM/DebugOpsToLLVM.cpp
+++ b/third_party/cpu/lib/TritonCPUToLLVM/DebugOpsToLLVM.cpp
@@ -140,8 +140,8 @@ getOrAddPrintMemrefFuncDecl(ConversionPatternRewriter &rewriter) {
               i32_ty,
               i32_ty, /*end type*/
               i32_ty};
-  auto funcType =
-      LLVM::LLVMFunctionType::get(i32_ty, argsType, /*isVarArg*/ false);
+  auto funcType = LLVM::LLVMFunctionType::get(void_ty(ctx), argsType,
+                                              /*isVarArg*/ false);
 
   ConversionPatternRewriter::InsertionGuard guard(rewriter);
   rewriter.setInsertionPointToStart(moduleOp.getBody());

--- a/third_party/cpu/runtime/cpu_runtime.cpp
+++ b/third_party/cpu/runtime/cpu_runtime.cpp
@@ -381,13 +381,13 @@ EXPORT void triton_assert(int32_t pid0, int32_t pid1, int32_t pid2, bool cond,
 EXPORT void triton_print_unranked_memref(int32_t pid0, int32_t pid1,
                                          int32_t pid2, const char *prefix,
                                          UnrankedMemRefType memref, int32_t btw,
-                                         bool isInteger, bool isSigned,
-                                         bool asHex) {
+                                         int32_t isInteger, int32_t isSigned,
+                                         int32_t asHex) {
   std::stringstream ss;
   ss << "(" << pid0 << ", " << pid1 << ", " << pid2 << ")" << prefix;
   std::string linePrefix(ss.str().size(), ' ');
-  printMemRef(ss, memref.rank, memref.descriptor, btw, isInteger, isSigned,
-              asHex, linePrefix);
+  printMemRef(ss, memref.rank, memref.descriptor, btw, isInteger != 0,
+              isSigned != 0, asHex != 0, linePrefix);
   ss << "\n";
   std::cout << ss.str() << std::flush;
 }


### PR DESCRIPTION
This PR minimize differences in shared upstream code so future rebases are smaller and less conflict-prone.

### Summary

- Move CPU-specific coverage into `python/test/unit/cpu`.
- Restore shared tests closer to upstream.
- Remove obsolete CPU-only test workarounds and generalize multi-backend guards.
- Preserve existing CPU test coverage.
- **I did NOT touch test_core.py intentionally; it still stays the same.**

### Testing

- CPU core, conversion, tensor descriptor, block pointer, print, pipeliner, and autotuner tests
- `pre-commit run --from-ref origin/main --to-ref HEAD`

This is a test-only refactoring; no production behavior changes are intended.


### Shared test files

| Shared file | Before: `main` vs upstream | After this PR vs upstream | Result |
|---|---:|---:|---|
| `python/test/conftest.py` | `+2/-0` | `0` | ✅ Restored; CPU marker registration moved to `pytest.ini` |
| `language/print_helper.py` | `+13/-8` | `0` | ✅ CPU print helper moved under `unit/cpu` |
| `language/test_annotations.py` | `+4/-0` | `0` | ✅ CPU cases isolated |
| `language/test_block_pointer.py` | `+30/-2` | `0` | ✅ Obsolete CPU accommodations removed |
| `language/test_compile_errors.py` | `+4/-1` | `0` | ✅ CPU FP8 coverage moved to CPU tests |
| `language/test_conversions.py` | `+14/-2` | `0` | ✅ CPU conversion matrix isolated |
| `language/test_standard.py` | `+5/-1` | `0` | ✅ CPU flip coverage isolated |
| `language/test_subprocess.py` | `+122/-3` | `0` | ✅ CPU print subprocess coverage isolated |
| `language/test_tensor_descriptor.py` | `+25/-3` | `0` | ✅ CPU descriptor matrix isolated |
| `runtime/test_launch.py` | `+5/-2` | `0` | ✅ CPU option handling moved into `CPUOptions` |
| `language/test_pipeliner.py` | `+7/-2` | `+1/-1` | 🟡 Explicit CPU logic removed; one generic non-CUDA guard remains |
| `runtime/test_autotuner.py` | `+7/-2` | `+5/-5` | 🟡 Explicit CPU logic removed; generic CUDA/HIP backend checks remain |
| `language/test_core.py` | `+296/-17` | `+296/-17` | ⏳ Intentionally deferred |
| `runtime/test_cache.py` | `+26/-23` | `+26/-23` | 🟡 Shared multi-backend cache-key validation |

### CPU-owned test files added

| CPU-owned file | Added lines | Coverage |
|---|---:|---|
| `cpu/cpu_print_helper.py` | `+167` | CPU print kernels and formatting |
| `cpu/test_cpu_subprocess.py` | `+144` | CPU subprocess printing |
| `cpu/test_cpu_annotations.py` | `+52` | CPU annotation behavior |
| `cpu/test_cpu_conversions.py` | `+93` | CPU FP8 conversion and compilation |
| `cpu/test_cpu_flip.py` | `+39` | CPU flip support |
| `cpu/test_cpu_tensor_descriptor.py` | `+118` | CPU-supported descriptor matrix |
| **Total** | **`+613`** | CPU-specific coverage consolidated |

### Isolation summary

| Metric | Before | After | Improvement |
|---|---:|---:|---:|
| Modified shared test/support files | 14 | 4 | ✅ **71.4% fewer** |
| Shared test churn | 626 lines | 374 lines | ✅ **40.3% reduction** |
| Excluding deferred `test_core.py` and `test_cache.py` | 264 lines in 12 files | 12 lines in 2 files | ✅ **95.5% reduction** |
| CPU-owned Python test files | 2 | 8 | ✅ Coverage consolidated |

The remaining differences in `test_pipeliner.py` and `test_autotuner.py` are backend-neutral correctness guards. The major intentionally deferred area is `test_core.py`.


### Directories/files compared

<img width="1432" height="1522" alt="image" src="https://github.com/user-attachments/assets/a3f65fb4-6bf3-4a30-a320-0a7c519968cd" />

