### PR TITLE
[CPU] Flatten contiguous vector transfer reads before LLVM lowering

### DIFF
--- a/test/TritonCPU/canonicalize.mlir
+++ b/test/TritonCPU/canonicalize.mlir
@@ -26,3 +26,45 @@ module {
     tt.return
   }
 }
+
+// -----
+
+// Flatten a fully in-bounds contiguous read to a rank-1 wide read.
+
+// CHECK-LABEL: @flatten_contiguous_transfer_read
+// CHECK: %[[WIDE:.+]] = vector.transfer_read %{{.+}}[%{{.+}}, %{{.+}}, %{{.+}}], %{{.+}} {in_bounds = [true]} : memref<1x64x2xbf16, strided<[?, 2, 1], offset: ?>>, vector<32xbf16>
+// CHECK-NOT: vector.shape_cast
+// CHECK: vector.store %[[WIDE]]
+module {
+  tt.func public @flatten_contiguous_transfer_read(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<bf16> {tt.divisibility = 16 : i32}) {
+    %cst = arith.constant 0.000000e+00 : bf16
+    %c0 = arith.constant 0 : index
+    %src = triton_cpu.ptr_to_memref %arg0 : <bf16> -> memref<1x64x2xbf16, strided<[?, 2, 1], offset: ?>>
+    %read = vector.transfer_read %src[%c0, %c0, %c0], %cst {in_bounds = [true, true, true]} : memref<1x64x2xbf16, strided<[?, 2, 1], offset: ?>>, vector<1x16x2xbf16>
+    %flat = vector.shape_cast %read : vector<1x16x2xbf16> to vector<32xbf16>
+    %dst = triton_cpu.ptr_to_memref %arg1 : <bf16> -> memref<32xbf16>
+    vector.store %flat, %dst[%c0] : memref<32xbf16>, vector<32xbf16>
+    tt.return
+  }
+}
+
+// -----
+
+// Do not flatten a read whose row stride contains gaps.
+
+// CHECK-LABEL: @keep_noncontiguous_transfer_read
+// CHECK: %[[READ:.+]] = vector.transfer_read %{{.+}}[%{{.+}}, %{{.+}}, %{{.+}}], %{{.+}} {in_bounds = [true, true, true]} : memref<1x16x2xbf16, strided<[64, 4, 1]>>, vector<1x16x2xbf16>
+// CHECK: %[[FLAT:.+]] = vector.shape_cast %[[READ]] : vector<1x16x2xbf16> to vector<32xbf16>
+// CHECK: vector.store %[[FLAT]]
+module {
+  tt.func public @keep_noncontiguous_transfer_read(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<bf16> {tt.divisibility = 16 : i32}) {
+    %cst = arith.constant 0.000000e+00 : bf16
+    %c0 = arith.constant 0 : index
+    %src = triton_cpu.ptr_to_memref %arg0 : <bf16> -> memref<1x16x2xbf16, strided<[64, 4, 1]>>
+    %read = vector.transfer_read %src[%c0, %c0, %c0], %cst {in_bounds = [true, true, true]} : memref<1x16x2xbf16, strided<[64, 4, 1]>>, vector<1x16x2xbf16>
+    %flat = vector.shape_cast %read : vector<1x16x2xbf16> to vector<32xbf16>
+    %dst = triton_cpu.ptr_to_memref %arg1 : <bf16> -> memref<32xbf16>
+    vector.store %flat, %dst[%c0] : memref<32xbf16>, vector<32xbf16>
+    tt.return
+  }
+}

--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -244,6 +244,10 @@ class CPUBackend(BaseBackend):
             cpu.passes.ttcpuir.add_unroll_and_reorder_elementwise_ops(pm, ",".join(self.cpu_features))
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)
+        # Nanokernel lowering can introduce contiguous multi-dimensional
+        # transfer reads followed by flattening shape casts. Run the CPU
+        # canonicalizations again before generic cleanup and LLVM lowering.
+        cpu.passes.ttcpuir.add_triton_cpu_canonicalizer(pm)
         passes.common.add_canonicalizer(pm)
         pm.run(mod, "make_tttcir")
         return mod

--- a/third_party/cpu/lib/TritonCPUTransforms/Canonicalize.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/Canonicalize.cpp
@@ -80,6 +80,81 @@ struct FoldReadShapeCast : public OpRewritePattern<vector::TransferReadOp> {
   }
 };
 
