### PR TITLE
[CPU] Fix Python reference handling in launcher

### DIFF
--- a/python/test/unit/cpu/cpu_print_helper.py
+++ b/python/test/unit/cpu/cpu_print_helper.py
@@ -102,6 +102,76 @@ def kernel_print_2d_tensor(X, Y, BLOCK_SIZE_X: tl.constexpr, BLOCK_SIZE_Y: tl.co
     tl.device_print("", x)
 
 
+@triton.jit
+def kernel_noop_pointer(_ptr):
+    pass
+
+
+@triton.jit
+def kernel_noop():
+    pass
+
+
+class RefCountedZero(int):
+    pass
+
+
+class Pointer:
+
+    def __init__(self, value):
+        self.value = value
+        self.dtype = torch.float32
+
+    def data_ptr(self):
+        return self.value
+
+
+class RaisingPointer:
+    dtype = torch.float32
+
+    def __init__(self):
+        self.calls = 0
+
+    def data_ptr(self):
+        self.calls += 1
+        if self.calls == 1:
+            return 0
+        raise RuntimeError("data_ptr sentinel error")
+
+
+def test_pointer_refcount(device: str):
+    zero = RefCountedZero(0)
+    pointer = Pointer(zero)
+    kernel_noop_pointer[(1, )](pointer, num_warps=1, num_cpu_threads=1)
+    initial_refcount = sys.getrefcount(zero)
+    for _ in range(10):
+        kernel_noop_pointer[(1, )](pointer, num_warps=1, num_cpu_threads=1)
+    final_refcount = sys.getrefcount(zero)
+    if final_refcount != initial_refcount:
+        raise RuntimeError(f"data_ptr return reference leaked: {initial_refcount} -> {final_refcount}")
+
+
+def test_pointer_error(device: str):
+    kernel_noop_pointer[(1, )](RaisingPointer(), num_warps=1, num_cpu_threads=1)
+
+
+def test_hook_refcount(device: str):
+    result = object()
+
+    def hook(_metadata):
+        return result
+
+    triton.knobs.runtime.launch_enter_hook = hook
+    triton.knobs.runtime.launch_exit_hook = hook
+    kernel_noop[(1, )](num_warps=1, num_cpu_threads=1)
+    initial_refcount = sys.getrefcount(result)
+    for _ in range(10):
+        kernel_noop[(1, )](num_warps=1, num_cpu_threads=1)
+    final_refcount = sys.getrefcount(result)
+    if final_refcount != initial_refcount:
+        raise RuntimeError(f"launch hook return reference leaked: {initial_refcount} -> {final_refcount}")
+
+
 def test_print(func: str, data_type: str, device: str):
     if device != "cpu":
         raise ValueError(f"CPU print helper received unexpected device: {device}")

--- a/python/test/unit/cpu/test_cpu_subprocess.py
+++ b/python/test/unit/cpu/test_cpu_subprocess.py
@@ -49,6 +49,58 @@ def test_cpu_print(func_type: str, data_type: str, device: str):
     _check_cpu_print(proc.stdout.decode("UTF-8"), func_type, data_type, 128, 42)
 
 
+@pytest.mark.cpu
+def test_cpu_launcher_pointer_refcount(device: str):
+    if device != "cpu":
+        pytest.skip("CPU launcher tests require --device cpu.")
+
+    env = os.environ.copy()
+    env.pop("TRITON_CPU_BACKEND", None)
+    env.pop("TRITON_INTERPRET", None)
+    env["TRITON_DEFAULT_BACKEND"] = "cpu"
+    proc = subprocess.run(
+        [sys.executable, print_path, "test_pointer_refcount", device],
+        capture_output=True,
+        env=env,
+    )
+    assert proc.returncode == 0, proc.stderr.decode("UTF-8", errors="replace")
+
+
+@pytest.mark.cpu
+def test_cpu_launcher_pointer_error(device: str):
+    if device != "cpu":
+        pytest.skip("CPU launcher tests require --device cpu.")
+
+    env = os.environ.copy()
+    env.pop("TRITON_CPU_BACKEND", None)
+    env.pop("TRITON_INTERPRET", None)
+    env["TRITON_DEFAULT_BACKEND"] = "cpu"
+    proc = subprocess.run(
+        [sys.executable, print_path, "test_pointer_error", device],
+        capture_output=True,
+        env=env,
+    )
+    assert proc.returncode != 0
+    assert proc.stderr.decode("UTF-8", errors="replace").rstrip().endswith("RuntimeError: data_ptr sentinel error")
+
+
+@pytest.mark.cpu
+def test_cpu_launcher_hook_refcount(device: str):
+    if device != "cpu":
+        pytest.skip("CPU launcher tests require --device cpu.")
+
+    env = os.environ.copy()
+    env.pop("TRITON_CPU_BACKEND", None)
+    env.pop("TRITON_INTERPRET", None)
+    env["TRITON_DEFAULT_BACKEND"] = "cpu"
+    proc = subprocess.run(
+        [sys.executable, print_path, "test_hook_refcount", device],
+        capture_output=True,
+        env=env,
+    )
+    assert proc.returncode == 0, proc.stderr.decode("UTF-8", errors="replace")
+
+
 def _check_cpu_print(actual, func_type, data_type, N, SCALAR_VAL):
     # An example of tensor printing is:
     # (0, 0, 0) x: [  0,   1,   2,   3,   4,   5,   6,   7,

--- a/third_party/cpu/backend/driver.py
+++ b/third_party/cpu/backend/driver.py
@@ -175,6 +175,8 @@ static inline DevicePtrInfo getPointer(PyObject *obj, int idx) {{
   ptr_info.valid = true;
   if (PyLong_Check(obj)) {{
     ptr_info.dev_ptr = (void*) PyLong_AsLongLong(obj);
+    if (PyErr_Occurred())
+      ptr_info.valid = false;
     return ptr_info;
   }}
   if (obj == Py_None) {{
@@ -184,19 +186,30 @@ static inline DevicePtrInfo getPointer(PyObject *obj, int idx) {{
   PyObject *ptr = PyObject_GetAttrString(obj, "data_ptr");
   if(ptr){{
     PyObject *empty_tuple = PyTuple_New(0);
+    if (!empty_tuple) {{
+      Py_DECREF(ptr);
+      ptr_info.valid = false;
+      return ptr_info;
+    }}
     PyObject *ret = PyObject_Call(ptr, empty_tuple, NULL);
     Py_DECREF(empty_tuple);
     Py_DECREF(ptr);
+    if (!ret) {{
+      ptr_info.valid = false;
+      return ptr_info;
+    }}
     if (!PyLong_Check(ret)) {{
+      Py_DECREF(ret);
       PyErr_SetString(PyExc_TypeError, "data_ptr method of Pointer object must return 64-bit int");
       ptr_info.valid = false;
       return ptr_info;
     }}
     ptr_info.dev_ptr = (void*) PyLong_AsLongLong(ret);
-    if(!ptr_info.dev_ptr) {{
+    Py_DECREF(ret);
+    if (PyErr_Occurred()) {{
+      ptr_info.valid = false;
       return ptr_info;
     }}
-    Py_DECREF(ret);  // Thanks ChatGPT!
     return ptr_info;
   }}
   PyErr_SetString(PyExc_TypeError, "Pointer argument must be either uint64 or have data_ptr method");
@@ -275,8 +288,20 @@ static PyObject* launch(PyObject* self, PyObject* args) {{
   // Extract num_threads metadata.
   int num_threads = 0;
   PyObject *num_threads_attr = PyObject_GetAttrString(kernel_metadata, "num_cpu_threads");
-  if (num_threads_attr && PyLong_Check(num_threads_attr))
-    num_threads = PyLong_AsLong(num_threads_attr);
+  if (num_threads_attr) {{
+    if (PyLong_Check(num_threads_attr)) {{
+      num_threads = PyLong_AsLong(num_threads_attr);
+      if (PyErr_Occurred()) {{
+        Py_DECREF(num_threads_attr);
+        return NULL;
+      }}
+    }}
+    Py_DECREF(num_threads_attr);
+  }} else if (PyErr_ExceptionMatches(PyExc_AttributeError)) {{
+    PyErr_Clear();
+  }} else {{
+    return NULL;
+  }}
 
   // extract launch metadata
   if (launch_enter_hook != Py_None){{
@@ -285,6 +310,7 @@ static PyObject* launch(PyObject* self, PyObject* args) {{
     Py_DECREF(args);
     if (!ret)
       return NULL;
+    Py_DECREF(ret);
   }}
 
   {"; ".join([f"DevicePtrInfo ptr_info{i} = getPointer(arg{i}, {i}); if (!ptr_info{i}.valid) return NULL;" if ty[0] == "*" else "" for i, ty in signature_without_constexprs.items()])};
@@ -296,6 +322,7 @@ static PyObject* launch(PyObject* self, PyObject* args) {{
     Py_DECREF(args);
     if (!ret)
       return NULL;
+    Py_DECREF(ret);
   }}
 
   if (PyErr_Occurred()) {{


### PR DESCRIPTION
# Summary

Fix Python C API reference and error handling in the generated CPU launcher.

## Root cause

- Owned references from metadata, hooks, and `data_ptr()` were not always released.
- A `data_ptr()` exception could pass `NULL` into `PyLong_Check`, causing a segfault.
- Missing metadata could leave a stale Python exception.

## Testing

- CPU subprocess tests: `30 passed, 4 skipped`
- Added regression coverage for refcount leaks and `data_ptr()` errors.