### PR TITLE
[DotToNanokernel] Misc AVX fixes

### DIFF
--- a/test/TritonCPU/dot-to-nanokernel-looped.mlir
+++ b/test/TritonCPU/dot-to-nanokernel-looped.mlir
@@ -5,7 +5,7 @@
 // AVX512:       %[[ZERO:.+]] = arith.constant dense<0.000000e+00> : vector<16xf32>
 // AVX512:       scf.for %{{.+}} = %c0 to %c32 step %c4
 // AVX512:         scf.for %{{.+}} = %c0 to %c64 step %c64
-// AVX512:           %{{.+}}:16 = scf.for %{{.+}} = %{{.+}} to %{{.+}} step %c1
+// AVX512:           %{{.+}}:16 = scf.for %{{.+}} = %{{.+}} to %{{.+}} step %c4
 // AVX512-SAME:          iter_args(%{{.+}} = %[[ZERO]],
 // AVX512-COUNT-16:    x86.avx512.dot
 // AVX512:             scf.yield
@@ -82,7 +82,7 @@ tt.func public @gemm_looped_avx512(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %
 // AVX_NE_CONVERT-NOT:   memref.alloca
 // AVX_NE_CONVERT:       scf.for %{{.+}} = %c0 to %c32 step %c4
 // AVX_NE_CONVERT:         scf.for %{{.+}} = %c0 to %c32 step %c16
-// AVX_NE_CONVERT:           %{{.+}}:8 = scf.for %{{.+}} = %{{.+}} to %{{.+}} step %c1
+// AVX_NE_CONVERT:           %{{.+}}:8 = scf.for %{{.+}} = %{{.+}} to %{{.+}} step %c4
 // AVX_NE_CONVERT:             x86.avx.bcst_to_f32.packed
 // AVX_NE_CONVERT:             x86.avx.cvt.packed.odd.indexed_to_f32
 // AVX_NE_CONVERT:             x86.avx.bcst_to_f32.packed

--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -239,7 +239,7 @@ class CPUBackend(BaseBackend):
         promote_lib_math_to_fp32 = True
         cpu.passes.ttcpuir.add_convert_unsupported_ops(pm, promote_bf16_to_fp32, convert_mixed_precision_matmul,
                                                        promote_lib_math_to_fp32)
-        decompose_bf16_conv = self.cpu_arch == "x86_64" and "avx512bf16" not in self.cpu_features
+        decompose_bf16_conv = self.cpu_arch == "x86_64" and "avx512bf16" not in self.cpu_features and "avxneconvert" not in self.cpu_features
         decompose_fp8_conv = True
         cpu.passes.ttcpuir.add_decompose_fp_conversions(pm, decompose_bf16_conv, decompose_fp8_conv)
         if os.getenv("TRITON_CPU_UNROLL_AND_REORDER_ELEMENTWISE_OPS", "0") == "1":

--- a/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
+++ b/third_party/cpu/lib/TritonCPUTransforms/ConvertDotOp/ConvertDotToNanokernel.cpp
@@ -2,6 +2,7 @@
 
 #include "cpu/include/TritonCPUTransforms/Passes.h"
 
+#include "mlir/Dialect/SCF/Utils/Utils.h"
 #include "mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h"
 #include "mlir/Dialect/X86/Transforms.h"
 #include "mlir/Dialect/X86/X86Dialect.h"
@@ -1344,9 +1345,16 @@ LogicalResult convertCandidate(DotOpCandidate &candidate,
     elideZeroAcc(candidate, rewriter);
   }
 
+  if (candidate.isLoopedNanokernel) {
+    // TODO: Need heuristics.
+    (void)loopUnrollByFactor(candidate.splicedAccLoop, 4);
+  }
+
   // Flatten transfer ops to prevent inefficient lowering of VNNI-encoded reads,
   // e.g. `vector.transfer_read ... vector<1x16x2xbf16>` shall become a single
   // 32-element load instead of unrolling it to 16 2-element loads.
+  //
+  // NB: This comes last as it may replace candidate.splicedAccLoop.
   flattenTransferOps(candidate, rewriter);
 
   return success();


### PR DESCRIPTION
- AVX_NE_CONVERT has hardware support for BF16 conversions.
- Partially unroll the K-loop in the looped nanokernel setting.