+// Fold a fully in-bounds contiguous multi-dimensional transfer read followed
+// by a flattening shape cast into a rank-1 transfer read. This intentionally
+// handles only statically provable row-major reads without masks.
+struct FlattenContiguousReadShapeCast
+    : public OpRewritePattern<vector::TransferReadOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::TransferReadOp op,
+                                PatternRewriter &rewriter) const override {
+    if (!op->hasOneUse() || op.getMask())
+      return failure();
+
+    auto reshape = dyn_cast<vector::ShapeCastOp>(*op->user_begin());
+    if (!reshape)
+      return failure();
+
+    auto srcTy = dyn_cast<VectorType>(op.getType());
+    auto dstTy = dyn_cast<VectorType>(reshape.getType());
+    auto memrefTy = dyn_cast<MemRefType>(op.getBase().getType());
+    if (!srcTy || !dstTy || !memrefTy || srcTy.getRank() <= 1 ||
+        dstTy.getRank() != 1 ||
+        srcTy.getElementType() != dstTy.getElementType() ||
+        srcTy.getNumElements() != dstTy.getNumElements())
+      return failure();
+
+    auto permMap = op.getPermutationMap();
+    if (!permMap.isMinorIdentity() ||
+        permMap.getNumResults() != srcTy.getRank() ||
+        memrefTy.getRank() < srcTy.getRank())
+      return failure();
+
+    auto inBounds = op.getInBounds();
+    if (inBounds.size() != srcTy.getRank() ||
+        llvm::any_of(inBounds, [](Attribute attr) {
+          return !cast<BoolAttr>(attr).getValue();
+        }))
+      return failure();
+
+    SmallVector<int64_t> strides;
+    int64_t offset;
+    if (failed(memrefTy.getStridesAndOffset(strides, offset)))
+      return failure();
+
+    // The minor memref dimensions read by the transfer must be large enough
+    // for the vector tile and have row-major strides for every dimension that
+    // advances an address. Size-one vector dimensions do not constrain their
+    // corresponding memref stride because their sole index is zero.
+    int64_t expectedStride = 1;
+    int64_t memrefDim = memrefTy.getRank() - 1;
+    for (int64_t vectorDim = srcTy.getRank() - 1; vectorDim >= 0;
+         --vectorDim, --memrefDim) {
+      int64_t vectorSize = srcTy.getDimSize(vectorDim);
+      int64_t memrefSize = memrefTy.getDimSize(memrefDim);
+      if (ShapedType::isDynamic(vectorSize) ||
+          (!ShapedType::isDynamic(memrefSize) && memrefSize < vectorSize))
+        return failure();
+      if (vectorSize > 1 &&
+          (strides[memrefDim] == ShapedType::kDynamic ||
+           strides[memrefDim] != expectedStride))
+        return failure();
+      expectedStride *= vectorSize;
+    }
+
+    auto newPermMap = AffineMap::getMinorIdentityMap(
+        permMap.getNumDims(), 1, rewriter.getContext());
+    auto newInBounds = rewriter.getBoolArrayAttr({true});
+    auto newRead = vector::TransferReadOp::create(
+        rewriter, op.getLoc(), dstTy, op.getBase(), op.getIndices(),
+        newPermMap, op.getPadding(), Value(), newInBounds);
+    rewriter.replaceOp(reshape, newRead);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 struct Canonicalize : public triton::cpu::impl::CanonicalizeBase<Canonicalize> {
   Canonicalize() = default;
 
@@ -88,7 +163,7 @@ struct Canonicalize : public triton::cpu::impl::CanonicalizeBase<Canonicalize> {
     ModuleOp mod = getOperation();
 
     RewritePatternSet patterns(context);
-    patterns.add<FoldReadShapeCast>(context);
+    patterns.add<FoldReadShapeCast, FlattenContiguousReadShapeCast>(context);
 
     if (failed(mlir::applyPatternsGreedily(mod, std::move(patterns))))
       return signalPassFailure();


### PR DESCRIPTION
## Problem

A contiguous multidimensional BF16 `vector.transfer_read` followed by a flattening `vector.shape_cast` reaches LLVM lowering as fragmented pair loads and shuffle reconstruction instead of one wide read.

## Root cause

Nanokernel conversion introduces this transfer-read/shape-cast chain after the first TritonCPU canonicalizer has run. The existing fold only removes leading unit dimensions and cannot flatten the remaining contiguous dimensions.

## Solution

Add a conservative TritonCPU canonicalization that replaces a provably contiguous multidimensional transfer read plus flattening shape cast with an equivalent rank-one transfer read. Run TritonCPU canonicalization after dot/nanokernel conversion and before LLVM lowering.

## Safety

The rewrite requires a single direct shape-cast user, equal element type/count, a memref source, no mask, minor-identity permutation, explicit full in-bounds semantics, and static strides proving row-major contiguity. Masked, partial/OOB, transposed, broadcast, non-contiguous, and unprovable layouts remain unchanged. Tests include a contiguous positive case and a gapped-stride negative case.

## Codegen

On latest main `49665af3b0873b7cdefb8d8bec5153545e3f09f7`:

| Metric | Before | After |
|---|---:|---:|
| Minimal LLVM `<2 x bfloat>` loads | 16 | 0 |
| Minimal LLVM `<32 x bfloat>` loads | 0 | 1 |
| Minimal LLVM `shufflevector` | 29 | 0 |
| 128³ inner-loop B loads | 52 | 4 |
| 128³ B shuffle/insert | 48 | 0 |
| 128³ `vdpbf16ps` | 16 | 16 |
| Hot-loop spills | 0 | 0 |

The four remaining B reads are 64-byte ZMM loads.

## Tests

- `triton` and `triton-opt` build: PASS
- focused `canonicalize.mlir`: 1/1 PASS
- complete `test/TritonCPU`: 15/15 PASS
- minimal reproducer correctness: PASS
- 128³ and 256³ BF16 MatMul correctness: PASS
- `git diff --check`: PASS

## Performance

Four-core (`taskset -c 0-3`) pre-packed AVX512 BF16 MatMul compute-only sanity measurement on latest main, using direct synchronous single-call timing, 10 warmups, 20 calls per round, and 7 alternating baseline/C1 rounds:

| Shape | Before | After | Speedup |
|---|---:|---:|---:|
| 128³ | 117.3155 µs | 55.0265 µs | 2.132x |
| 256³ | 244.7945 µs | 147.7615 µs | 1.657x |

The 256³ observations were noisy (baseline CV 29.2%, patched CV 12.0%), so these are directional sanity results rather than formal performance claims. They exclude packing, allocation, JIT compilation, and reference computation and are not end-to-end GEMM results.

Historical measurements on the original development base `a00d6c44ec55906cf2e66107621265d410b5f6a0` measured 1.408x, 1.577x, and 2.164x at 64³, 128³, and 256³ respectively under the same pre-packed compute-only scope.
