### PR TITLE
[DotToNanokernel] Pass through zero-initialized accumulator for non-AMX targets

### DIFF
--- a/python/tutorials/cpu/08-sfc-matmul.py
+++ b/python/tutorials/cpu/08-sfc-matmul.py
@@ -88,9 +88,10 @@ def block_transpose_pack_kernel(a_in_ptr, a_out_ptr, a_sfc_map_ptr, b_in_ptr, b_
 #    [ ik * (BLOCKS_K // BLOCKING_FACTOR_K), (ik + 1) * (BLOCKS_K // BLOCKING_FACTOR_K) )
 #
 @triton.jit
-def sfc_kernel(a_ptr, b_ptr, c_ptr, sfc_map_ptr, M, N, K, ik, BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr,
-               BLOCK_SIZE_K: tl.constexpr, DTYPE: tl.constexpr, ACC_DTYPE: tl.constexpr,
-               BLOCKING_FACTOR_K: tl.constexpr):
+def sfc_kernel(a_ptr, b_ptr, c_ptr, c_tmp_ptr, sfc_map_ptr, M, N, K, ik,
+            BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
+            DTYPE: tl.constexpr, ACC_DTYPE: tl.constexpr,
+            BLOCKING_FACTOR_K: tl.constexpr, IS_FIRST_K_BLOCK: tl.constexpr, IS_LAST_K_BLOCK: tl.constexpr,):
     VNNI: tl.constexpr = 32 // b_ptr.type.element_ty.primitive_bitwidth
 
     BLOCKS_M = M // BLOCK_SIZE_M
@@ -116,11 +117,12 @@ def sfc_kernel(a_ptr, b_ptr, c_ptr, sfc_map_ptr, M, N, K, ik, BLOCK_SIZE_M: tl.c
                                        strides=(BLOCK_SIZE_M * N, BLOCK_SIZE_N, N, 1),
                                        block_shape=(1, 1, BLOCK_SIZE_M, BLOCK_SIZE_N))
 
-    if ik == 0:
-        c0 = tl.zeros((1, 1, BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=DTYPE)
-        c_desc.store([block_m, block_n, 0, 0], c0)
+    if BLOCKING_FACTOR_K > 1:
+        c_tmp_desc = tl.make_tensor_descriptor(base=c_tmp_ptr, shape=(BLOCKS_M, BLOCKS_N, BLOCK_SIZE_M, BLOCK_SIZE_N),
+                                               strides=(BLOCK_SIZE_M * N, BLOCK_SIZE_M * BLOCK_SIZE_N, BLOCK_SIZE_N, 1),
+                                               block_shape=(1, 1, BLOCK_SIZE_M, BLOCK_SIZE_N))
 
-    c = c_desc.load([block_m, block_n, 0, 0]).reshape((BLOCK_SIZE_M, BLOCK_SIZE_N)).to(ACC_DTYPE)
+    c = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=ACC_DTYPE)
 
     for block_ki in range(block_k, block_k + BLOCKS_K_PER_PROG):
         a = a_desc.load([block_m, block_ki, 0, 0]).reshape((BLOCK_SIZE_M, BLOCK_SIZE_K))
@@ -129,6 +131,15 @@ def sfc_kernel(a_ptr, b_ptr, c_ptr, sfc_map_ptr, M, N, K, ik, BLOCK_SIZE_M: tl.c
         b = tl.extra.cpu.vnni_decode(b)
 
         c = tl.dot(a, b, acc=c, out_dtype=ACC_DTYPE)
+
+    if not IS_FIRST_K_BLOCK:
+        c_tmp = c_tmp_desc.load([block_m, block_n, 0, 0]).reshape((BLOCK_SIZE_M, BLOCK_SIZE_N))
+        c += c_tmp
+
+    if not IS_LAST_K_BLOCK:
+        c = c.reshape((1, 1, BLOCK_SIZE_M, BLOCK_SIZE_N))
+        c_tmp_desc.store([block_m, block_n, 0, 0], c)
+        return
 
     c = c.to(DTYPE).reshape((1, 1, BLOCK_SIZE_M, BLOCK_SIZE_N))
     c_desc.store([block_m, block_n, 0, 0], c)
@@ -140,8 +151,9 @@ def make_sfc_tensor(x, y, dtype=torch.int32, device='cpu'):
     return torch.tensor([c for xy in gilbert for c in xy], dtype=dtype, device=device)
 
 
-def matmul(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor, ap: torch.Tensor, bp: torch.Tensor, M, N, K,
-           blocking_factor_k=1):
+def matmul(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor,
+           ap: torch.Tensor, bp: torch.Tensor, ctmp: torch.Tensor,
+           M, N, K, blocking_factor_k=1):
     assert (M % BLOCK_SIZE_M == 0) and (N % BLOCK_SIZE_N == 0) and (K % BLOCK_SIZE_K == 0), \
            "Masking currently not supported, matrix dimensions must be multiples of block size"
 
@@ -162,11 +174,13 @@ def matmul(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor, ap: torch.Tensor, 
                                                 BLOCK_SIZE_K=BLOCK_SIZE_K, assume_in_bounds=True)
 
     for ik in range(blocking_factor_k):
-        sfc_kernel[((M // BLOCK_SIZE_M) * (N // BLOCK_SIZE_N), )](ap, bp, c, sfc_map_mn, M, N, K, ik,
+        sfc_kernel[((M // BLOCK_SIZE_M) * (N // BLOCK_SIZE_N), )](ap, bp, c, ctmp, sfc_map_mn, M, N, K, ik,
                                                                   BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N,
                                                                   BLOCK_SIZE_K=BLOCK_SIZE_K, DTYPE=tt_dtype,
                                                                   ACC_DTYPE=tt_acc_dtype,
                                                                   BLOCKING_FACTOR_K=blocking_factor_k,
+                                                                  IS_FIRST_K_BLOCK=(ik == 0),
+                                                                  IS_LAST_K_BLOCK=(ik == blocking_factor_k - 1),
                                                                   assume_in_bounds=True)
     return c
 
@@ -179,9 +193,9 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--target', choices=['amx', 'avx512', 'avx_ne_convert', 'avx_vnni_int8'], default='amx')
 parser.add_argument('--dtype', choices=['bfloat16', 'int8'], default='bfloat16')
 parser.add_argument('--bench', action='store_true')
-parser.add_argument('-M', type=int, nargs='+', default=[512])
+parser.add_argument('-M', type=int, nargs='+', default=[1024])
 parser.add_argument('-N', type=int, nargs='+', default=[1024])
-parser.add_argument('-K', type=int, nargs='+', default=[256])
+parser.add_argument('-K', type=int, nargs='+', default=[1024])
 
 args = parser.parse_args()
 
@@ -237,11 +251,11 @@ print(f"Running unit test with "
       f"M={M}, N={N}, K={K} dtype={dtype_str} "
       f"BLOCK_SIZE_M={BLOCK_SIZE_M}, BLOCK_SIZE_N={BLOCK_SIZE_N}, BLOCK_SIZE_K={BLOCK_SIZE_K}...")
 
-torch_output = torch.empty((M, N), device='cpu', dtype=dtype)
-torch.matmul(a, b, out=torch_output)
+torch_output = torch.matmul(a.to(acc_dtype), b.to(acc_dtype)).to(dtype)
 
 triton_output = torch.empty((M, N), device='cpu', dtype=dtype)
-matmul(a, b, triton_output, torch.empty_like(a), torch.empty_like(b), M=M, N=N, K=K, blocking_factor_k=1)
+matmul(a, b, triton_output, torch.empty_like(a), torch.empty_like(b), torch.empty((M, N), device='cpu', dtype=acc_dtype),
+       M=M, N=N, K=K, blocking_factor_k=4)
 
 if torch.allclose(triton_output, torch_output, atol=1e-5, rtol=1e-2):
     print("✅ TritonCPU pre-packed SFC and TorchCPU match")
@@ -341,12 +355,14 @@ def benchmark(M, N, K, provider):
 
         ms, min_ms, max_ms = triton.testing.do_bench(doit, quantiles=quantiles, rep=10000)  # run for 10 seconds
     elif backend == 'triton-cpu':
-        ap = torch.empty((M, K), device=a.device, dtype=a.dtype)
-        bp = torch.empty((K, N), device=b.device, dtype=b.dtype)
+        ap = torch.empty((M, K), device=a.device, dtype=dtype)
+        bp = torch.empty((K, N), device=b.device, dtype=dtype)
+        ctmp = torch.empty((M, N), device=c.device, dtype=acc_dtype)
 
         def doit():
             for i in range(n_layers):
-                matmul(a[i % n_layers], b[i % n_layers], c[i % n_layers], ap, bp, M, N, K, blocking_factor_k=sfc_bfk)
+                matmul(a[i % n_layers], b[i % n_layers], c[i % n_layers],
+                       ap, bp, ctmp, M, N, K, blocking_factor_k=sfc_bfk)
 
         ms, min_ms, max_ms = triton.testing.do_bench(
             doit, quantiles=quantiles, measure_time_with_hooks=False,  # also capture potential Python loop overhead

--- a/python/tutorials/cpu/08-sfc-matmul.py
+++ b/python/tutorials/cpu/08-sfc-matmul.py
@@ -88,10 +88,25 @@ def block_transpose_pack_kernel(a_in_ptr, a_out_ptr, a_sfc_map_ptr, b_in_ptr, b_
 #    [ ik * (BLOCKS_K // BLOCKING_FACTOR_K), (ik + 1) * (BLOCKS_K // BLOCKING_FACTOR_K) )
 #
 @triton.jit
-def sfc_kernel(a_ptr, b_ptr, c_ptr, c_tmp_ptr, sfc_map_ptr, M, N, K, ik,
-            BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
-            DTYPE: tl.constexpr, ACC_DTYPE: tl.constexpr,
-            BLOCKING_FACTOR_K: tl.constexpr, IS_FIRST_K_BLOCK: tl.constexpr, IS_LAST_K_BLOCK: tl.constexpr,):
+def sfc_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    c_tmp_ptr,
+    sfc_map_ptr,
+    M,
+    N,
+    K,
+    ik,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    DTYPE: tl.constexpr,
+    ACC_DTYPE: tl.constexpr,
+    BLOCKING_FACTOR_K: tl.constexpr,
+    IS_FIRST_K_BLOCK: tl.constexpr,
+    IS_LAST_K_BLOCK: tl.constexpr,
+):
     VNNI: tl.constexpr = 32 // b_ptr.type.element_ty.primitive_bitwidth
 
     BLOCKS_M = M // BLOCK_SIZE_M
@@ -151,9 +166,8 @@ def make_sfc_tensor(x, y, dtype=torch.int32, device='cpu'):
     return torch.tensor([c for xy in gilbert for c in xy], dtype=dtype, device=device)
 
 
-def matmul(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor,
-           ap: torch.Tensor, bp: torch.Tensor, ctmp: torch.Tensor,
-           M, N, K, blocking_factor_k=1):
+def matmul(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor, ap: torch.Tensor, bp: torch.Tensor, ctmp: torch.Tensor, M,
+           N, K, blocking_factor_k=1):
     assert (M % BLOCK_SIZE_M == 0) and (N % BLOCK_SIZE_N == 0) and (K % BLOCK_SIZE_K == 0), \
            "Masking currently not supported, matrix dimensions must be multiples of block size"
 
@@ -174,14 +188,10 @@ def matmul(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor,
                                                 BLOCK_SIZE_K=BLOCK_SIZE_K, assume_in_bounds=True)
 
     for ik in range(blocking_factor_k):
-        sfc_kernel[((M // BLOCK_SIZE_M) * (N // BLOCK_SIZE_N), )](ap, bp, c, ctmp, sfc_map_mn, M, N, K, ik,
-                                                                  BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N,
-                                                                  BLOCK_SIZE_K=BLOCK_SIZE_K, DTYPE=tt_dtype,
-                                                                  ACC_DTYPE=tt_acc_dtype,
-                                                                  BLOCKING_FACTOR_K=blocking_factor_k,
-                                                                  IS_FIRST_K_BLOCK=(ik == 0),
-                                                                  IS_LAST_K_BLOCK=(ik == blocking_factor_k - 1),
-                                                                  assume_in_bounds=True)
+        sfc_kernel[((M // BLOCK_SIZE_M) * (N // BLOCK_SIZE_N), )](
+            ap, bp, c, ctmp, sfc_map_mn, M, N, K, ik, BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N,
+            BLOCK_SIZE_K=BLOCK_SIZE_K, DTYPE=tt_dtype, ACC_DTYPE=tt_acc_dtype, BLOCKING_FACTOR_K=blocking_factor_k,
+            IS_FIRST_K_BLOCK=(ik == 0), IS_LAST_K_BLOCK=(ik == blocking_factor_k - 1), assume_in_bounds=True)
     return c
 
 
@@ -254,8 +264,8 @@ print(f"Running unit test with "
 torch_output = torch.matmul(a.to(acc_dtype), b.to(acc_dtype)).to(dtype)
 
 triton_output = torch.empty((M, N), device='cpu', dtype=dtype)
-matmul(a, b, triton_output, torch.empty_like(a), torch.empty_like(b), torch.empty((M, N), device='cpu', dtype=acc_dtype),
-       M=M, N=N, K=K, blocking_factor_k=4)
+matmul(a, b, triton_output, torch.empty_like(a), torch.empty_like(b), torch.empty(
+    (M, N), device='cpu', dtype=acc_dtype), M=M, N=N, K=K, blocking_factor_k=4)
 
 if torch.allclose(triton_output, torch_output, atol=1e-5, rtol=1e-2):
     print("✅ TritonCPU pre-packed SFC and TorchCPU match")
@@ -361,8 +371,8 @@ def benchmark(M, N, K, provider):
 
         def doit():
             for i in range(n_layers):
-                matmul(a[i % n_layers], b[i % n_layers], c[i % n_layers],
-                       ap, bp, ctmp, M, N, K, blocking_factor_k=sfc_bfk)
+                matmul(a[i % n_layers], b[i % n_layers], c[i % n_layers], ap, bp, ctmp, M, N, K,
+                       blocking_factor_k=sfc_bfk)
 
         ms, min_ms, max_ms = triton.testing.do_bench(
             doit, quantiles=quantiles, measure_time_with_hooks=False,  # also capture potential Python loop overhead

--- a/python/tutorials/cpu/08-sfc-matmul.py
+++ b/python/tutorials/cpu/08-sfc-matmul.py
@@ -84,8 +84,9 @@ def block_transpose_pack_kernel(a_in_ptr, a_out_ptr, a_sfc_map_ptr, b_in_ptr, b_
 #
 # Each program computes a single output tile with the 2D coordinates derived from the precomputed SFC mapping.
 # If `BLOCKING_FACTOR_K == 1`, then program handles all `BLOCKS_K = K // BLOCK_SIZE_K` blocks along the common dimension,
-# otherwise the program performs a partial accumulation of the K blocks in the half-open interval:
-#    [ ik * (BLOCKS_K // BLOCKING_FACTOR_K), (ik + 1) * (BLOCKS_K // BLOCKING_FACTOR_K) )
+# otherwise the program performs a partial accumulation of `BLOCKS_K_PER_PROG = ⌈BLOCKS_K / BLOCKING_FACTOR_K⌉` blocks,
+# starting at `ik * BLOCKS_K_PER_PROG` and ending at `min((ik + 1) * BLOCKS_K_PER_PROG, BLOCKS_K)`. The partial
+# accumulation is stored in `c_tmp_ptr` and will be loaded and accumulated in the next iteration of the outer loop.
 #
 @triton.jit
 def sfc_kernel(

--- a/python/tutorials/cpu/08-sfc-matmul.py
+++ b/python/tutorials/cpu/08-sfc-matmul.py
@@ -112,7 +112,7 @@ def sfc_kernel(
     BLOCKS_M = M // BLOCK_SIZE_M
     BLOCKS_N = N // BLOCK_SIZE_N
     BLOCKS_K = K // BLOCK_SIZE_K
-    BLOCKS_K_PER_PROG = BLOCKS_K // BLOCKING_FACTOR_K
+    BLOCKS_K_PER_PROG = tl.cdiv(BLOCKS_K, BLOCKING_FACTOR_K)
 
     pid = tl.program_id(axis=0)
     block_m = tl.load(sfc_map_ptr + 2 * pid)
@@ -139,7 +139,7 @@ def sfc_kernel(
 
     c = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=ACC_DTYPE)
 
-    for block_ki in range(block_k, block_k + BLOCKS_K_PER_PROG):
+    for block_ki in range(block_k, min(block_k + BLOCKS_K_PER_PROG, BLOCKS_K)):
         a = a_desc.load([block_m, block_ki, 0, 0]).reshape((BLOCK_SIZE_M, BLOCK_SIZE_K))
         b = b_desc.load([block_n, block_ki, 0, 0]).reshape((BLOCK_SIZE_K // VNNI, BLOCK_SIZE_N * VNNI))
 
@@ -265,12 +265,32 @@ torch_output = torch.matmul(a.to(acc_dtype), b.to(acc_dtype)).to(dtype)
 
 triton_output = torch.empty((M, N), device='cpu', dtype=dtype)
 matmul(a, b, triton_output, torch.empty_like(a), torch.empty_like(b), torch.empty(
-    (M, N), device='cpu', dtype=acc_dtype), M=M, N=N, K=K, blocking_factor_k=4)
+    (M, N), device='cpu', dtype=acc_dtype), M=M, N=N, K=K, blocking_factor_k=1)
 
 if torch.allclose(triton_output, torch_output, atol=1e-5, rtol=1e-2):
     print("✅ TritonCPU pre-packed SFC and TorchCPU match")
 else:
     print("⚠️ TritonCPU pre-packed SFC and TorchCPU differ, the maximum difference is "
+          f'{torch.max(torch.abs(triton_output - torch_output))}')
+
+triton_output = torch.empty((M, N), device='cpu', dtype=dtype)
+matmul(a, b, triton_output, torch.empty_like(a), torch.empty_like(b), torch.empty(
+    (M, N), device='cpu', dtype=acc_dtype), M=M, N=N, K=K, blocking_factor_k=4)
+
+if torch.allclose(triton_output, torch_output, atol=1e-5, rtol=1e-2):
+    print("✅ TritonCPU pre-packed SFC (kbf=4) and TorchCPU match")
+else:
+    print("⚠️ TritonCPU pre-packed SFC (kbf=4) and TorchCPU differ, the maximum difference is "
+          f'{torch.max(torch.abs(triton_output - torch_output))}')
+
+triton_output = torch.empty((M, N), device='cpu', dtype=dtype)
+matmul(a, b, triton_output, torch.empty_like(a), torch.empty_like(b), torch.empty(
+    (M, N), device='cpu', dtype=acc_dtype), M=M, N=N, K=K, blocking_factor_k=7)
+
+if torch.allclose(triton_output, torch_output, atol=1e-5, rtol=1e-2):
+    print("✅ TritonCPU pre-packed SFC (kbf=7) and TorchCPU match")
+else:
+    print("⚠️ TritonCPU pre-packed SFC (kbf=7) and TorchCPU differ, the maximum difference is "
           f'{torch.max(torch.abs(triton_output - torch_output))}')
 
 # %%

--- a/test/TritonCPU/dot-to-nanokernel-looped.mlir
+++ b/test/TritonCPU/dot-to-nanokernel-looped.mlir
@@ -1,15 +1,12 @@
 // RUN: triton-opt %s -split-input-file -triton-cpu-convert-dot-to-nanokernel=cpu-features=avx512bf16 -cse  | FileCheck %s --check-prefixes=AVX512,ALL
 // RUN: triton-opt %s -split-input-file -triton-cpu-convert-dot-to-nanokernel=cpu-features=avxneconvert -cse  | FileCheck %s --check-prefixes=AVX_NE_CONVERT,ALL
 
-// Lowering to AVX512 target. Accumulator is zero-initialized, hence we currently need to insert a temporary buffer.
-
 // ALL-LABEL: gemm_looped_avx512
-// AVX512:       %[[ZERO:.+]] = arith.constant dense<0.000000e+00> : vector<32x64xf32>
-// AVX512:       %[[BUFFER:.+]] = memref.alloca() : memref<32x64xf32>
-// AVX512:       vector.transfer_write %[[ZERO]], %[[BUFFER]][%c0, %c0] {in_bounds = [true, true]} : vector<32x64xf32>, memref<32x64xf32>
+// AVX512:       %[[ZERO:.+]] = arith.constant dense<0.000000e+00> : vector<16xf32>
 // AVX512:       scf.for %{{.+}} = %c0 to %c32 step %c4
 // AVX512:         scf.for %{{.+}} = %c0 to %c64 step %c64
 // AVX512:           %{{.+}}:16 = scf.for %{{.+}} = %{{.+}} to %{{.+}} step %c1
+// AVX512-SAME:          iter_args(%{{.+}} = %[[ZERO]],
 // AVX512-COUNT-16:    x86.avx512.dot
 // AVX512:             scf.yield
 // AVX512-COUNT-16:  vector.transfer_write
@@ -79,8 +76,6 @@ tt.func public @gemm_looped_avx512(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %
 }
 
 // -----
-
-// Lowering to AVX_NE_CONVERT target. The accumulator reads/writes can be used directly by the nanokernel patterns.
 
 // ALL-LABEL: gemm_looped_avx_ne_convert
 

--- a/test/TritonCPU/dot-to-nanokernel.mlir
+++ b/test/TritonCPU/dot-to-nanokernel.mlir
@@ -1018,6 +1018,62 @@ tt.func public @gemm_amx_bf16_const_init(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf
 
 // -----
 
+// Accumulator is initialized from a constant. This is directly supported by the non-AMX targets.
+
+// ALL-LABEL: @gemm_avx512_const_init
+
+// AVX512:      %[[ZERO:.+]] = arith.constant dense<0.000000e+00> : vector<16xf32>
+// AVX512-NOT:  vector.shuffle
+
+// Main loop (using 16 accumulators (1x16xf32))
+// AVX512:           %{{.+}}:16 = scf.for %arg{{.+}} = %c0 to %{{.+}} step %c2
+// AVX512-SAME:          iter_args(%{{.+}} = %[[ZERO]],
+
+// AVX512-COUNT-4:     vector.shuffle
+// AVX512-COUNT-16:    x86.avx512.dot
+
+// AVX512:             scf.yield
+
+// Shuffle back before storing to memory
+// AVX512-COUNT-16: vector.shuffle
+
+tt.func public @gemm_avx512_const_init(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %arg2: !tt.ptr<f32>, %arg3: i32, %arg4: i32, %arg5: i32) {
+  %cst = arith.constant 0.000000e+00 : bf16
+  %cst_0 = arith.constant dense<0.000000e+00> : vector<4x64xf32>
+  %c2_i32 = arith.constant 2 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i64 = arith.constant 1 : i64
+  %c64_i32 = arith.constant 64 : i32
+  %c4_i32 = arith.constant 4 : i32
+  %0 = tt.get_program_id x : i32
+  %1 = arith.muli %0, %c4_i32 : i32
+  %2 = tt.get_program_id y : i32
+  %3 = arith.muli %2, %c64_i32 : i32
+  %4 = arith.extsi %arg5 : i32 to i64
+  %5 = tt.make_tensor_descriptor %arg0, [%arg3, %arg5], [%4, %c1_i64] : <bf16>, <4x2xbf16>
+  %6 = arith.extsi %arg4 : i32 to i64
+  %7 = tt.make_tensor_descriptor %arg1, [%arg5, %arg4], [%6, %c1_i64] : <bf16>, <2x64xbf16>
+  %8 = tt.make_tensor_descriptor %arg2, [%arg3, %arg4], [%6, %c1_i64] : <f32>, <4x64xf32>
+  %9 = scf.for %arg6 = %c0_i32 to %arg5 step %c2_i32 iter_args(%arg7 = %cst_0) -> (vector<4x64xf32>)  : i32 {
+    %13 = triton_cpu.extract_memref %5 : <4x2xbf16> -> memref<?x?xbf16, strided<[?, 1]>>
+    %14 = arith.index_cast %1 : i32 to index
+    %15 = arith.index_cast %arg6 : i32 to index
+    %16 = vector.transfer_read %13[%14, %15], %cst {in_bounds = [true, true]} : memref<?x?xbf16, strided<[?, 1]>>, vector<4x2xbf16>
+    %17 = triton_cpu.extract_memref %7 : <2x64xbf16> -> memref<?x?xbf16, strided<[?, 1]>>
+    %18 = arith.index_cast %3 : i32 to index
+    %19 = vector.transfer_read %17[%15, %18], %cst {in_bounds = [true, true]} : memref<?x?xbf16, strided<[?, 1]>>, vector<2x64xbf16>
+    %20 = triton_cpu.dot %16, %19, %arg7, inputPrecision = tf32 : vector<4x2xbf16> * vector<2x64xbf16> -> vector<4x64xf32>
+    scf.yield %20 : vector<4x64xf32>
+  }
+  %10 = triton_cpu.extract_memref %8 : <4x64xf32> -> memref<?x?xf32, strided<[?, 1]>>
+  %11 = arith.index_cast %1 : i32 to index
+  %12 = arith.index_cast %3 : i32 to index
+  vector.transfer_write %9, %10[%11, %12] {in_bounds = [true, true]} : vector<4x64xf32>, memref<?x?xf32, strided<[?, 1]>>
+  tt.return
+}
+
+// -----
+
 // Post op
 
 // ALL-LABEL: @gemm_amx_bf16_post_op

--- a/test/TritonCPU/dot-to-nanokernel.mlir
+++ b/test/TritonCPU/dot-to-nanokernel.mlir
@@ -1303,3 +1303,49 @@ tt.func public @gemm_amx_bf16_blocked(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>
   vector.transfer_write %28, %20[%21, %22, %c0, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x32x32xbf16>, memref<?x?x32x32xbf16, strided<[?, 32, ?, 1]>>
   tt.return
 }
+
+// -----
+
+// Nanokernel application with a conditional write.
+
+// ALL-LABEL: @gemm_avx_vnni_int8_int8_cond
+
+// AVX_VNNI_INT8-COUNT-8:  x86.avx.dot.i8
+// AVX_VNNI_INT8:          scf.if
+// AVX_VNNI_INT8-COUNT-8:  vector.transfer_write
+
+tt.func public @gemm_avx_vnni_int8_int8_cond(%arg0: !tt.ptr<i8>, %arg1: !tt.ptr<i8>, %arg2: !tt.ptr<i32>, %arg3: i32, %arg4: i32, %arg5: i32) {
+  %c0_i8 = arith.constant 0 : i8
+  %c4_i32 = arith.constant 4 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i64 = arith.constant 1 : i64
+  %c32_i32 = arith.constant 32 : i32
+  %c2_i32 = arith.constant 2 : i32
+  %zero = arith.constant dense<0> : vector<2x32xi32>
+  %0 = tt.get_program_id x : i32
+  %1 = arith.muli %0, %c2_i32 : i32
+  %2 = tt.get_program_id y : i32
+  %3 = arith.muli %2, %c32_i32 : i32
+  %4 = arith.extsi %arg5 : i32 to i64
+  %5 = tt.make_tensor_descriptor %arg0, [%arg3, %arg5], [%4, %c1_i64] : <i8>, <2x4xsi8>
+  %6 = arith.extsi %arg4 : i32 to i64
+  %7 = tt.make_tensor_descriptor %arg1, [%arg5, %arg4], [%6, %c1_i64] : <i8>, <4x32xsi8>
+  %8 = tt.make_tensor_descriptor %arg2, [%arg3, %arg4], [%6, %c1_i64] : <i32>, <2x32xsi32>
+  %10 = arith.index_cast %1 : i32 to index
+  %11 = arith.index_cast %3 : i32 to index
+  %13 = scf.for %arg6 = %c0_i32 to %arg5 step %c4_i32 iter_args(%arg7 = %zero) -> (vector<2x32xi32>)  : i32 {
+    %14 = triton_cpu.extract_memref %5 : <2x4xsi8> -> memref<?x?xi8, strided<[?, 1]>>
+    %15 = arith.index_cast %arg6 : i32 to index
+    %16 = vector.transfer_read %14[%10, %15], %c0_i8 {in_bounds = [true, true]} : memref<?x?xi8, strided<[?, 1]>>, vector<2x4xi8>
+    %17 = triton_cpu.extract_memref %7 : <4x32xsi8> -> memref<?x?xi8, strided<[?, 1]>>
+    %18 = vector.transfer_read %17[%15, %11], %c0_i8 {in_bounds = [true, true]} : memref<?x?xi8, strided<[?, 1]>>, vector<4x32xi8>
+    %19 = triton_cpu.dot %16, %18, %arg7, inputPrecision = tf32 : vector<2x4xi8> * vector<4x32xi8> -> vector<2x32xi32>
+    scf.yield %19 : vector<2x32xi32>
+  }
+  %cmp = arith.cmpi eq, %arg5, %c0_i32 : i32
+  scf.if %cmp {
+    %20 = triton_cpu.extract_memref %8 : <2x32xsi32> -> memref<?x?xi32, strided<[?, 1]>>
+    vector.transfer_write %13, %20[%10, %11] {in_bounds = [true, true]} : vector<2x32xi32>, memref<?x?xi32, strided<[?, 1]>>
+  }
+  tt.return
+}

--- a/test/TritonCPU/dot-to-nanokernel.mlir
+++ b/test/TritonCPU/dot-to-nanokernel.mlir
@@ -1074,6 +1074,85 @@ tt.func public @gemm_avx512_const_init(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16
 
 // -----
 
+// Two accumulation loops share the same constant for accumulator initialization.
+
+// ALL-LABEL: @gemm_avx512_const_init_shared
+
+// AVX512:      %[[ZERO:.+]] = arith.constant dense<0.000000e+00> : vector<16xf32>
+// AVX512-NOT:  vector.shuffle
+
+// First loop (using 16 accumulators (1x16xf32))
+// AVX512:           %{{.+}}:16 = scf.for %arg{{.+}} = %c0 to %{{.+}} step %c2
+// AVX512-SAME:          iter_args(%{{.+}} = %[[ZERO]],
+
+// AVX512-COUNT-4:     vector.shuffle
+// AVX512-COUNT-16:    x86.avx512.dot
+
+// AVX512:             scf.yield
+
+// Shuffle back before storing to memory
+// AVX512-COUNT-16: vector.shuffle
+
+// Second loop (using 16 accumulators (1x16xf32))
+// AVX512:           %{{.+}}:16 = scf.for %arg{{.+}} = %c0 to %{{.+}} step %c2
+// AVX512-SAME:          iter_args(%{{.+}} = %[[ZERO]],
+
+// AVX512-COUNT-4:     vector.shuffle
+// AVX512-COUNT-16:    x86.avx512.dot
+
+// AVX512:             scf.yield
+
+// Shuffle back before storing to memory
+// AVX512-COUNT-16: vector.shuffle
+
+tt.func public @gemm_avx512_const_init_shared(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %arg2: !tt.ptr<f32>, %arg3: i32, %arg4: i32, %arg5: i32) {
+  %cst = arith.constant 0.000000e+00 : bf16
+  %cst_0 = arith.constant dense<0.000000e+00> : vector<4x64xf32>
+  %c2_i32 = arith.constant 2 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i64 = arith.constant 1 : i64
+  %c64_i32 = arith.constant 64 : i32
+  %c8_i32 = arith.constant 8 : i32
+  %c4_i32 = arith.constant 4 : i32
+  %0 = tt.get_program_id x : i32
+  %1 = arith.muli %0, %c8_i32 : i32
+  %2 = arith.addi %1, %c4_i32 : i32
+  %3 = tt.get_program_id y : i32
+  %4 = arith.muli %3, %c64_i32 : i32
+  %5 = arith.extsi %arg5 : i32 to i64
+  %6 = tt.make_tensor_descriptor %arg0, [%arg3, %arg5], [%5, %c1_i64] : <bf16>, <4x2xbf16>
+  %7 = arith.extsi %arg4 : i32 to i64
+  %8 = tt.make_tensor_descriptor %arg1, [%arg5, %arg4], [%7, %c1_i64] : <bf16>, <2x64xbf16>
+  %9 = tt.make_tensor_descriptor %arg2, [%arg3, %arg4], [%7, %c1_i64] : <f32>, <4x64xf32>
+  %10 = triton_cpu.extract_memref %9 : <4x64xf32> -> memref<?x?xf32, strided<[?, 1]>>
+  %11 = arith.index_cast %1 : i32 to index
+  %12 = arith.index_cast %2 : i32 to index
+  %13 = arith.index_cast %4 : i32 to index
+  %14 = scf.for %arg6 = %c0_i32 to %arg5 step %c2_i32 iter_args(%arg7 = %cst_0) -> (vector<4x64xf32>)  : i32 {
+    %17 = triton_cpu.extract_memref %6 : <4x2xbf16> -> memref<?x?xbf16, strided<[?, 1]>>
+    %18 = arith.index_cast %arg6 : i32 to index
+    %19 = vector.transfer_read %17[%11, %18], %cst {in_bounds = [true, true]} : memref<?x?xbf16, strided<[?, 1]>>, vector<4x2xbf16>
+    %20 = triton_cpu.extract_memref %8 : <2x64xbf16> -> memref<?x?xbf16, strided<[?, 1]>>
+    %21 = vector.transfer_read %20[%18, %13], %cst {in_bounds = [true, true]} : memref<?x?xbf16, strided<[?, 1]>>, vector<2x64xbf16>
+    %22 = triton_cpu.dot %19, %21, %arg7, inputPrecision = tf32 : vector<4x2xbf16> * vector<2x64xbf16> -> vector<4x64xf32>
+    scf.yield %22 : vector<4x64xf32>
+  }
+  vector.transfer_write %14, %10[%11, %13] {in_bounds = [true, true]} : vector<4x64xf32>, memref<?x?xf32, strided<[?, 1]>>
+  %15 = scf.for %arg8 = %c0_i32 to %arg5 step %c2_i32 iter_args(%arg9 = %cst_0) -> (vector<4x64xf32>)  : i32 {
+    %23 = triton_cpu.extract_memref %6 : <4x2xbf16> -> memref<?x?xbf16, strided<[?, 1]>>
+    %24 = arith.index_cast %arg8 : i32 to index
+    %25 = vector.transfer_read %23[%12, %24], %cst {in_bounds = [true, true]} : memref<?x?xbf16, strided<[?, 1]>>, vector<4x2xbf16>
+    %26 = triton_cpu.extract_memref %8 : <2x64xbf16> -> memref<?x?xbf16, strided<[?, 1]>>
+    %27 = vector.transfer_read %26[%24, %13], %cst {in_bounds = [true, true]} : memref<?x?xbf16, strided<[?, 1]>>, vector<2x64xbf16>
+    %28 = triton_cpu.dot %25, %27, %arg9, inputPrecision = tf32 : vector<4x2xbf16> * vector<2x64xbf16> -> vector<4x64xf32>
+    scf.yield %28 : vector<4x64xf32>
+  }
+  vector.transfer_write %15, %10[%12, %13] {in_bounds = [true, true]} : vector<4x64xf32>, memref<?x?xf32, strided<[?, 1]>>
+  tt.return
+}
+
+// -----
+
 // Post op
 
 // ALL-LABEL: @gemm_amx_bf16_post_op

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
@@ -98,11 +98,14 @@ struct DotOpCandidate {
   BlockArgument accIterArg;
   scf::ForOp splicedAccLoop;
 
-  // Vector transfer ops for inputs/output.
+  // Vector transfer ops for inputs/output...
   vector::TransferReadOp lhsRead;
   vector::TransferReadOp rhsRead;
   vector::TransferReadOp accRead;
   vector::TransferWriteOp accWrite;
+
+  // ... or a zero-initialization constant for the accumulator.
+  arith::ConstantOp accConstInit;
 
   // Temporary buffer for accumulator.
   memref::AllocaOp accBuffer;
@@ -300,12 +303,17 @@ bool isNanokernelCandidate(triton::cpu::DotOp op, DotOpCandidate &candidate,
     return false;
   }
 
+  Value accInitValue = candidate.isAccumulationLoop
+                           ? accLoop.getTiedLoopInit(accIterArg)->get()
+                           : op.getC();
   vector::TransferReadOp accRead =
-      candidate.isAccumulationLoop
-          ? accLoop.getTiedLoopInit(accIterArg)
-                ->get()
-                .getDefiningOp<vector::TransferReadOp>()
-          : op.getC().getDefiningOp<vector::TransferReadOp>();
+      accInitValue.getDefiningOp<vector::TransferReadOp>();
+  arith::ConstantOp accConstInit;
+  if (!accRead && isZeroConst(accInitValue) &&
+      (mask & ~(AMX_BF16 | AMX_INT8 | AMX_FP8))) {
+    // AMX lowering doesn't support direct zero-initialization yet.
+    accConstInit = accInitValue.getDefiningOp<arith::ConstantOp>();
+  }
 
   vector::TransferWriteOp accWrite;
   OpResult accRes = candidate.isAccumulationLoop
@@ -413,6 +421,7 @@ bool isNanokernelCandidate(triton::cpu::DotOp op, DotOpCandidate &candidate,
   candidate.lhsRead = lhsRead;
   candidate.rhsRead = rhsRead;
   candidate.accRead = accRead;
+  candidate.accConstInit = accConstInit;
   candidate.accWrite = accWrite;
 
   return true;
@@ -437,7 +446,7 @@ void fuseAccWriteShapeCast(DotOpCandidate &candidate,
 }
 
 void makeAccBuffer(DotOpCandidate &candidate, PatternRewriter &rewriter) {
-  if (candidate.accRead && candidate.accWrite)
+  if ((candidate.accRead || candidate.accConstInit) && candidate.accWrite)
     return; // Nothing to do.
 
   auto accTy = cast<VectorType>(candidate.dot.getC().getType());
@@ -467,11 +476,13 @@ void makeAccBuffer(DotOpCandidate &candidate, PatternRewriter &rewriter) {
   Value padding = arith::ConstantOp::create(
       rewriter, loc, rewriter.getZeroAttr(accTy.getElementType()));
 
-  candidate.accInit = vector::TransferWriteOp::create(
-      rewriter, loc, operand->get(), candidate.accBuffer, zeroIndices);
-  candidate.accRead = vector::TransferReadOp::create(
-      rewriter, loc, accTy, candidate.accBuffer, zeroIndices, padding);
-  operand->set(candidate.accRead);
+  if (!candidate.accConstInit) {
+    candidate.accInit = vector::TransferWriteOp::create(
+        rewriter, loc, operand->get(), candidate.accBuffer, zeroIndices);
+    candidate.accRead = vector::TransferReadOp::create(
+        rewriter, loc, accTy, candidate.accBuffer, zeroIndices, padding);
+    operand->set(candidate.accRead);
+  }
 
   // After dot or loop...
   rewriter.setInsertionPointAfter(candidate.accLoop ? candidate.accLoop
@@ -594,7 +605,8 @@ void moveIndicesToSubview(DotOpCandidate &candidate,
                           PatternRewriter &rewriter) {
   moveIndicesToSubview(candidate.lhsRead, rewriter);
   moveIndicesToSubview(candidate.rhsRead, rewriter);
-  moveIndicesToSubview(candidate.accRead, rewriter);
+  if (candidate.accRead)
+    moveIndicesToSubview(candidate.accRead, rewriter);
   moveIndicesToSubview(candidate.accWrite, rewriter);
 }
 
@@ -660,14 +672,19 @@ void insertLoops(DotOpCandidate &candidate, PatternRewriter &rewriter) {
   } else
     llvm_unreachable("Unexpected target ISA for looping the nanokernel");
 
-  Type accElemTy = candidate.accRead.getType().getElementType();
+  Value accInitVal = candidate.accRead
+                         ? static_cast<Value>(candidate.accRead)
+                         : static_cast<Value>(candidate.accConstInit);
+  Type accElemTy = cast<VectorType>(accInitVal.getType()).getElementType();
   Type inpElemTy = candidate.lhsRead.getType().getElementType();
 
   VectorType accRegTileTy = VectorType::get({regTileM, regTileN}, accElemTy);
   VectorType lhsRegTileTy = VectorType::get({regTileM, 1, vnni}, inpElemTy);
   VectorType rhsRegTileTy = VectorType::get({1, regTileN, vnni}, inpElemTy);
 
-  rewriter.setInsertionPoint(candidate.accLoop);
+  // Construct after the loop, to ensure that all tensor descriptors and their
+  // extracted memrefs are defined.
+  rewriter.setInsertionPoint(candidate.accWrite);
   auto loc = candidate.accLoop.getLoc();
 
   // Set up loop bounds.
@@ -749,44 +766,49 @@ void insertLoops(DotOpCandidate &candidate, PatternRewriter &rewriter) {
             [&](OpBuilder &b, Location loc, Value ivN, ValueRange iterArgs) {
               // We know that accRead/accWrite operate on a 2D vector shaped as
               // the block sizes, hence we can modify the last two indices to
-              // select the smaller register tiles.
-              SmallVector<Value> indices{candidate.accRead.getIndices()};
+              // select the smaller register tiles. The candidate selection
+              // enforces the same indices for accRead (if present) and
+              // accWrite, so we can use the latter one's.
+              SmallVector<Value> indices{candidate.accWrite.getIndices()};
               Value &idxM = indices[indices.size() - 2];
               Value &idxN = indices[indices.size() - 1];
               idxM = arith::AddIOp::create(b, loc, idxM, ivM);
               idxN = arith::AddIOp::create(b, loc, idxN, ivN);
 
-              auto accRead = vector::TransferReadOp::create(
-                  b, candidate.accRead.getLoc(), accRegTileTy,
-                  candidate.accRead.getBase(), indices,
-                  arith::ConstantOp::create(b, loc, b.getZeroAttr(accElemTy)),
-                  candidate.accRead.getInBoundsValues());
+              if (candidate.accRead) {
+                candidate.accRead = vector::TransferReadOp::create(
+                    b, candidate.accRead.getLoc(), accRegTileTy,
+                    candidate.accRead.getBase(), indices,
+                    arith::ConstantOp::create(b, loc, b.getZeroAttr(accElemTy)),
+                    candidate.accRead.getInBoundsValues());
+                accInitVal = candidate.accRead;
+              } else {
+                candidate.accConstInit = arith::ConstantOp::create(
+                    b, loc, b.getZeroAttr(accRegTileTy));
+                accInitVal = candidate.accConstInit;
+              }
 
-              auto accLoop = scf::ForOp::create(
-                  b, loc, lbK, ubK, stepK, ValueRange{accRead},
+              candidate.accLoop = scf::ForOp::create(
+                  b, loc, lbK, ubK, stepK, ValueRange{accInitVal},
                   [&](OpBuilder &b, Location loc, Value ivK,
                       ValueRange iterArgs) {
                     loopKBodyBuilder(b, loc, ivM, ivN, ivK, iterArgs);
                   });
 
-              // The candidate selection enforces the same indices for accRead
-              // and accWrite, so we can reuse the indices vector.
-              auto accWrite = vector::TransferWriteOp::create(
-                  b, candidate.accWrite.getLoc(), accLoop.getResult(0),
-                  candidate.accWrite.getBase(), indices,
-                  candidate.accWrite.getInBoundsValues());
+              candidate.accWrite = vector::TransferWriteOp::create(
+                  b, candidate.accWrite.getLoc(),
+                  candidate.accLoop.getResult(0), candidate.accWrite.getBase(),
+                  indices, candidate.accWrite.getInBoundsValues());
               scf::YieldOp::create(b, loc);
-
-              candidate.accRead = accRead;
-              candidate.accLoop = accLoop;
-              candidate.accWrite = accWrite;
             });
         scf::YieldOp::create(b, loc);
       });
 
   rewriter.eraseOp(oldAccWrite);
   rewriter.eraseOp(oldAccLoop);
-  rewriter.eraseOp(oldAccRead);
+  if (oldAccRead)
+    rewriter.eraseOp(oldAccRead);
+  // Don't bother erasing the old constant.
 
   LDBG("  Inserted register-tiled contraction: " << candidate.contract);
 }
@@ -818,8 +840,9 @@ void performRegisterTiling(DotOpCandidate &candidate,
                                : rewriter.getI64ArrayAttr({k * vnniFactor, n}));
   };
   auto setAccShape = [&](int64_t m, int64_t n) {
-    candidate.accRead->setAttr(unrollShapeAttrName,
-                               rewriter.getI64ArrayAttr({m, n}));
+    Operation *accInitOp =
+        candidate.accRead ? candidate.accRead : candidate.accConstInit;
+    accInitOp->setAttr(unrollShapeAttrName, rewriter.getI64ArrayAttr({m, n}));
     candidate.accWrite->setAttr(unrollShapeAttrName,
                                 rewriter.getI64ArrayAttr({m, n}));
   };
@@ -1180,7 +1203,8 @@ struct ElideSelfCopyPattern : public OpRewritePattern<vector::StoreOp> {
 // If the accumulation buffer is only set to zero once, and read from otherwise,
 // we can replace loads and transfer_reads from it with constants.
 void elideZeroAcc(DotOpCandidate &candidate, PatternRewriter &rewriter) {
-  if (!isZeroConst(candidate.accInit.getValueToStore()))
+  if (candidate.accConstInit ||
+      !isZeroConst(candidate.accInit.getValueToStore()))
     return;
 
   // Bail out if there's an unexpected user of the accumulation buffer.

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
@@ -355,6 +355,16 @@ bool isNanokernelCandidate(triton::cpu::DotOp op, DotOpCandidate &candidate,
     accWrite = nullptr;
   }
 
+  if (candidate.isAccumulationLoop && accWrite &&
+      accLoop->getBlock() != accWrite->getBlock()) {
+    // NB: This filters out conditional writes after the loop. We don't need the
+    // same check for the read, because if that were wrapped in an `scf.if`,
+    // then we wouldn't have detected it in the first place.
+    LDBG("  Cannot use existing vector.transfer_write because it is in a "
+         "different block than the accumulation loop.");
+    accWrite = nullptr;
+  }
+
   auto checkTransferOp = [&](auto transferOp,
                              bool expectBlockBasedIndexing = false) {
     if (!transferOp)
@@ -690,10 +700,15 @@ void insertLoops(DotOpCandidate &candidate, PatternRewriter &rewriter) {
   // `candidate.accLoop`, the current insertion point.
   auto ensureBeforeLoop = [&](Value val) {
     Operation *defOp = val.getDefiningOp();
-    if (!defOp)
-      return; // Block argument, so it's already before the loop.
-    if (defOp->isBeforeInBlock(candidate.accLoop))
-      return; // Already before the loop.
+    if (!defOp || defOp->getBlock() != candidate.accLoop->getBlock() ||
+        defOp->isBeforeInBlock(candidate.accLoop)) {
+      // No need to move because the value is either:
+      // 1) a block argument,
+      // 2) defined in a different block (which must dominate the block that
+      //    accLoop and accWrite are in), or
+      // 3) in same block but already before accLoop.
+      return;
+    }
     [[maybe_unused]] auto res =
         moveOperationDependencies(rewriter, defOp, candidate.accLoop);
     assert(succeeded(res));

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
@@ -355,11 +355,12 @@ bool isNanokernelCandidate(triton::cpu::DotOp op, DotOpCandidate &candidate,
     accWrite = nullptr;
   }
 
-  if (candidate.isAccumulationLoop && accWrite &&
+  if (candidate.isLoopedNanokernel && accWrite &&
       accLoop->getBlock() != accWrite->getBlock()) {
-    // NB: This filters out conditional writes after the loop. We don't need the
-    // same check for the read, because if that were wrapped in an `scf.if`,
-    // then we wouldn't have detected it in the first place.
+    // NB: This filters out conditional writes after the loop, which
+    // `insertLoops` currently doesn't handle. We don't need the same check for
+    // the read, because if that were wrapped in an `scf.if`, then we wouldn't
+    // have detected it in the first place.
     LDBG("  Cannot use existing vector.transfer_write because it is in a "
          "different block than the accumulation loop.");
     accWrite = nullptr;

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
@@ -8,6 +8,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/LoopInvariantCodeMotionUtils.h"
+#include "mlir/Transforms/RegionUtils.h"
 #include "triton/Analysis/Utility.h"
 
 namespace mlir {
@@ -682,9 +683,26 @@ void insertLoops(DotOpCandidate &candidate, PatternRewriter &rewriter) {
   VectorType lhsRegTileTy = VectorType::get({regTileM, 1, vnni}, inpElemTy);
   VectorType rhsRegTileTy = VectorType::get({1, regTileN, vnni}, inpElemTy);
 
-  // Construct after the loop, to ensure that all tensor descriptors and their
-  // extracted memrefs are defined.
-  rewriter.setInsertionPoint(candidate.accWrite);
+  rewriter.setInsertionPoint(candidate.accLoop);
+
+  // We'll recreate a register-tiled version of `candidate.accWrite` inside the
+  // new loops. Hence we must ensure its operands are defined at
+  // `candidate.accLoop`, the current insertion point.
+  auto ensureBeforeLoop = [&](Value val) {
+    Operation *defOp = val.getDefiningOp();
+    if (!defOp)
+      return; // Block argument, so it's already before the loop.
+    if (defOp->isBeforeInBlock(candidate.accLoop))
+      return; // Already before the loop.
+    [[maybe_unused]] auto res =
+        moveOperationDependencies(rewriter, defOp, candidate.accLoop);
+    assert(succeeded(res));
+    defOp->moveBefore(candidate.accLoop);
+  };
+  ensureBeforeLoop(candidate.accWrite.getBase());
+  for (Value idx : candidate.accWrite.getIndices())
+    ensureBeforeLoop(idx);
+
   auto loc = candidate.accLoop.getLoc();
 
   // Set up loop bounds.


### PR DESCRIPTION
Since llvm/llvm-project#204327, the non-AMX nanokernel patterns accept a zero constant as initial accumulator value, hence it is no longer necessary to materialize zeros on the stack. For AMX, we continue rely on the `elideZeroAcc` cleanup method for the time being.

Also change the SFC matmul tutorial to a) always start with a zero accumulator and do the partial sum after the loop, and b) introduce a temporary, block-packed float32/int32 buffer to store the partial results when K-blocking is enabled.