### PR TITLE
[CPU] Remove TRITON_CPU_BACKEND; use TRITON_DEFAULT_BACKEND

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -93,14 +93,14 @@ jobs:
         run: |
           export CC=$(which clang)
           export TRITON_DISABLE_OPENMP=1 # temporary
-          export TRITON_CPU_BACKEND=1
+          export TRITON_DEFAULT_BACKEND=cpu
 
           # Document some versions/flags
           echo "xcode-select:"; xcode-select -p
           echo "CC: ${CC}"
           clang --version
           echo "TRITON_DISABLE_OPENMP=${TRITON_DISABLE_OPENMP}"
-          echo "TRITON_CPU_BACKEND=${TRITON_CPU_BACKEND}"
+          echo "TRITON_DEFAULT_BACKEND=${TRITON_DEFAULT_BACKEND}"
 
           # Skip bfloat16 tests for now
           # We are generating bfcvt for bfloat16 tests when converting to fp32.

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ uv run python python/tutorials/cpu/08-sfc-matmul.py
 ```
 
 The samples use `triton.runtime.driver.set_active_to_cpu()` to switch to CPU
-usage. Alternatively, setting the environment variable `TRITON_CPU_BACKEND=1`
-gives the CPU backend priority over any available GPU backends.
+usage. Alternatively, set `TRITON_DEFAULT_BACKEND=cpu` to select the CPU
+backend explicitly. When no GPU backend is active, Triton selects CPU
+automatically.
 
 **NOTE: It's still work in progress.**
 

--- a/python/test/unit/cpu/test_cpu_subprocess.py
+++ b/python/test/unit/cpu/test_cpu_subprocess.py
@@ -37,7 +37,6 @@ def test_cpu_print(func_type: str, data_type: str, device: str):
         pytest.skip("Printing float16, pointers, and large tensors is not yet supported on CPU.")
 
     env = os.environ.copy()
-    env.pop("TRITON_CPU_BACKEND", None)
     env.pop("TRITON_INTERPRET", None)
     env["TRITON_DEFAULT_BACKEND"] = "cpu"
     proc = subprocess.run(
@@ -56,7 +55,6 @@ def test_cpu_launcher_pointer_refcount(device: str):
         pytest.skip("CPU launcher tests require --device cpu.")
 
     env = os.environ.copy()
-    env.pop("TRITON_CPU_BACKEND", None)
     env.pop("TRITON_INTERPRET", None)
     env["TRITON_DEFAULT_BACKEND"] = "cpu"
     proc = subprocess.run(
@@ -73,7 +71,6 @@ def test_cpu_launcher_pointer_error(device: str):
         pytest.skip("CPU launcher tests require --device cpu.")
 
     env = os.environ.copy()
-    env.pop("TRITON_CPU_BACKEND", None)
     env.pop("TRITON_INTERPRET", None)
     env["TRITON_DEFAULT_BACKEND"] = "cpu"
     proc = subprocess.run(
@@ -91,7 +88,6 @@ def test_cpu_launcher_hook_refcount(device: str):
         pytest.skip("CPU launcher tests require --device cpu.")
 
     env = os.environ.copy()
-    env.pop("TRITON_CPU_BACKEND", None)
     env.pop("TRITON_INTERPRET", None)
     env["TRITON_DEFAULT_BACKEND"] = "cpu"
     proc = subprocess.run(
@@ -108,7 +104,6 @@ def test_cpu_print_from_subfunction(device: str):
         pytest.skip("CPU print tests require --device cpu.")
 
     env = os.environ.copy()
-    env.pop("TRITON_CPU_BACKEND", None)
     env.pop("TRITON_INTERPRET", None)
     env["TRITON_DEFAULT_BACKEND"] = "cpu"
     proc = subprocess.run(

--- a/python/triton/runtime/driver.py
+++ b/python/triton/runtime/driver.py
@@ -15,13 +15,14 @@ def _create_driver() -> DriverBase:
             raise RuntimeError(f"Backend device '{selected}' is not active.")
         return driver()
     else:
-        if os.getenv("TRITON_CPU_BACKEND", "0") == "1":
-            if "cpu" not in backends:
-                raise RuntimeError("TRITON_CPU_BACKEND is set, but CPU backend is unavailable.")
-            return backends["cpu"].driver()
-        active_drivers = [x.driver for x in backends.values() if x.driver.is_active()]
-        if len(active_drivers) >= 2 and backends["cpu"].driver.is_active():
-            active_drivers.remove(backends["cpu"].driver)
+        # Prefer an active GPU driver, falling back to CPU when none are active.
+        active_drivers = [
+            backend.driver for name, backend in backends.items() if name != "cpu" and backend.driver.is_active()
+        ]
+        if not active_drivers:
+            cpu_backend = backends.get("cpu")
+            if cpu_backend is not None and cpu_backend.driver.is_active():
+                active_drivers.append(cpu_backend.driver)
         if len(active_drivers) != 1:
             raise RuntimeError(f"{len(active_drivers)} active drivers ({active_drivers}). There should only be one.")
         return active_drivers[0]()


### PR DESCRIPTION
### Summary 

From the very beginning of the triton-cpu, we have been using `TRITON_CPU_BACKEND=1` to select the CPU backend if triton-cpu runs on a machine with GPU and CPU. But the upstream now has `TRITON_DEFAULT_BACKEND`.

So, let's use `TRITON_DEFAULT_BACKEND=cpu` for explicit CPU selection. Without an explicit selection, prefer an active GPU backend and fall back to CPU when no GPU backend is active.

I understand that `TRITON_DEFAULT_BACKEND=cpu` is not 100% identical to `TRITON_CPU_BACKEND`, but I want to always minimize the divergence from the upstream.

### Backend selection policy

`TRITON_DEFAULT_BACKEND` is now the only environment variable for explicit backend selection. `TRITON_CPU_BACKEND` is removed.

| `TRITON_DEFAULT_BACKEND` | Available backends | Result |
|---|---|---|
| Set to an active backend | Any | Select it explicitly, including CPU |
| Set to an unknown or inactive backend | Any | Raise an error; do not fall back |
| Unset | Exactly one active GPU backend | Select the GPU |
| Unset | No active GPU, active CPU backend | Fall back to CPU |
| Unset | Multiple active GPU backends | Raise an error |
| Unset | No active backend | Raise an error |

An empty `TRITON_DEFAULT_BACKEND` is treated as unset. This matches the policy used by `fbtriton`.

This policy fully preserves upstream Triton’s behavior for upstream-supported configurations. The CPU backend only extends the no-active-GPU case with a CPU fallback, without conflicting with explicit backend selection or existing GPU selection semantics.


### Test Plan
- GPU visible with no override: CudaDriver selected.
- GPU hidden with no override: CPUDriver selected.
- TRITON_DEFAULT_BACKEND=cpu: CPUDriver selected.
- PYTHONPATH=python python -m pytest -s --tb=short --device cpu python/test/unit/cpu/test_cpu_subprocess.py (31 passed, 4 skipped).