### PR TITLE
[CPU] Propagate program context to subfunctions (fix a tl.print bug)

### DIFF
--- a/python/test/unit/cpu/cpu_print_helper.py
+++ b/python/test/unit/cpu/cpu_print_helper.py
@@ -172,6 +172,34 @@ def test_hook_refcount(device: str):
         raise RuntimeError(f"launch hook return reference leaked: {initial_refcount} -> {final_refcount}")
 
 
+@triton.jit(noinline=True)
+def print_context_from_subfunction(s0, s1, s2, s3, s4, s5):
+    pid = tl.program_id(0) + 10 * tl.program_id(1)
+    num_programs = tl.num_programs(0) + 10 * tl.num_programs(1)
+    encoded_context = pid + 100 * num_programs
+    # Keep all six sentinel arguments live so that the regression test catches
+    # them being mistaken for pid and num_programs arguments.
+    sentinel_sum = s0 + s1 + s2 + s3 + s4 + s5
+    print("context:", encoded_context + 0 * sentinel_sum)
+
+
+@triton.jit
+def kernel_print_from_subfunction(SENTINELS):
+    print_context_from_subfunction(
+        tl.load(SENTINELS + 0),
+        tl.load(SENTINELS + 1),
+        tl.load(SENTINELS + 2),
+        tl.load(SENTINELS + 3),
+        tl.load(SENTINELS + 4),
+        tl.load(SENTINELS + 5),
+    )
+
+
+def test_print_from_subfunction(device: str):
+    sentinels = torch.tensor([11, 12, 13, 14, 15, 16], dtype=torch.int32, device=device)
+    kernel_print_from_subfunction[(2, 3)](sentinels, num_warps=1, num_cpu_threads=1)
+
+
 def test_print(func: str, data_type: str, device: str):
     if device != "cpu":
         raise ValueError(f"CPU print helper received unexpected device: {device}")

--- a/python/test/unit/cpu/test_cpu_subprocess.py
+++ b/python/test/unit/cpu/test_cpu_subprocess.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+from collections import Counter
 
 import pytest
 
@@ -99,6 +100,28 @@ def test_cpu_launcher_hook_refcount(device: str):
         env=env,
     )
     assert proc.returncode == 0, proc.stderr.decode("UTF-8", errors="replace")
+
+
+@pytest.mark.cpu
+def test_cpu_print_from_subfunction(device: str):
+    if device != "cpu":
+        pytest.skip("CPU print tests require --device cpu.")
+
+    env = os.environ.copy()
+    env.pop("TRITON_CPU_BACKEND", None)
+    env.pop("TRITON_INTERPRET", None)
+    env["TRITON_DEFAULT_BACKEND"] = "cpu"
+    proc = subprocess.run(
+        [sys.executable, print_path, "test_print_from_subfunction", device],
+        capture_output=True,
+        env=env,
+    )
+    assert proc.returncode == 0, proc.stderr.decode("UTF-8", errors="replace")
+
+    actual = proc.stdout.decode("UTF-8")
+    expected = [f"({x}, {y}, 0) context: {3200 + x + 10 * y}" for y in range(3) for x in range(2)]
+    assert actual.endswith("\n")
+    assert Counter(actual.splitlines()) == Counter(expected)
 
 
 def _check_cpu_print(actual, func_type, data_type, N, SCALAR_VAL):

