### PR TITLE
[DotToNanokernel] Improve codegen for non-AMX targets

### DIFF
--- a/python/tutorials/cpu/08-sfc-matmul.py
+++ b/python/tutorials/cpu/08-sfc-matmul.py
@@ -195,19 +195,19 @@ if args.target == 'amx':
 elif args.target == 'avx512':
     if dtype != torch.bfloat16:
         parser.error("AVX-512 target only supports bfloat16 data type")
-    BLOCK_SIZE_M = 4
+    BLOCK_SIZE_M = 32
     BLOCK_SIZE_N = 64
     BLOCK_SIZE_K = 2
 elif args.target == 'avx_ne_convert':
     if dtype != torch.bfloat16:
         parser.error("AVX-NE-CONVERT target only supports bfloat16 data type")
-    BLOCK_SIZE_M = 2
+    BLOCK_SIZE_M = 32
     BLOCK_SIZE_N = 32
     BLOCK_SIZE_K = 2
 elif args.target == 'avx_vnni_int8':
     if dtype != torch.int8:
         parser.error("AVX-VNNI-INT8 target only supports int8 data type")
-    BLOCK_SIZE_M = 2
+    BLOCK_SIZE_M = 32
     BLOCK_SIZE_N = 32
     BLOCK_SIZE_K = 4
 

