### PR TITLE
[RUNTIME] Unload kernels with their loading driver

### DIFF
--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -1119,3 +1119,76 @@ def test_module_load_unload(device, fresh_knobs):
     assert pre_compile.module is None
     # turn on garbage collector
     gc.enable()
+
+
+def test_module_unload_uses_loading_driver(monkeypatch, fresh_knobs):
+    from types import SimpleNamespace
+    from triton.compiler import compiler
+
+    module = object()
+    function = object()
+    loading_driver_unloads = []
+    current_driver_unloads = []
+
+    loading_driver = SimpleNamespace(
+        get_current_device=lambda: 0,
+        get_current_target=lambda: SimpleNamespace(warp_size=32),
+        launcher_cls=lambda src, metadata: object(),
+        utils=SimpleNamespace(
+            load_binary=lambda *args: (module, function, 0, 0, 1024),
+            unload_module=loading_driver_unloads.append,
+        ),
+    )
+    current_driver = SimpleNamespace(utils=SimpleNamespace(unload_module=current_driver_unloads.append), )
+
+    compiled = object.__new__(compiler.CompiledKernel)
+    compiled.src = object()
+    compiled.metadata = SimpleNamespace(shared=0, num_warps=1)
+    compiled.metadata_group = {}
+    compiled.hash = "hash"
+    compiled.name = "kernel"
+    compiled.kernel = b"binary"
+    compiled.module = None
+    compiled.function = None
+    compiled._run = None
+
+    monkeypatch.setattr(compiler, "_max_shared_mem", lambda device, driver_utils: 1024)
+    monkeypatch.setattr(compiler.driver, "_active", loading_driver)
+
+    compiled._init_handles()
+    compiler.driver.set_active(current_driver)
+    compiled.__del__()
+
+    assert loading_driver_unloads == [module]
+    assert current_driver_unloads == []
+    assert compiled.module is None
+
+
+def test_max_shared_mem_cache_is_driver_specific(monkeypatch):
+    from types import SimpleNamespace
+    from triton.compiler import compiler
+
+    class DriverUtils:
+
+        def __init__(self, value):
+            self.value = value
+            self.calls = 0
+
+        def get_device_properties(self, device):
+            self.calls += 1
+            return {"max_shared_mem": self.value}
+
+    cpu_utils = DriverUtils(0)
+    gpu_utils = DriverUtils(65536)
+    compiler._max_shared_mem.cache_clear()
+
+    monkeypatch.setattr(compiler.driver, "_active", SimpleNamespace(utils=cpu_utils))
+    assert compiler.max_shared_mem(0) == 0
+    compiler.driver.set_active(SimpleNamespace(utils=gpu_utils))
+    assert compiler.max_shared_mem(0) == 65536
+    compiler.driver.set_active(SimpleNamespace(utils=cpu_utils))
+    assert compiler.max_shared_mem(0) == 0
+    assert cpu_utils.calls == 1
+    assert gpu_utils.calls == 1
+
+    compiler._max_shared_mem.cache_clear()

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -131,8 +131,12 @@ class IRSource:
 
 
 @functools.lru_cache()
+def _max_shared_mem(device, driver_utils):
+    return driver_utils.get_device_properties(device)["max_shared_mem"]
+
+
 def max_shared_mem(device):
-    return driver.active.utils.get_device_properties(device)["max_shared_mem"]
+    return _max_shared_mem(device, driver.active.utils)
 
 
 def parse(full_name, ext, context):
@@ -435,6 +439,7 @@ class CompiledKernel:
         self.module = None
         self.function = None
         self._run = None
+        self._unload_module = None
 
     def __del__(self):
 
@@ -442,7 +447,8 @@ class CompiledKernel:
             if knobs.runtime.kernel_unload_hook is not None:
                 knobs.runtime.kernel_unload_hook(self.module, self.function, self.name, self.metadata_group, self.hash)
 
-            driver.active.utils.unload_module(self.module)
+            if self._unload_module is not None:
+                self._unload_module(self.module)
             self.module = None
 
     def _init_handles(self):
@@ -459,11 +465,13 @@ class CompiledKernel:
             self._run = functools.partial(_raise_error, cloned_err)
             raise err
 
-        device = driver.active.get_current_device()
+        active_driver = driver.active
+        device = active_driver.get_current_device()
+        utils = active_driver.utils
         # create launcher
-        self._run = driver.active.launcher_cls(self.src, self.metadata)
+        self._run = active_driver.launcher_cls(self.src, self.metadata)
         # not enough shared memory to run the kernel
-        max_shared = max_shared_mem(device)
+        max_shared = _max_shared_mem(device, utils)
         if self.metadata.shared > max_shared:
             raise_(OutOfResources(self.metadata.shared, max_shared, "shared memory"))
         if hasattr(self.metadata, "tmem_size") and self.metadata.tmem_size is not None:
@@ -474,9 +482,10 @@ class CompiledKernel:
         if knobs.runtime.kernel_load_start_hook is not None:
             knobs.runtime.kernel_load_start_hook(self.module, self.function, self.name, self.metadata_group, self.hash)
         # TODO: n_regs, n_spills should be metadata generated when calling `ptxas`
-        self.module, self.function, self.n_regs, self.n_spills, self.n_max_threads = driver.active.utils.load_binary(
+        self._unload_module = utils.unload_module
+        self.module, self.function, self.n_regs, self.n_spills, self.n_max_threads = utils.load_binary(
             self.name, self.kernel, self.metadata.shared, device)
-        warp_size = driver.active.get_current_target().warp_size
+        warp_size = active_driver.get_current_target().warp_size
         if self.metadata.num_warps * warp_size > self.n_max_threads:
             raise_(OutOfResources(self.metadata.num_warps * warp_size, self.n_max_threads, "threads"))
         if knobs.runtime.kernel_load_end_hook is not None:


### PR DESCRIPTION
`unload_module` was recently introduced (upstream PR #9444, 946e151bf, 2026-02-17), and we have potential bugs related to handling backend state.

## Summary

- Store each `CompiledKernel`'s unload callback from its loading driver.
- Key `max_shared_mem` by both device and driver utilities.

This prevents backend switches from unloading modules through the wrong driver or reusing CPU device 0's shared-memory limit for GPU device 0.

## Testing

```bash
pytest -s --tb=short python/test/unit/runtime/test_cache.py::test_module_unload_uses_loading_driver python/test/unit/runtime/test_cache.py::test_max_shared_mem_cache_is_driver_specific
```

Result: `2 passed`
