### PR TITLE
[CPU] Fix SleefNameGenerator ulp buffer truncation (#3443)

### DIFF
--- a/third_party/cpu/lib/TritonCPUToLLVM/MathToVecLib.cpp
+++ b/third_party/cpu/lib/TritonCPUToLLVM/MathToVecLib.cpp
@@ -240,8 +240,8 @@ public:
     if (ulp == 0) {
       ulpSuffix = "";
     } else {
-      char buf[5]; // 4 char suffix + '\0' added by snprintf
-      snprintf(buf, 5, "_u%02u", ulp);
+      char buf[13]; // "_u" + 10 unsigned digits + '\0'
+      snprintf(buf, sizeof(buf), "_u%02u", ulp);
       ulpSuffix = buf;
     }
   }


### PR DESCRIPTION
Port of https://github.com/facebookexperimental/triton/pull/3443 (fbtriton commit d103cfd161) to triton-cpu.

The 5-byte buffer with snprintf(buf, 5, ...) truncates the _u suffix for large ulp values, since %02u is a minimum width, not a maximum. Size the buffer for the full unsigned range ("_u" + 10 digits + NUL) and pass sizeof(buf).