--- a/test/TritonCPU/dot-to-nanokernel-looped.mlir
+++ b/test/TritonCPU/dot-to-nanokernel-looped.mlir
@@ -97,7 +97,7 @@ tt.func public @gemm_looped_avx512(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %
 // In lieu of matching the full sequence:
 // AVX_NE_CONVERT-COUNT-7:     vector.fma
 
-// AVX_NE_CONVERT              scf.yield
+// AVX_NE_CONVERT:             scf.yield
 // AVX_NE_CONVERT-COUNT-8:  vector.transfer_write
 
 tt.func public @gemm_looped_avx_ne_convert(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %arg2: !tt.ptr<bf16>, %arg3: !tt.ptr<f32>, %arg4: !tt.ptr<bf16>, %arg5: !tt.ptr<i32>, %arg6: i32, %arg7: i32, %arg8: i32) {

--- a/test/TritonCPU/dot-to-nanokernel-looped.mlir
+++ b/test/TritonCPU/dot-to-nanokernel-looped.mlir
@@ -1,8 +1,12 @@
 // RUN: triton-opt %s -split-input-file -triton-cpu-convert-dot-to-nanokernel=cpu-features=avx512bf16 -cse  | FileCheck %s --check-prefixes=AVX512,ALL
 // RUN: triton-opt %s -split-input-file -triton-cpu-convert-dot-to-nanokernel=cpu-features=avxneconvert -cse  | FileCheck %s --check-prefixes=AVX_NE_CONVERT,ALL
 
-// ALL-LABEL: gemm_looped_avx512
+// Lowering to AVX512 target. Accumulator is zero-initialized, hence we currently need to insert a temporary buffer.
 
+// ALL-LABEL: gemm_looped_avx512
+// AVX512:       %[[ZERO:.+]] = arith.constant dense<0.000000e+00> : vector<32x64xf32>
+// AVX512:       %[[BUFFER:.+]] = memref.alloca() : memref<32x64xf32>
+// AVX512:       vector.transfer_write %[[ZERO]], %[[BUFFER]][%c0, %c0] {in_bounds = [true, true]} : vector<32x64xf32>, memref<32x64xf32>
 // AVX512:       scf.for %{{.+}} = %c0 to %c32 step %c4
 // AVX512:         scf.for %{{.+}} = %c0 to %c64 step %c64
 // AVX512:           %{{.+}}:16 = scf.for %{{.+}} = %{{.+}} to %{{.+}} step %c1
@@ -76,8 +80,11 @@ tt.func public @gemm_looped_avx512(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %
 
 // -----
 
+// Lowering to AVX_NE_CONVERT target. The accumulator reads/writes can be used directly by the nanokernel patterns.
+
 // ALL-LABEL: gemm_looped_avx_ne_convert
 
+// AVX_NE_CONVERT-NOT:   memref.alloca
 // AVX_NE_CONVERT:       scf.for %{{.+}} = %c0 to %c32 step %c4
 // AVX_NE_CONVERT:         scf.for %{{.+}} = %c0 to %c32 step %c16
 // AVX_NE_CONVERT:           %{{.+}}:8 = scf.for %{{.+}} = %{{.+}} to %{{.+}} step %c1
@@ -94,10 +101,9 @@ tt.func public @gemm_looped_avx512(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %
 // AVX_NE_CONVERT-COUNT-8:  vector.transfer_write
 
 tt.func public @gemm_looped_avx_ne_convert(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %arg2: !tt.ptr<bf16>, %arg3: !tt.ptr<f32>, %arg4: !tt.ptr<bf16>, %arg5: !tt.ptr<i32>, %arg6: i32, %arg7: i32, %arg8: i32) {
-  %cst = arith.constant 0.000000e+00 : f32
-  %cst_0 = arith.constant 0.000000e+00 : bf16
+  %cst = arith.constant 0.000000e+00 : bf16
+  %cst_0 = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index
-  %cst_1 = arith.constant dense<0.000000e+00> : vector<32x32xf32>
   %c7_i32 = arith.constant 7 : i32
   %c8_i32 = arith.constant 8 : i32
   %c32_i64 = arith.constant 32 : i64
@@ -128,30 +134,27 @@ tt.func public @gemm_looped_avx_ne_convert(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<
   %16 = arith.muli %arg7, %c32_i32 : i32
   %17 = arith.extsi %16 : i32 to i64
   %18 = tt.make_tensor_descriptor %arg3, [%0, %1, %c32_i32, %c32_i32], [%17, %c1024_i64, %c32_i64, %c1_i64] : <f32>, <1x1x32x32xf32>
-  %19 = arith.addi %4, %4 : i32
-  %20 = arith.minsi %19, %2 : i32
-  %21 = scf.for %arg9 = %4 to %20 step %c1_i32 iter_args(%arg10 = %cst_1) -> (vector<32x32xf32>)  : i32 {
-    %28 = triton_cpu.extract_memref %14 : <1x1x32x2xbf16> -> memref<?x?x32x2xbf16, strided<[?, 2, ?, 1]>>
-    %29 = arith.index_cast %8 : i32 to index
-    %30 = arith.index_cast %arg9 : i32 to index
-    %31 = vector.transfer_read %28[%29, %30, %c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<?x?x32x2xbf16, strided<[?, 2, ?, 1]>>, vector<32x2xbf16>
-    %32 = triton_cpu.extract_memref %15 : <1x1x1x64xbf16> -> memref<?x?x1x64xbf16, strided<[?, 64, 64, 1]>>
-    %33 = arith.index_cast %10 : i32 to index
-    %34 = vector.transfer_read %32[%33, %30, %c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<?x?x1x64xbf16, strided<[?, 64, 64, 1]>>, vector<1x64xbf16>
-    %res1, %res2 = vector.deinterleave %34 : vector<1x64xbf16> -> vector<1x32xbf16>
-    %35 = vector.transpose %res1, [1, 0] : vector<1x32xbf16> to vector<32x1xbf16>
-    %36 = vector.transpose %res2, [1, 0] : vector<1x32xbf16> to vector<32x1xbf16>
-    %37 = vector.interleave %35, %36 : vector<32x1xbf16> -> vector<32x2xbf16>
-    %38 = vector.transpose %37, [1, 0] : vector<32x2xbf16> to vector<2x32xbf16>
-    %39 = triton_cpu.dot %31, %38, %arg10, inputPrecision = tf32 : vector<32x2xbf16> * vector<2x32xbf16> -> vector<32x32xf32>
-    scf.yield %39 : vector<32x32xf32>
+  %19 = triton_cpu.extract_memref %18 : <1x1x32x32xf32> -> memref<?x?x32x32xf32, strided<[?, 1024, 32, 1]>>
+  %20 = arith.index_cast %8 : i32 to index
+  %21 = arith.index_cast %10 : i32 to index
+  %22 = vector.transfer_read %19[%20, %21, %c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<?x?x32x32xf32, strided<[?, 1024, 32, 1]>>, vector<32x32xf32>
+  %23 = arith.addi %4, %4 : i32
+  %24 = arith.minsi %23, %2 : i32
+  %25 = scf.for %arg9 = %4 to %24 step %c1_i32 iter_args(%arg10 = %22) -> (vector<32x32xf32>)  : i32 {
+    %27 = triton_cpu.extract_memref %14 : <1x1x32x2xbf16> -> memref<?x?x32x2xbf16, strided<[?, 2, ?, 1]>>
+    %28 = arith.index_cast %arg9 : i32 to index
+    %29 = vector.transfer_read %27[%20, %28, %c0, %c0], %cst {in_bounds = [true, true]} : memref<?x?x32x2xbf16, strided<[?, 2, ?, 1]>>, vector<32x2xbf16>
+    %30 = triton_cpu.extract_memref %15 : <1x1x1x64xbf16> -> memref<?x?x1x64xbf16, strided<[?, 64, 64, 1]>>
+    %31 = vector.transfer_read %30[%21, %28, %c0, %c0], %cst {in_bounds = [true, true]} : memref<?x?x1x64xbf16, strided<[?, 64, 64, 1]>>, vector<1x64xbf16>
+    %res1, %res2 = vector.deinterleave %31 : vector<1x64xbf16> -> vector<1x32xbf16>
+    %32 = vector.transpose %res1, [1, 0] : vector<1x32xbf16> to vector<32x1xbf16>
+    %33 = vector.transpose %res2, [1, 0] : vector<1x32xbf16> to vector<32x1xbf16>
+    %34 = vector.interleave %32, %33 : vector<32x1xbf16> -> vector<32x2xbf16>
+    %35 = vector.transpose %34, [1, 0] : vector<32x2xbf16> to vector<2x32xbf16>
+    %36 = triton_cpu.dot %29, %35, %arg10, inputPrecision = tf32 : vector<32x2xbf16> * vector<2x32xbf16> -> vector<32x32xf32>
+    scf.yield %36 : vector<32x32xf32>
   }
-  %22 = triton_cpu.extract_memref %18 : <1x1x32x32xf32> -> memref<?x?x32x32xf32, strided<[?, 1024, 32, 1]>>
-  %23 = arith.index_cast %8 : i32 to index
-  %24 = arith.index_cast %10 : i32 to index
-  %25 = vector.transfer_read %22[%23, %24, %c0, %c0], %cst {in_bounds = [true, true]} : memref<?x?x32x32xf32, strided<[?, 1024, 32, 1]>>, vector<32x32xf32>
-  %26 = arith.addf %21, %25 : vector<32x32xf32>
-  %27 = vector.shape_cast %26 : vector<32x32xf32> to vector<1x1x32x32xf32>
-  vector.transfer_write %27, %22[%23, %24, %c0, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x32x32xf32>, memref<?x?x32x32xf32, strided<[?, 1024, 32, 1]>>
+  %26 = vector.shape_cast %25 : vector<32x32xf32> to vector<1x1x32x32xf32>
+  vector.transfer_write %26, %19[%20, %21, %c0, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x32x32xf32>, memref<?x?x32x32xf32, strided<[?, 1024, 32, 1]>>
   tt.return
 }

--- a/test/TritonCPU/dot-to-nanokernel-looped.mlir
+++ b/test/TritonCPU/dot-to-nanokernel-looped.mlir
@@ -1,0 +1,157 @@
+// RUN: triton-opt %s -split-input-file -triton-cpu-convert-dot-to-nanokernel=cpu-features=avx512bf16 -cse  | FileCheck %s --check-prefixes=AVX512,ALL
+// RUN: triton-opt %s -split-input-file -triton-cpu-convert-dot-to-nanokernel=cpu-features=avxneconvert -cse  | FileCheck %s --check-prefixes=AVX_NE_CONVERT,ALL
+
+// ALL-LABEL: gemm_looped_avx512
+
+// AVX512:       scf.for %{{.+}} = %c0 to %c32 step %c4
+// AVX512:         scf.for %{{.+}} = %c0 to %c64 step %c64
+// AVX512:           %{{.+}}:16 = scf.for %{{.+}} = %{{.+}} to %{{.+}} step %c1
+// AVX512-COUNT-16:    x86.avx512.dot
+// AVX512:             scf.yield
+// AVX512-COUNT-16:  vector.transfer_write
+
+tt.func public @gemm_looped_avx512(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %arg2: !tt.ptr<bf16>, %arg3: !tt.ptr<f32>, %arg4: !tt.ptr<bf16>, %arg5: !tt.ptr<i32>, %arg6: i32, %arg7: i32, %arg8: i32, %arg9: i32) {
+  %cst = arith.constant 0.000000e+00 : bf16
+  %c0 = arith.constant 0 : index
+  %cst_0 = arith.constant dense<0.000000e+00> : vector<32x64xf32>
+  %c7_i32 = arith.constant 7 : i32
+  %c8_i32 = arith.constant 8 : i32
+  %c64_i64 = arith.constant 64 : i64
+  %c2048_i64 = arith.constant 2048 : i64
+  %c128_i64 = arith.constant 128 : i64
+  %c128_i32 = arith.constant 128 : i32
+  %c1_i64 = arith.constant 1 : i64
+  %c2_i64 = arith.constant 2 : i64
+  %c1_i32 = arith.constant 1 : i32
+  %c2_i32 = arith.constant 2 : i32
+  %c64_i32 = arith.constant 64 : i32
+  %c32_i32 = arith.constant 32 : i32
+  %0 = arith.divsi %arg6, %c32_i32 : i32
+  %1 = arith.divsi %arg7, %c64_i32 : i32
+  %2 = arith.divsi %arg8, %c2_i32 : i32
+  %3 = arith.addi %2, %c7_i32 : i32
+  %4 = arith.divsi %3, %c8_i32 : i32
+  %5 = tt.get_program_id x : i32
+  %6 = arith.muli %5, %c2_i32 : i32
+  %7 = tt.addptr %arg5, %6 : !tt.ptr<i32>, i32
+  %8 = tt.load %7 : !tt.ptr<i32>
+  %9 = tt.addptr %7, %c1_i32 : !tt.ptr<i32>, i32
+  %10 = tt.load %9 : !tt.ptr<i32>
+  %11 = arith.muli %arg9, %4 : i32
+  %12 = arith.muli %arg8, %c32_i32 : i32
+  %13 = arith.extsi %12 : i32 to i64
+  %14 = arith.extsi %arg8 : i32 to i64
+  %15 = tt.make_tensor_descriptor %arg0, [%0, %2, %c32_i32, %c2_i32], [%13, %c2_i64, %14, %c1_i64] : <bf16>, <1x1x32x2xbf16>
+  %16 = arith.muli %arg8, %c64_i32 : i32
+  %17 = arith.extsi %16 : i32 to i64
+  %18 = tt.make_tensor_descriptor %arg1, [%1, %2, %c1_i32, %c128_i32], [%17, %c128_i64, %c128_i64, %c1_i64] : <bf16>, <1x1x1x128xbf16>
+  %19 = arith.muli %arg7, %c32_i32 : i32
+  %20 = arith.extsi %19 : i32 to i64
+  %21 = tt.make_tensor_descriptor %arg3, [%0, %1, %c32_i32, %c64_i32], [%20, %c2048_i64, %c64_i64, %c1_i64] : <f32>, <1x1x32x64xf32>
+  %22 = arith.addi %11, %4 : i32
+  %23 = arith.minsi %22, %2 : i32
+  %24 = scf.for %arg10 = %11 to %23 step %c1_i32 iter_args(%arg11 = %cst_0) -> (vector<32x64xf32>)  : i32 {
+    %29 = triton_cpu.extract_memref %15 : <1x1x32x2xbf16> -> memref<?x?x32x2xbf16, strided<[?, 2, ?, 1]>>
+    %30 = arith.index_cast %8 : i32 to index
+    %31 = arith.index_cast %arg10 : i32 to index
+    %32 = vector.transfer_read %29[%30, %31, %c0, %c0], %cst {in_bounds = [true, true]} : memref<?x?x32x2xbf16, strided<[?, 2, ?, 1]>>, vector<32x2xbf16>
+    %33 = triton_cpu.extract_memref %18 : <1x1x1x128xbf16> -> memref<?x?x1x128xbf16, strided<[?, 128, 128, 1]>>
+    %34 = arith.index_cast %10 : i32 to index
+    %35 = vector.transfer_read %33[%34, %31, %c0, %c0], %cst {in_bounds = [true, true]} : memref<?x?x1x128xbf16, strided<[?, 128, 128, 1]>>, vector<1x128xbf16>
+    %res1, %res2 = vector.deinterleave %35 : vector<1x128xbf16> -> vector<1x64xbf16>
+    %36 = vector.transpose %res1, [1, 0] : vector<1x64xbf16> to vector<64x1xbf16>
+    %37 = vector.transpose %res2, [1, 0] : vector<1x64xbf16> to vector<64x1xbf16>
+    %38 = vector.interleave %36, %37 : vector<64x1xbf16> -> vector<64x2xbf16>
+    %39 = vector.transpose %38, [1, 0] : vector<64x2xbf16> to vector<2x64xbf16>
+    %40 = triton_cpu.dot %32, %39, %arg11, inputPrecision = tf32 : vector<32x2xbf16> * vector<2x64xbf16> -> vector<32x64xf32>
+    scf.yield %40 : vector<32x64xf32>
+  }
+  %25 = vector.shape_cast %24 : vector<32x64xf32> to vector<1x1x32x64xf32>
+  %26 = triton_cpu.extract_memref %21 : <1x1x32x64xf32> -> memref<?x?x32x64xf32, strided<[?, 2048, 64, 1]>>
+  %27 = arith.index_cast %8 : i32 to index
+  %28 = arith.index_cast %10 : i32 to index
+  vector.transfer_write %25, %26[%27, %28, %c0, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x32x64xf32>, memref<?x?x32x64xf32, strided<[?, 2048, 64, 1]>>
+  tt.return
+}
+
+// -----
+
+// ALL-LABEL: gemm_looped_avx_ne_convert
+
+// AVX_NE_CONVERT:       scf.for %{{.+}} = %c0 to %c32 step %c4
+// AVX_NE_CONVERT:         scf.for %{{.+}} = %c0 to %c32 step %c16
+// AVX_NE_CONVERT:           %{{.+}}:8 = scf.for %{{.+}} = %{{.+}} to %{{.+}} step %c1
+// AVX_NE_CONVERT:             x86.avx.bcst_to_f32.packed
+// AVX_NE_CONVERT:             x86.avx.cvt.packed.odd.indexed_to_f32
+// AVX_NE_CONVERT:             x86.avx.bcst_to_f32.packed
+// AVX_NE_CONVERT:             x86.avx.cvt.packed.even.indexed_to_f32
+// AVX_NE_CONVERT:             vector.fma
+
+// In lieu of matching the full sequence:
+// AVX_NE_CONVERT-COUNT-7:     vector.fma
+
+// AVX_NE_CONVERT              scf.yield
+// AVX_NE_CONVERT-COUNT-8:  vector.transfer_write
+
+tt.func public @gemm_looped_avx_ne_convert(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %arg2: !tt.ptr<bf16>, %arg3: !tt.ptr<f32>, %arg4: !tt.ptr<bf16>, %arg5: !tt.ptr<i32>, %arg6: i32, %arg7: i32, %arg8: i32) {
+  %cst = arith.constant 0.000000e+00 : f32
+  %cst_0 = arith.constant 0.000000e+00 : bf16
+  %c0 = arith.constant 0 : index
+  %cst_1 = arith.constant dense<0.000000e+00> : vector<32x32xf32>
+  %c7_i32 = arith.constant 7 : i32
+  %c8_i32 = arith.constant 8 : i32
+  %c32_i64 = arith.constant 32 : i64
+  %c1024_i64 = arith.constant 1024 : i64
+  %c64_i64 = arith.constant 64 : i64
+  %c64_i32 = arith.constant 64 : i32
+  %c1_i64 = arith.constant 1 : i64
+  %c2_i64 = arith.constant 2 : i64
+  %c1_i32 = arith.constant 1 : i32
+  %c2_i32 = arith.constant 2 : i32
+  %c32_i32 = arith.constant 32 : i32
+  %0 = arith.divsi %arg6, %c32_i32 : i32
+  %1 = arith.divsi %arg7, %c32_i32 : i32
+  %2 = arith.divsi %arg8, %c2_i32 : i32
+  %3 = arith.addi %2, %c7_i32 : i32
+  %4 = arith.divsi %3, %c8_i32 : i32
+  %5 = tt.get_program_id x : i32
+  %6 = arith.muli %5, %c2_i32 : i32
+  %7 = tt.addptr %arg5, %6 : !tt.ptr<i32>, i32
+  %8 = tt.load %7 : !tt.ptr<i32>
+  %9 = tt.addptr %7, %c1_i32 : !tt.ptr<i32>, i32
+  %10 = tt.load %9 : !tt.ptr<i32>
+  %11 = arith.muli %arg8, %c32_i32 : i32
+  %12 = arith.extsi %11 : i32 to i64
+  %13 = arith.extsi %arg8 : i32 to i64
+  %14 = tt.make_tensor_descriptor %arg0, [%0, %2, %c32_i32, %c2_i32], [%12, %c2_i64, %13, %c1_i64] : <bf16>, <1x1x32x2xbf16>
+  %15 = tt.make_tensor_descriptor %arg1, [%1, %2, %c1_i32, %c64_i32], [%12, %c64_i64, %c64_i64, %c1_i64] : <bf16>, <1x1x1x64xbf16>
+  %16 = arith.muli %arg7, %c32_i32 : i32
+  %17 = arith.extsi %16 : i32 to i64
+  %18 = tt.make_tensor_descriptor %arg3, [%0, %1, %c32_i32, %c32_i32], [%17, %c1024_i64, %c32_i64, %c1_i64] : <f32>, <1x1x32x32xf32>
+  %19 = arith.addi %4, %4 : i32
+  %20 = arith.minsi %19, %2 : i32
+  %21 = scf.for %arg9 = %4 to %20 step %c1_i32 iter_args(%arg10 = %cst_1) -> (vector<32x32xf32>)  : i32 {
+    %28 = triton_cpu.extract_memref %14 : <1x1x32x2xbf16> -> memref<?x?x32x2xbf16, strided<[?, 2, ?, 1]>>
+    %29 = arith.index_cast %8 : i32 to index
+    %30 = arith.index_cast %arg9 : i32 to index
+    %31 = vector.transfer_read %28[%29, %30, %c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<?x?x32x2xbf16, strided<[?, 2, ?, 1]>>, vector<32x2xbf16>
+    %32 = triton_cpu.extract_memref %15 : <1x1x1x64xbf16> -> memref<?x?x1x64xbf16, strided<[?, 64, 64, 1]>>
+    %33 = arith.index_cast %10 : i32 to index
+    %34 = vector.transfer_read %32[%33, %30, %c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<?x?x1x64xbf16, strided<[?, 64, 64, 1]>>, vector<1x64xbf16>
+    %res1, %res2 = vector.deinterleave %34 : vector<1x64xbf16> -> vector<1x32xbf16>
+    %35 = vector.transpose %res1, [1, 0] : vector<1x32xbf16> to vector<32x1xbf16>
+    %36 = vector.transpose %res2, [1, 0] : vector<1x32xbf16> to vector<32x1xbf16>
+    %37 = vector.interleave %35, %36 : vector<32x1xbf16> -> vector<32x2xbf16>
+    %38 = vector.transpose %37, [1, 0] : vector<32x2xbf16> to vector<2x32xbf16>
+    %39 = triton_cpu.dot %31, %38, %arg10, inputPrecision = tf32 : vector<32x2xbf16> * vector<2x32xbf16> -> vector<32x32xf32>
+    scf.yield %39 : vector<32x32xf32>
+  }
+  %22 = triton_cpu.extract_memref %18 : <1x1x32x32xf32> -> memref<?x?x32x32xf32, strided<[?, 1024, 32, 1]>>
+  %23 = arith.index_cast %8 : i32 to index
+  %24 = arith.index_cast %10 : i32 to index
+  %25 = vector.transfer_read %22[%23, %24, %c0, %c0], %cst {in_bounds = [true, true]} : memref<?x?x32x32xf32, strided<[?, 1024, 32, 1]>>, vector<32x32xf32>
+  %26 = arith.addf %21, %25 : vector<32x32xf32>
+  %27 = vector.shape_cast %26 : vector<32x32xf32> to vector<1x1x32x32xf32>
+  vector.transfer_write %27, %22[%23, %24, %c0, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x32x32xf32>, memref<?x?x32x32xf32, strided<[?, 1024, 32, 1]>>
+  tt.return
+}

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -14,7 +14,7 @@ from lit.llvm.subst import ToolSubst
 # name: The name of this test suite
 config.name = 'TRITON'
 
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest()
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = ['.mlir', '.ll']

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
@@ -117,6 +117,10 @@ struct DotOpCandidate {
 
   // Has block sizes that require looping the nanokernel (experimental).
   bool isLoopedNanokernel;
+
+  // Indicates whether an unsqueezing shape cast can be fused into the
+  // accumulator write.
+  bool hasUnsqueezingShapeCast;
 };
 
 unsigned checkElemTypes(Type lhsElemTy, Type rhsElemTy, Type accElemTy,
@@ -143,6 +147,28 @@ unsigned checkElemTypes(Type lhsElemTy, Type rhsElemTy, Type accElemTy,
 
   LDBG("  Drop candidate. Unsupported type combination");
   return 0;
+}
+
+bool isUnsqueezingShapeCast(Operation *op) {
+  auto castOp = dyn_cast<vector::ShapeCastOp>(op);
+  if (!castOp)
+    return false;
+
+  VectorType srcType = castOp.getSourceVectorType();
+  VectorType dstType = castOp.getResultVectorType();
+
+  if (dstType.getRank() <= srcType.getRank())
+    return false;
+
+  ArrayRef<int64_t> srcShape = srcType.getShape();
+  ArrayRef<int64_t> dstShape = dstType.getShape();
+
+  unsigned added = dstType.getRank() - srcType.getRank();
+  for (unsigned i = 0; i < added; ++i)
+    if (dstShape[i] != 1)
+      return false;
+
+  return dstShape.take_back(srcShape.size()).equals(srcShape);
 }
 
 unsigned checkInputShapes(VectorType lhsTy, VectorType resTy,
@@ -285,8 +311,16 @@ bool isNanokernelCandidate(triton::cpu::DotOp op, DotOpCandidate &candidate,
   OpResult accRes = candidate.isAccumulationLoop
                         ? accLoop.getTiedLoopResult(accIterArg)
                         : op->getOpResult(0);
-  if (accRes.hasOneUse())
-    accWrite = dyn_cast<vector::TransferWriteOp>(*accRes.getUsers().begin());
+
+  candidate.hasUnsqueezingShapeCast = false;
+  if (accRes.hasOneUse()) {
+    Operation *user = *accRes.getUsers().begin();
+    accWrite = dyn_cast<vector::TransferWriteOp>(user);
+    if (!accWrite && user->hasOneUse() && isUnsqueezingShapeCast(user)) {
+      candidate.hasUnsqueezingShapeCast = true;
+      accWrite = dyn_cast<vector::TransferWriteOp>(*user->getUsers().begin());
+    }
+  }
 
   // Quirk in the patterns: they assume that the accumulator read and
   // write are from/to the same memref with the same indices. If not, we can't
@@ -297,13 +331,6 @@ bool isNanokernelCandidate(triton::cpu::DotOp op, DotOpCandidate &candidate,
        !llvm::equal(accRead.getIndices(), accWrite.getIndices()))) {
     LDBG("  Cannot use existing vector.transfer_read/write due to mismatch in "
          "memref or indices.");
-    accRead = nullptr;
-    accWrite = nullptr;
-  }
-
-  // For now, always allocate a temporary accumulator buffer for the looped
-  // nanokernel case, as it makes indexing simpler.
-  if (candidate.isLoopedNanokernel) {
     accRead = nullptr;
     accWrite = nullptr;
   }
@@ -338,13 +365,6 @@ bool isNanokernelCandidate(triton::cpu::DotOp op, DotOpCandidate &candidate,
 
     auto vecTy = transferOp.getVectorType();
     auto vecRank = vecTy.getRank();
-    if (vecRank != 2) {
-      LDBG("  Drop candidate. Expected 2D vector.transfer_read/write op, but "
-           "got: "
-           << transferOp);
-      return false;
-    }
-
     auto memrefTy = cast<MemRefType>(transferOp.getBase().getType());
     auto memrefRank = memrefTy.getRank();
     // If the memref has more than 2 dimensions, we expect to find block-based
@@ -396,6 +416,24 @@ bool isNanokernelCandidate(triton::cpu::DotOp op, DotOpCandidate &candidate,
   candidate.accWrite = accWrite;
 
   return true;
+}
+
+void fuseAccWriteShapeCast(DotOpCandidate &candidate,
+                           PatternRewriter &rewriter) {
+  if (!candidate.hasUnsqueezingShapeCast || !candidate.accWrite)
+    return;
+
+  auto shapeCast =
+      candidate.accWrite.getValueToStore().getDefiningOp<vector::ShapeCastOp>();
+
+  rewriter.setInsertionPoint(candidate.accWrite);
+  auto rank = shapeCast.getSourceVectorType().getRank();
+  candidate.accWrite = rewriter.replaceOpWithNewOp<vector::TransferWriteOp>(
+      candidate.accWrite, shapeCast.getSource(), candidate.accWrite.getBase(),
+      candidate.accWrite.getIndices(),
+      ArrayRef<bool>(candidate.accWrite.getInBoundsValues()).take_back(rank));
+
+  rewriter.eraseOp(shapeCast);
 }
 
 void makeAccBuffer(DotOpCandidate &candidate, PatternRewriter &rewriter) {
@@ -709,18 +747,20 @@ void insertLoops(DotOpCandidate &candidate, PatternRewriter &rewriter) {
         scf::ForOp::create(
             b, loc, c0, ubN, stepN, {},
             [&](OpBuilder &b, Location loc, Value ivN, ValueRange iterArgs) {
-              // We unconditionally allocate a temporary accumulator buffer for
-              // the looped nanokernel case, hence we don't need any
-              // out-of-bounds handling.
-              SmallVector<bool> inBounds(
-                  cast<MemRefType>(candidate.accBuffer.getType()).getRank(),
-                  true);
+              // We know that accRead/accWrite operate on a 2D vector shaped as
+              // the block sizes, hence we can modify the last two indices to
+              // select the smaller register tiles.
+              SmallVector<Value> indices{candidate.accRead.getIndices()};
+              Value &idxM = indices[indices.size() - 2];
+              Value &idxN = indices[indices.size() - 1];
+              idxM = arith::AddIOp::create(b, loc, idxM, ivM);
+              idxN = arith::AddIOp::create(b, loc, idxN, ivN);
 
               auto accRead = vector::TransferReadOp::create(
                   b, candidate.accRead.getLoc(), accRegTileTy,
-                  candidate.accBuffer, ValueRange{ivM, ivN},
+                  candidate.accRead.getBase(), indices,
                   arith::ConstantOp::create(b, loc, b.getZeroAttr(accElemTy)),
-                  inBounds);
+                  candidate.accRead.getInBoundsValues());
 
               auto accLoop = scf::ForOp::create(
                   b, loc, lbK, ubK, stepK, ValueRange{accRead},
@@ -729,9 +769,12 @@ void insertLoops(DotOpCandidate &candidate, PatternRewriter &rewriter) {
                     loopKBodyBuilder(b, loc, ivM, ivN, ivK, iterArgs);
                   });
 
+              // The candidate selection enforces the same indices for accRead
+              // and accWrite, so we can reuse the indices vector.
               auto accWrite = vector::TransferWriteOp::create(
                   b, candidate.accWrite.getLoc(), accLoop.getResult(0),
-                  candidate.accBuffer, ValueRange{ivM, ivN}, inBounds);
+                  candidate.accWrite.getBase(), indices,
+                  candidate.accWrite.getInBoundsValues());
               scf::YieldOp::create(b, loc);
 
               candidate.accRead = accRead;
@@ -1193,6 +1236,9 @@ void flattenTransferOps(DotOpCandidate &candidate, PatternRewriter &rewriter) {
 
 LogicalResult convertCandidate(DotOpCandidate &candidate,
                                PatternRewriter &rewriter) {
+  // Fuse shape cast into the accumulator write, if possible.
+  fuseAccWriteShapeCast(candidate, rewriter);
+
   // Introduce temporary buffer if needed.
   makeAccBuffer(candidate, rewriter);
 

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
@@ -613,8 +613,8 @@ void insertLoops(DotOpCandidate &candidate, PatternRewriter &rewriter) {
   int64_t vnni = candidate.blockK;
 
   if (candidate.target & (AVX512_BF16 | AVX10_2)) {
-    regTileM = 8;
-    regTileN = 32;
+    regTileM = candidate.blockN >= 64 ? 4 : 8;
+    regTileN = candidate.blockN >= 64 ? 64 : 32;
   } else if (candidate.target & (AVX_NE_CONVERT | AVX_VNNI_INT8)) {
     regTileM = 4;
     regTileN = 16;

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
@@ -114,6 +114,9 @@ struct DotOpCandidate {
 
   // Distinguish between replacing only the dot, or an entire accumulation loop.
   bool isAccumulationLoop;
+
+  // Has block sizes that require looping the nanokernel (experimental).
+  bool isLoopedNanokernel;
 };
 
 unsigned checkElemTypes(Type lhsElemTy, Type rhsElemTy, Type accElemTy,
@@ -147,6 +150,21 @@ unsigned checkInputShapes(VectorType lhsTy, VectorType resTy,
   candidate.blockM = resTy.getDimSize(0);
   candidate.blockN = resTy.getDimSize(1);
   candidate.blockK = lhsTy.getDimSize(1);
+
+  // Experimental new support for block sizes that require looping the
+  // nanokernel.
+  // TODO: Integrate with the existing logic.
+  if (candidate.isAccumulationLoop && candidate.isVnniPacked &&
+      candidate.blockM >= 32 && candidate.blockN >= 32 &&
+      candidate.blockK <= 4) {
+    // Block sizes are powers of two. The AVX512 lowering expects at least a
+    // pair of 16-element dot products in the N dimension, so we're good here.
+    candidate.isLoopedNanokernel = true;
+    if (candidate.blockK == 2)
+      return mask & (AVX_NE_CONVERT | AVX512_BF16);
+    if (candidate.blockK == 4)
+      return mask & (AVX10_2 | AVX_VNNI_INT8);
+  }
 
   auto shapeUnrollsTo = [&candidate](int64_t m, int64_t n, int64_t k,
                                      int64_t numRegs, bool needsNPair = true) {
@@ -278,6 +296,13 @@ bool isNanokernelCandidate(triton::cpu::DotOp op, DotOpCandidate &candidate,
        !llvm::equal(accRead.getIndices(), accWrite.getIndices()))) {
     LDBG("  Cannot use existing vector.transfer_read/write due to mismatch in "
          "memref or indices.");
+    accRead = nullptr;
+    accWrite = nullptr;
+  }
+
+  // For now, always allocate a temporary accumulator buffer for the looped
+  // nanokernel case, as it makes indexing simpler.
+  if (candidate.isLoopedNanokernel) {
     accRead = nullptr;
     accWrite = nullptr;
   }
@@ -578,6 +603,148 @@ void convertToContract(DotOpCandidate &candidate, PatternRewriter &rewriter) {
   candidate.dot = {};
 
   LDBG("  Converted to contraction op: " << candidate.contract);
+}
+
+void insertLoops(DotOpCandidate &candidate, PatternRewriter &rewriter) {
+  // Pick register tile sizes based on the target ISA. Currently we check for
+  // block sizes >= 32 in `checkInputShapes()`, so we know that the sizes below
+  // evenly divide the block sizes.
+  int64_t regTileM, regTileN;
+  int64_t vnni = candidate.blockK;
+
+  if (candidate.target & (AVX512_BF16 | AVX10_2)) {
+    regTileM = 8;
+    regTileN = 32;
+  } else if (candidate.target & (AVX_NE_CONVERT | AVX_VNNI_INT8)) {
+    regTileM = 4;
+    regTileN = 16;
+  } else
+    llvm_unreachable("Unexpected target ISA for looping the nanokernel");
+
+  Type accElemTy = candidate.accRead.getType().getElementType();
+  Type inpElemTy = candidate.lhsRead.getType().getElementType();
+
+  VectorType accRegTileTy = VectorType::get({regTileM, regTileN}, accElemTy);
+  VectorType lhsRegTileTy = VectorType::get({regTileM, 1, vnni}, inpElemTy);
+  VectorType rhsRegTileTy = VectorType::get({1, regTileN, vnni}, inpElemTy);
+
+  rewriter.setInsertionPoint(candidate.accLoop);
+  auto loc = candidate.accLoop.getLoc();
+
+  // Set up loop bounds.
+  Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+  Value ubM = arith::ConstantIndexOp::create(rewriter, loc, candidate.blockM);
+  Value ubN = arith::ConstantIndexOp::create(rewriter, loc, candidate.blockN);
+  Value stepM = arith::ConstantIndexOp::create(rewriter, loc, regTileM);
+  Value stepN = arith::ConstantIndexOp::create(rewriter, loc, regTileN);
+
+  // We'll reconstruct the K loop using an index-typed induction variable, so
+  // convert bounds and step as needed.
+  auto indexCast = [&](Value val) -> Value {
+    if (val.getType().isIndex())
+      return val;
+    return rewriter.createOrFold<arith::IndexCastOp>(
+        val.getLoc(), rewriter.getIndexType(), val);
+  };
+  Value lbK = indexCast(candidate.accLoop.getLowerBound());
+  Value ubK = indexCast(candidate.accLoop.getUpperBound());
+  Value stepK = indexCast(candidate.accLoop.getStep());
+
+  auto isEqualToIndexTypedIV = [&](Value val) -> bool {
+    Value oldIV = candidate.accLoop.getInductionVar();
+    // If the loop was already index-typed, we compare against its IV.
+    if (oldIV.getType().isIndex())
+      return val == oldIV;
+    // Otherwise, we check if the value is an index cast of the old IV.
+    auto defOp = val.getDefiningOp<arith::IndexCastOp>();
+    return defOp && defOp.getOperand() == oldIV;
+  };
+
+  // Save for cleanup after inserting the new loops.
+  auto oldAccLoop = candidate.accLoop;
+  auto oldAccRead = candidate.accRead;
+  auto oldAccWrite = candidate.accWrite;
+
+  auto loopKBodyBuilder = [&](OpBuilder &b, Location loc, Value ivM, Value ivN,
+                              Value ivK, ValueRange iterArgs) {
+    candidate.accIterArg = cast<BlockArgument>(iterArgs[0]);
+
+    // Create copies of the transfer reads based on the new induction variables
+    // in the indices and smaller vector types (hence we can't just clone with
+    // an IRMapping).
+    // As this transformation is currently limited to pre-packed
+    // operands, we have checked earlier that the kernel uses block-based
+    // indexing.
+    SmallVector<Value> lhsIndices, rhsIndices;
+    llvm::replace_copy_if(candidate.lhsRead.getIndices(),
+                          std::back_inserter(lhsIndices), isEqualToIndexTypedIV,
+                          ivK);
+    assert(lhsIndices.size() >= 5 && "Expected block-based indexing for LHS");
+    lhsIndices[lhsIndices.size() - 3] = ivM;
+    candidate.lhsRead = vector::TransferReadOp::create(
+        b, loc, lhsRegTileTy, candidate.lhsRead.getBase(), lhsIndices,
+        candidate.lhsRead.getPadding(), candidate.lhsRead.getInBoundsValues());
+
+    llvm::replace_copy_if(candidate.rhsRead.getIndices(),
+                          std::back_inserter(rhsIndices), isEqualToIndexTypedIV,
+                          ivK);
+    assert(rhsIndices.size() >= 5 && "Expected block-based indexing for RHS");
+    rhsIndices[rhsIndices.size() - 2] = ivN;
+    candidate.rhsRead = vector::TransferReadOp::create(
+        b, loc, rhsRegTileTy, candidate.rhsRead.getBase(), rhsIndices,
+        candidate.rhsRead.getPadding(), candidate.rhsRead.getInBoundsValues());
+
+    candidate.contract = vector::ContractionOp::create(
+        b, candidate.contract.getLoc(), candidate.lhsRead, candidate.rhsRead,
+        iterArgs[0], candidate.contract.getIndexingMaps(),
+        candidate.contract.getIteratorTypes());
+
+    scf::YieldOp::create(b, loc, candidate.contract.getResult());
+  };
+
+  auto loopM = scf::ForOp::create(
+      rewriter, loc, c0, ubM, stepM, {},
+      [&](OpBuilder &b, Location loc, Value ivM, ValueRange iterArgs) {
+        scf::ForOp::create(
+            b, loc, c0, ubN, stepN, {},
+            [&](OpBuilder &b, Location loc, Value ivN, ValueRange iterArgs) {
+              // We unconditionally allocate a temporary accumulator buffer for
+              // the looped nanokernel case, hence we don't need any
+              // out-of-bounds handling.
+              SmallVector<bool> inBounds(
+                  cast<MemRefType>(candidate.accBuffer.getType()).getRank(),
+                  true);
+
+              auto accRead = vector::TransferReadOp::create(
+                  b, candidate.accRead.getLoc(), accRegTileTy,
+                  candidate.accBuffer, ValueRange{ivM, ivN},
+                  arith::ConstantOp::create(b, loc, b.getZeroAttr(accElemTy)),
+                  inBounds);
+
+              auto accLoop = scf::ForOp::create(
+                  b, loc, lbK, ubK, stepK, ValueRange{accRead},
+                  [&](OpBuilder &b, Location loc, Value ivK,
+                      ValueRange iterArgs) {
+                    loopKBodyBuilder(b, loc, ivM, ivN, ivK, iterArgs);
+                  });
+
+              auto accWrite = vector::TransferWriteOp::create(
+                  b, candidate.accWrite.getLoc(), accLoop.getResult(0),
+                  candidate.accBuffer, ValueRange{ivM, ivN}, inBounds);
+              scf::YieldOp::create(b, loc);
+
+              candidate.accRead = accRead;
+              candidate.accLoop = accLoop;
+              candidate.accWrite = accWrite;
+            });
+        scf::YieldOp::create(b, loc);
+      });
+
+  rewriter.eraseOp(oldAccWrite);
+  rewriter.eraseOp(oldAccLoop);
+  rewriter.eraseOp(oldAccRead);
+
+  LDBG("  Inserted register-tiled contraction: " << candidate.contract);
 }
 
 void performRegisterTiling(DotOpCandidate &candidate,
@@ -1031,11 +1198,20 @@ LogicalResult convertCandidate(DotOpCandidate &candidate,
   // by encoding it in the types.
   encodeVnniPacking(candidate, rewriter);
 
-  // Insert memref.subview ops to ensure all transfer ops have zero indices.
-  moveIndicesToSubview(candidate, rewriter);
-
   // 1:1 replacement of triton_cpu.dot -> vector.contract.
   convertToContract(candidate, rewriter);
+
+  if (candidate.isLoopedNanokernel) {
+    // Move loop-invariant code out of the way first.
+    moveLoopInvariantCode(candidate.accLoop);
+
+    // Insert loops around the nanokernel if the block sizes are larger than the
+    // maximum register tile sizes.
+    insertLoops(candidate, rewriter);
+  }
+
+  // Insert memref.subview ops to ensure all transfer ops have zero indices.
+  moveIndicesToSubview(candidate, rewriter);
 
   // Apply target-specific register tiling via upstream vector-dialect unroll
   // patterns.

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
@@ -1286,7 +1286,7 @@ LogicalResult convertCandidate(DotOpCandidate &candidate,
     elideZeroAcc(candidate, rewriter);
   }
 
-  // Flatten transfer ops to prevent inefficent lowering of VNNI-encoded reads,
+  // Flatten transfer ops to prevent inefficient lowering of VNNI-encoded reads,
   // e.g. `vector.transfer_read ... vector<1x16x2xbf16>` shall become a single
   // 32-element load instead of unrolling it to 16 2-element loads.
   flattenTransferOps(candidate, rewriter);

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
@@ -165,6 +165,7 @@ unsigned checkInputShapes(VectorType lhsTy, VectorType resTy,
     if (candidate.blockK == 4)
       return mask & (AVX10_2 | AVX_VNNI_INT8);
   }
+  candidate.isLoopedNanokernel = false;
 
   auto shapeUnrollsTo = [&candidate](int64_t m, int64_t n, int64_t k,
                                      int64_t numRegs, bool needsNPair = true) {

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
@@ -1184,7 +1184,8 @@ void elideZeroAcc(DotOpCandidate &candidate, PatternRewriter &rewriter) {
 
 void flattenTransferOps(DotOpCandidate &candidate, PatternRewriter &rewriter) {
   RewritePatternSet patterns(candidate.func.getContext());
-  unsigned targetVectorBitwidth = (candidate.target & (AVX_NE_CONVERT | AVX_VNNI_INT8)) ? 256 : 512;
+  unsigned targetVectorBitwidth =
+      (candidate.target & (AVX_NE_CONVERT | AVX_VNNI_INT8)) ? 256 : 512;
   vector::populateFlattenVectorTransferPatterns(patterns, targetVectorBitwidth);
   (void)applyPatternsGreedily(candidate.func, std::move(patterns));
 }

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
@@ -1015,6 +1015,13 @@ void elideZeroAcc(DotOpCandidate &candidate, PatternRewriter &rewriter) {
   LDBG("  Elided zero accumulation buffer.");
 }
 
+void flattenTransferOps(DotOpCandidate &candidate, PatternRewriter &rewriter) {
+  RewritePatternSet patterns(candidate.func.getContext());
+  unsigned targetVectorBitwidth = (candidate.target & (AVX_NE_CONVERT | AVX_VNNI_INT8)) ? 256 : 512;
+  vector::populateFlattenVectorTransferPatterns(patterns, targetVectorBitwidth);
+  (void)applyPatternsGreedily(candidate.func, std::move(patterns));
+}
+
 LogicalResult convertCandidate(DotOpCandidate &candidate,
                                PatternRewriter &rewriter) {
   // Introduce temporary buffer if needed.
@@ -1054,6 +1061,11 @@ LogicalResult convertCandidate(DotOpCandidate &candidate,
     elideAccCopy(candidate, rewriter);
     elideZeroAcc(candidate, rewriter);
   }
+
+  // Flatten transfer ops to prevent inefficent lowering of VNNI-encoded reads,
+  // e.g. `vector.transfer_read ... vector<1x16x2xbf16>` shall become a single
+  // 32-element load instead of unrolling it to 16 2-element loads.
+  flattenTransferOps(candidate, rewriter);
 
   return success();
 }


### PR DESCRIPTION
Introduces experimental support for handling `triton_cpu.dot` ops with shapes that cannot be unrolled fully due to (accumulator-)register constraints. The approach is to insert loops in the M and N dimensions around an accumulation loop with a smaller (register-unrollable) contraction. Support is currently limited to the non-AMX targets, pre-packed operands, and register tiles that cleanly divide the requested block size, but could be extended in the future.

Also fixes naive lowering of VNNI-shaped loads by applying MLIR's `FlattenVectorTransferPatterns`.