--- a/test/TritonCPU/func-op-to-llvm.mlir
+++ b/test/TritonCPU/func-op-to-llvm.mlir
@@ -1,0 +1,38 @@
+// RUN: triton-opt %s -triton-cpu-func-op-to-llvm | FileCheck %s
+
+module {
+  tt.func public @kernel(%arg0: i32) attributes {noinline = false} {
+    tt.call @middle() : () -> ()
+    %0 = tt.call @external(%arg0) : (i32) -> i32
+    tt.return
+  }
+
+  tt.func private @middle() attributes {noinline = true} {
+    tt.call @leaf() : () -> ()
+    tt.return
+  }
+
+  tt.func private @leaf() attributes {noinline = true} {
+    tt.return
+  }
+
+  tt.func private @external(%arg0: i32) -> i32
+}
+
+// CHECK-LABEL: llvm.func @kernel(
+// CHECK-SAME: %[[VALUE:[^:]+]]: i32,
+// CHECK-SAME: %[[KPID0:[^:]+]]: i32, %[[KPID1:[^:]+]]: i32, %[[KPID2:[^:]+]]: i32,
+// CHECK-SAME: %[[KNUM0:[^:]+]]: i32, %[[KNUM1:[^:]+]]: i32, %[[KNUM2:[^:]+]]: i32)
+// CHECK: llvm.call @middle(%[[KPID0]], %[[KPID1]], %[[KPID2]], %[[KNUM0]], %[[KNUM1]], %[[KNUM2]])
+// CHECK: llvm.call @external(%[[VALUE]]) : (i32) -> i32
+
+// CHECK-LABEL: llvm.func @middle(
+// CHECK-SAME: %[[MPID0:[^:]+]]: i32, %[[MPID1:[^:]+]]: i32, %[[MPID2:[^:]+]]: i32,
+// CHECK-SAME: %[[MNUM0:[^:]+]]: i32, %[[MNUM1:[^:]+]]: i32, %[[MNUM2:[^:]+]]: i32)
+// CHECK: llvm.call @leaf(%[[MPID0]], %[[MPID1]], %[[MPID2]], %[[MNUM0]], %[[MNUM1]], %[[MNUM2]])
+
+// CHECK-LABEL: llvm.func @leaf(
+// CHECK-SAME: %{{[^:]+}}: i32, %{{[^:]+}}: i32, %{{[^:]+}}: i32,
+// CHECK-SAME: %{{[^:]+}}: i32, %{{[^:]+}}: i32, %{{[^:]+}}: i32)
+
+// CHECK-LABEL: llvm.func @external(i32) -> i32

--- a/third_party/cpu/lib/TritonCPUToLLVM/FuncOpToLLVM.cpp
+++ b/third_party/cpu/lib/TritonCPUToLLVM/FuncOpToLLVM.cpp
@@ -1,4 +1,5 @@
 #include "TypeConverter.h"
+#include "Utility.h"
 
 #include "cpu/include/TritonCPUToLLVM/Passes.h"
 
