### PR TITLE
[CPU] Recover num_cpu_threads in Config for torch dynamo HOP

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -348,11 +348,13 @@ class Config:
     :ivar ir_override: filename of a user-defined IR (*.{ttgir|llir|ptx|amdgcn}).
     """
 
-    def __init__(self, kwargs, num_warps=4, num_stages=3, num_ctas=1, maxnreg=None, pre_hook=None, ir_override=None):
+    def __init__(self, kwargs, num_warps=4, num_stages=3, num_ctas=1, num_cpu_threads=0, maxnreg=None, pre_hook=None,
+                 ir_override=None):
         self.kwargs = kwargs
         self.num_warps = num_warps
         self.num_ctas = num_ctas
         self.num_stages = num_stages
+        self.num_cpu_threads = num_cpu_threads
         self.maxnreg = maxnreg
         self.pre_hook = pre_hook
         self.ir_override = ir_override
@@ -362,6 +364,7 @@ class Config:
         self.num_warps = state.get("num_warps", 4)
         self.num_stages = state.get("num_stages", 3)
         self.num_ctas = state.get("num_ctas", 1)
+        self.num_cpu_threads = state.get("num_cpu_threads", 0)
         self.maxnreg = state.get("maxnreg", None)
         self.pre_hook = state.get("pre_hook", None)
         self.ir_override = state.get("ir_override", None)
@@ -374,6 +377,8 @@ class Config:
                     ("num_warps", self.num_warps),
                     ("num_ctas", self.num_ctas),
                     ("num_stages", self.num_stages),
+                    # Omit when 0: unknown to GPU options and rejected by _pack_args.
+                    ("num_cpu_threads", self.num_cpu_threads or None),
                     ("maxnreg", self.maxnreg),
                     ("ir_override", self.ir_override),
                 ) if v is not None
@@ -387,6 +392,7 @@ class Config:
         res.append(f"num_warps: {self.num_warps}")
         res.append(f"num_ctas: {self.num_ctas}")
         res.append(f"num_stages: {self.num_stages}")
+        res.append(f"num_cpu_threads: {self.num_cpu_threads}")
         res.append(f"maxnreg: {self.maxnreg}")
         return ", ".join(res)
 


### PR DESCRIPTION
Restore the num_cpu_threads Config parameter dropped during over-aggressive CPU isolation in #284, fixing TypeError on CPU launches through torch's dynamo HOP path.

- torch's triton_kernel_wrap passes num_cpu_threads into Config(...) unconditionally (pytorch/pytorch#166255); Config must accept it.
- Caller-side CPU-only gating does not help: the crash is in wrap->Config, not in the caller.
- Eager launches unaffected (kwargs reach CPUOptions via parse_options).
- GPU backends untouched (nothing reads it there).

Validation: py_compile plus functional smoke test (default 0, constructor kwarg, pickle roundtrip, all_kwargs/__str__) - all pass.