@@ -63,19 +64,15 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
 
   triton::FuncOp amendProgramIdArgs(triton::FuncOp funcOp,
                                     ConversionPatternRewriter &rewriter) const {
-    // Push back a variable that indicates the current stack pointer of shared
-    // memory to the function arguments.
     auto loc = funcOp.getLoc();
     auto ctx = funcOp->getContext();
+    SmallVector<Type, cpu::kNumProgramContextArgs> programContextTypes = {
+        i32_ty, i32_ty, i32_ty, ui32_ty, ui32_ty, ui32_ty};
+
     // 1. Modify the function type to add new arguments.
     auto funcTy = funcOp.getFunctionType();
     auto amendedInputTy = llvm::to_vector<4>(funcTy.getInputs());
-    amendedInputTy.push_back(i32_ty);
-    amendedInputTy.push_back(i32_ty);
-    amendedInputTy.push_back(i32_ty);
-    amendedInputTy.push_back(ui32_ty);
-    amendedInputTy.push_back(ui32_ty);
-    amendedInputTy.push_back(ui32_ty);
+    amendedInputTy.append(programContextTypes);
     auto amendedFuncTy = FunctionType::get(funcTy.getContext(), amendedInputTy,
                                            funcTy.getResults());
     // 2. Modify the argument attributes to add new arguments.
@@ -84,27 +81,19 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
     SmallVector<Attribute> amendedArgAttrs;
     if (funcOp.getAllArgAttrs()) {
       amendedArgAttrs = llvm::to_vector<4>(funcOp.getAllArgAttrs());
-      amendedArgAttrs.emplace_back(DictionaryAttr::get(ctx));
-      amendedArgAttrs.emplace_back(DictionaryAttr::get(ctx));
-      amendedArgAttrs.emplace_back(DictionaryAttr::get(ctx));
-      amendedArgAttrs.emplace_back(DictionaryAttr::get(ctx));
-      amendedArgAttrs.emplace_back(DictionaryAttr::get(ctx));
-      amendedArgAttrs.emplace_back(DictionaryAttr::get(ctx));
+      amendedArgAttrs.append(cpu::kNumProgramContextArgs,
+                             DictionaryAttr::get(ctx));
       amendedAttrs.push_back(
           rewriter.getNamedAttr(funcOp.getArgAttrsAttrName(),
                                 rewriter.getArrayAttr(amendedArgAttrs)));
     }
-    // 3. Add a new arguments to the region
+    // 3. Add new arguments to the region.
     auto amendedFuncOp =
         triton::FuncOp::create(rewriter, funcOp.getLoc(), funcOp.getName(),
                                amendedFuncTy, amendedAttrs);
     auto &region = funcOp.getBody();
-    region.addArgument(i32_ty, loc);
-    region.addArgument(i32_ty, loc);
-    region.addArgument(i32_ty, loc);
-    region.addArgument(ui32_ty, loc);
-    region.addArgument(ui32_ty, loc);
-    region.addArgument(ui32_ty, loc);
+    for (Type type : programContextTypes)
+      region.addArgument(type, loc);
     rewriter.inlineRegionBefore(region, amendedFuncOp.getBody(),
                                 amendedFuncOp.end());
     return amendedFuncOp;
@@ -113,9 +102,11 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
   LogicalResult
   matchAndRewrite(triton::FuncOp funcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // Prevent LLVM's inliner to inline this function
+    // Defined Triton functions need pid and num_programs arguments because
+    // operations such as program_id and print may also occur in subfunctions.
+    bool isExternal = funcOp.isExternal();
     auto modifiedFuncOp = funcOp;
-    if (LLVM::isKernel(funcOp))
+    if (!isExternal)
       modifiedFuncOp = amendProgramIdArgs(modifiedFuncOp, rewriter);
 
     LLVM::LLVMFuncOp newFuncOp = *mlir::convertFuncOpToLLVMFuncOp(
@@ -127,8 +118,7 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
     // which not all assemblers support.
     newFuncOp.setAlignment(128);
 
-    // required by AxisInfoAnalysis
-    if (LLVM::isKernel(funcOp))
+    if (!isExternal)
       rewriter.eraseOp(modifiedFuncOp);
     rewriter.eraseOp(funcOp);
     return success();
@@ -178,8 +168,10 @@ struct CallOpConversion : public ConvertOpToLLVMPattern<triton::CallOp> {
                   typename triton::CallOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto promotedOperands = promoteOperands(callOp, adaptor, rewriter);
+    if (failed(promotedOperands))
+      return failure();
     auto newCallOp =
-        convertCallOpToLLVMCallOp(callOp, promotedOperands, rewriter);
+        convertCallOpToLLVMCallOp(callOp, *promotedOperands, rewriter);
     if (!newCallOp)
       return failure();
     auto results = getCallOpResults(callOp, newCallOp, rewriter);
@@ -188,15 +180,49 @@ struct CallOpConversion : public ConvertOpToLLVMPattern<triton::CallOp> {
   }
 
 private:
-  SmallVector<Value, 4>
+  FailureOr<SmallVector<Value, 4>>
   promoteOperands(triton::CallOp callOp,
                   typename triton::CallOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const {
-    auto loc = callOp.getLoc();
-    auto caller = callOp->getParentOfType<FunctionOpInterface>();
     auto promotedOperands = this->getTypeConverter()->promoteOperands(
         callOp.getLoc(), /*opOperands=*/callOp->getOperands(),
         adaptor.getOperands(), rewriter);
+
+    auto callee = SymbolTable::lookupNearestSymbolFrom<LLVM::LLVMFuncOp>(
+        callOp, callOp.getCalleeAttr());
+    if (!callee) {
+      callOp.emitOpError("expected an LLVM function callee");
+      return failure();
+    }
+    if (callee.isExternal())
+      return promotedOperands;
+
+    auto caller = callOp->getParentOfType<LLVM::LLVMFuncOp>();
+    if (!caller) {
+      callOp.emitOpError("expected an enclosing LLVM function");
+      return failure();
+    }
+
+    // FuncOpConversion runs before CallOpConversion, so this call's enclosing
+    // function should already have the program-context arguments appended.
+    auto callerArgs = caller.getArguments();
+    if (callerArgs.size() < cpu::kNumProgramContextArgs) {
+      callOp.emitOpError("caller is missing pid and num_programs arguments");
+      return failure();
+    }
+
+    auto expectedNumArgs =
+        promotedOperands.size() + cpu::kNumProgramContextArgs;
+    if (callee.getFunctionType().getNumParams() != expectedNumArgs) {
+      callOp.emitOpError("callee has an unexpected number of arguments");
+      return failure();
+    }
+
+    // Forward pid_x/y/z and num_programs_x/y/z to the Triton subfunction.
+    for (unsigned i = callerArgs.size() - cpu::kNumProgramContextArgs;
+         i < callerArgs.size(); ++i)
+      promotedOperands.push_back(callerArgs[i]);
+
     return promotedOperands;
   }
 

--- a/third_party/cpu/lib/TritonCPUToLLVM/Utility.cpp
+++ b/third_party/cpu/lib/TritonCPUToLLVM/Utility.cpp
@@ -7,11 +7,11 @@ namespace mlir::triton::cpu {
 
 Value getProgramId(mlir::FunctionOpInterface funcOp, int axis) {
   auto args = funcOp.getArguments();
-  assert(funcOp && args.size() >= 6);
-  assert(axis >= 0 && axis < 3);
+  assert(funcOp && args.size() >= kNumProgramContextArgs);
+  assert(axis >= 0 && axis < static_cast<int>(kNumProgramDims));
 
   // The first three of the last six args are x, y, z program ids.
-  auto argIdx = args.size() - 6 + axis;
+  auto argIdx = args.size() - kNumProgramContextArgs + axis;
   assert(argIdx < args.size() && "out-of-bounds arg index");
   assert(args[argIdx].getType().isInteger(32) && "unexpected arg type");
   return args[argIdx];
@@ -19,11 +19,11 @@ Value getProgramId(mlir::FunctionOpInterface funcOp, int axis) {
 
 Value getNumPrograms(mlir::FunctionOpInterface funcOp, int axis) {
   auto args = funcOp.getArguments();
-  assert(funcOp && args.size() >= 6);
-  assert(axis >= 0 && axis < 3);
+  assert(funcOp && args.size() >= kNumProgramContextArgs);
+  assert(axis >= 0 && axis < static_cast<int>(kNumProgramDims));
 
   // The last three of the args are gridX, gridY, gridZ (bounds) of grid.
-  auto argIdx = args.size() - 3 + axis;
+  auto argIdx = args.size() - kNumProgramDims + axis;
   assert(argIdx < args.size() && "out-of-bounds arg index");
   assert(args[argIdx].getType().isInteger(32) && "unexpected arg type");
   return args[argIdx];

--- a/third_party/cpu/lib/TritonCPUToLLVM/Utility.h
+++ b/third_party/cpu/lib/TritonCPUToLLVM/Utility.h
@@ -6,6 +6,9 @@
 
 namespace mlir::triton::cpu {
 
+inline constexpr unsigned kNumProgramDims = 3;
+inline constexpr unsigned kNumProgramContextArgs = 2 * kNumProgramDims;
+
 Value getProgramId(mlir::FunctionOpInterface funcOp, int axis);
 Value getNumPrograms(mlir::FunctionOpInterface funcOp, int axis);
 


### PR DESCRIPTION
# Summary

Propagate program IDs and grid dimensions through CPU subfunction calls.

## Root cause

CPU lowering assumed every function already contained six launch-context arguments. Non-inlined Triton subfunctions therefore read ordinary arguments as `program_id`/`num_programs`, producing incorrect output or crashes.

The fix adds and forwards the context arguments while preserving external function ABIs.

## Testing

- Added MLIR coverage for nested calls and external functions.
- Added a CPU print regression test for non-inlined subfunctions.
- CPU print suite: `28 passed, 4 skipped`.